### PR TITLE
improve compatibility with stalwart-jmap

### DIFF
--- a/modules/imap/hm-jmap.php
+++ b/modules/imap/hm-jmap.php
@@ -995,7 +995,7 @@ class Hm_JMAP {
         return json_encode(array(
             'using' => count($caps) == 0 ? $this->default_caps : $caps,
             'methodCalls' => $methods
-        ));
+        ), JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/modules/imap/hm-jmap.php
+++ b/modules/imap/hm-jmap.php
@@ -873,10 +873,10 @@ class Hm_JMAP {
             $data['uploadUrl']
         );
         foreach ($data['accounts'] as $account) {
-            if (array_key_exists('isPrimary', $account) && $account['isPrimary']) {
+            //if (array_key_exists('isPrimary', $account) && $account['isPrimary']) {
                 $this->account_id = array_keys($data['accounts'])[0];
-                break;
-            }
+            //    break;
+            //}
         }
         if ($this->account_id && count($this->folder_list) == 0) {
             $this->reset_folders();

--- a/modules/imap/hm-jmap.php
+++ b/modules/imap/hm-jmap.php
@@ -861,6 +861,7 @@ class Hm_JMAP {
             preg_replace("/\/$/", '', $url),
             $data['apiUrl']
         );
+	$this->api_url = $data['apiUrl'];
         $this->download_url = sprintf(
             '%s%s',
             preg_replace("/\/$/", '', $url),

--- a/modules/imap/hm-jmap.php
+++ b/modules/imap/hm-jmap.php
@@ -833,8 +833,8 @@ class Hm_JMAP {
             'internal_date' => $msg['receivedAt'],
             'size' => $msg['size'],
             'date' => $msg['sentAt'],
-            'from' => $this->combine_addresses($msg['from']),
-            'to' => $this->combine_addresses($msg['to']),
+            'from' => (is_array($msg['from']) ? $this->combine_addresses($msg['from']) : $msg['from']),
+            'to' => (is_array($msg['to']) ? $this->combine_addresses($msg['to']) : $msg['to']),
             'subject' => $msg['subject'],
             'content-type' => '',
             'timestamp' => strtotime($msg['receivedAt']),
@@ -842,7 +842,7 @@ class Hm_JMAP {
             'x-priority' => '',
             'type' => 'jmap',
             'references' => '',
-            'message_id' => implode(' ', $msg['messageId']),
+            'message_id' => (is_array($msg['messageId']) ? implode(' ', $msg['messageId']) : ''),
             'x_auto_bcc' => ''
         );
     }


### PR DESCRIPTION
## Pullrequest
work in progress, fixing the issues i described in #180. With that PR i can list mails in the INBOX, but clicking on a mail sometimes crashes stalwart-jmap. Still digging..

- `apiUrl` is a full url, the current code does something weird
- don't escape forward slashes when sending json, otherwise it returns a 400 code with `urn:ietf:params:jmap:error:notRequest`
- `messageId`/`From`/`To` might be null/empty
- `isPrimary` isnt mentioned anymore in https://jmap.io/spec-core.html, `primaryAccount` should be used