### PR TITLE
Dirty fix for 500 on outgoing mail

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1033,7 +1033,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
                 $cc = $imap_draft['Cc'];
             }
             if (array_key_exists('From', $imap_draft)) {
-                $from = $imap_draft['From'];
+                $from = $imap_draft['From'];select_mailbox
             }
             $draft_id = $msg_uid;
         }
@@ -1528,6 +1528,7 @@ function get_primary_recipient($profiles, $headers, $smtp_servers, $is_draft=Fal
 if (!hm_exists('delete_draft')) {
 function delete_draft($id, $cache, $imap_server_id, $folder) {
     $imap = Hm_IMAP_List::connect($imap_server_id);
+    if ( ! $imap ) return false;
     if ($imap->select_mailbox($folder)) {
         if ($imap->message_action('DELETE', array($id))) {
             $imap->message_action('EXPUNGE', array($id));
@@ -1573,7 +1574,7 @@ if (!hm_exists('rrmdir')) {
                     if (filetype($dir . "/" . $object) == "dir") {
                         rrmdir($dir . "/" . $object); 
                     } else {
-                        unlink($dir . "/" . $object);
+                        unlink($dir . "/" . $object);select_mailbox
                     }
                 }
             }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1033,7 +1033,7 @@ class Hm_Output_compose_form_content extends Hm_Output_Module {
                 $cc = $imap_draft['Cc'];
             }
             if (array_key_exists('From', $imap_draft)) {
-                $from = $imap_draft['From'];select_mailbox
+                $from = $imap_draft['From'];
             }
             $draft_id = $msg_uid;
         }
@@ -1528,7 +1528,9 @@ function get_primary_recipient($profiles, $headers, $smtp_servers, $is_draft=Fal
 if (!hm_exists('delete_draft')) {
 function delete_draft($id, $cache, $imap_server_id, $folder) {
     $imap = Hm_IMAP_List::connect($imap_server_id);
-    if ( ! $imap ) return false;
+    if (! imap_authed($imap)) {
+        return false;
+    }
     if ($imap->select_mailbox($folder)) {
         if ($imap->message_action('DELETE', array($id))) {
             $imap->message_action('EXPUNGE', array($id));
@@ -1574,7 +1576,7 @@ if (!hm_exists('rrmdir')) {
                     if (filetype($dir . "/" . $object) == "dir") {
                         rrmdir($dir . "/" . $object); 
                     } else {
-                        unlink($dir . "/" . $object);select_mailbox
+                        unlink($dir . "/" . $object);
                     }
                 }
             }


### PR DESCRIPTION
## Pullrequest
There is a hard-to-reproduce bug that was first reported on gitter and now by me here on github, #650 

This is not a clean fix in that it does not addres root causes, but it allows me to use the software right now apparently without issue and might give additional information.

### Issues
- dirty fix for #650

### Checklist
- [X] None

### How2Test
Reproduce bug #650 and watch it go away with this patch.

### Todo
- [ ] Reproduce: Spin up a debian bullseye instance somewhere, install apache, php and cypht and install cypht using the install script. 
- [ ] Find root cause and fix properly
