### PR TITLE
Added snooze functionnality to imap

### DIFF
--- a/lib/module.php
+++ b/lib/module.php
@@ -434,6 +434,14 @@ abstract class Hm_Handler_Module {
         return in_array(strtolower($name), $this->config->get_modules(true), true);
     }
 
+    public function save_hm_msgs() {
+        $msgs = Hm_Msgs::get();
+        if (!empty($msgs)) {
+            Hm_Msgs::flush();
+            $this->session->secure_cookie($this->request, 'hm_msgs', base64_encode(json_encode($msgs)));
+        }
+    }
+
     /**
      * Handler modules need to override this method to do work
      */

--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -281,10 +281,11 @@ function subject_callback($vals, $style, $output_mod) {
  */
 if (!hm_exists('date_callback')) {
 function date_callback($vals, $style, $output_mod) {
+    $snooze_class = isset($vals[2]) && $vals[2]? ' snoozed_date': '';
     if ($style == 'news') {
-        return sprintf('<div class="msg_date">%s<input type="hidden" class="msg_timestamp" value="%s" /></div>', $output_mod->html_safe($vals[0]), $output_mod->html_safe($vals[1]));
+        return sprintf('<div class="msg_date%s">%s<input type="hidden" class="msg_timestamp" value="%s" /></div>', $snooze_class, $output_mod->html_safe($vals[0]), $output_mod->html_safe($vals[1]));
     }
-    return sprintf('<td class="msg_date" title="%s">%s<input type="hidden" class="msg_timestamp" value="%s" /></td>', $output_mod->html_safe(date('r', $vals[1])), $output_mod->html_safe($vals[0]), $output_mod->html_safe($vals[1]));
+    return sprintf('<td class="msg_date%s" title="%s">%s<input type="hidden" class="msg_timestamp" value="%s" /></td>', $snooze_class, $output_mod->html_safe(date('r', $vals[1])), $output_mod->html_safe($vals[0]), $output_mod->html_safe($vals[1]));
 }}
 
 /**

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -317,3 +317,4 @@ div.unseen, .unseen .subject { font-weight: 700; }
     padding-bottom: 5px;
     background-color: #fff;
 }
+.snoozed_date { color: teal !important; }

--- a/modules/github/modules.php
+++ b/modules/github/modules.php
@@ -185,8 +185,7 @@ class Hm_Handler_process_github_authorization extends Hm_Handler_Module {
             else {
                 Hm_Msgs::add('ERRAn Error Occurred');
             }
-            $msgs = Hm_Msgs::get();
-            $this->session->secure_cookie($this->request, 'hm_msgs', base64_encode(serialize($msgs)));
+            $this->save_hm_msgs();
             Hm_Dispatch::page_redirect('?page=servers');
         }
     }

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -215,13 +215,21 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
             $from = '[No From]';
             $nofrom = ' nofrom';
         }
-        if ($list_sort == 'date') {
-            $date_field = 'date';
+        $is_snoozed = !empty($msg['x_snoozed']) && hex2bin($msg['folder']) == 'Snoozed';
+        if ($is_snoozed) {
+            $snooze_header = parse_snooze_header('X-Snoozed: '.$msg['x_snoozed']);
+            $date = $snooze_header['until'];
+            $timestamp = strtotime($date);
         } else {
-            $date_field = 'internal_date';
-        }
-        $timestamp = strtotime($msg[$date_field]);
-        $date = translate_time_str(human_readable_interval($msg[$date_field]), $output_module);
+            if ($list_sort == 'date') {
+                $date_field = 'date';
+            } else {
+                $date_field = 'internal_date';
+            }
+            $date = translate_time_str(human_readable_interval($msg[$date_field]), $output_module);
+            $timestamp = strtotime($msg[$date_field]);
+        }    
+        
         $flags = array();
         if (!stristr($msg['flags'], 'seen')) {
             $flags[] = 'unseen';
@@ -286,7 +294,7 @@ function format_imap_message_list($msg_list, $output_module, $parent_list=false,
                     array('safe_output_callback', 'source', $source, $icon),
                     array('safe_output_callback', 'from'.$nofrom, $from, null, str_replace(array($from, '<', '>'), '', $msg['from'])),
                     array('subject_callback', $subject, $url, $flags),
-                    array('date_callback', $date, $timestamp),
+                    array('date_callback', $date, $timestamp, $is_snoozed),
                     array('icon_callback', $flags)
                 ),
                 $id,
@@ -1247,3 +1255,148 @@ function get_request_params($request) {
 
     return [$server_id, $uid, $folder, $msg_id];
 }}
+
+if (!hm_exists('snooze_message')) {
+function snooze_message($imap, $msg_id, $folder, $snooze_tag) {
+    if (!$imap->select_mailbox($folder)) {
+        return false;
+    }
+    if (!$snooze_tag) {
+        $imap->message_action('UNREAD', array($msg_id));
+    }
+    $msg = $imap->get_message_content($msg_id, 0);
+    preg_match("/^X-Snoozed:.*(\r?\n[ \t]+.*)*\r?\n?/im", $msg, $matches);
+    if (count($matches)) {
+        $msg = str_replace($matches[0], '', $msg);
+        $old_folder = parse_snooze_header($matches[0])['from'];
+    }
+    if ($snooze_tag) {
+        $from = $old_folder ?? $folder;
+        $msg = "$snooze_tag;\n \tfrom $from\n".$msg;
+    }
+    $msg = str_replace("\r\n", "\n", $msg);
+    $msg = str_replace("\n", "\r\n", $msg);
+    $msg = rtrim($msg)."\r\n";
+
+    $res = false;
+    $snooze_folder = 'Snoozed';
+    if ($snooze_tag) {
+        if (!count($imap->get_mailbox_status($snooze_folder))) {
+            $imap->create_mailbox($snooze_folder);
+        }
+        if ($imap->select_mailbox($snooze_folder) && $imap->append_start($snooze_folder, strlen($msg))) {
+            $imap->append_feed($msg."\r\n");
+            if ($imap->append_end()) {
+                if ($imap->select_mailbox($folder) && $imap->message_action('DELETE', array($msg_id))) {
+                    $imap->message_action('EXPUNGE', array($msg_id));
+                    $res = true;
+                }
+            }
+        }
+    } else {
+        $snooze_headers = parse_snooze_header($matches[0]);
+        $original_folder = $snooze_headers['from'];
+        if ($imap->select_mailbox($original_folder) && $imap->append_start($original_folder, strlen($msg))) {
+            $imap->append_feed($msg."\r\n");
+            if ($imap->append_end()) {
+                if ($imap->select_mailbox($snooze_folder) && $imap->message_action('DELETE', array($msg_id))) {
+                    $imap->message_action('EXPUNGE', array($msg_id));
+                    $res = true;
+                }
+            }
+        }
+    }
+    return $res;
+}}
+
+/**
+ * @subpackage imap/functions
+ */
+if (!hm_exists('parse_snooze_header')) {
+function parse_snooze_header($snooze_header)
+{
+    $snooze_header = str_replace('X-Snoozed: ', '', $snooze_header);
+    $result = [];
+    foreach (explode(';', str_replace("\r\n", " ", $snooze_header)) as $kv)
+    {
+        $kv = trim($kv);
+        $spacePos = strpos($kv, ' ');
+        if ($spacePos > 0) {
+            $result[rtrim(substr($kv, 0, $spacePos), ':')] = trim(substr($kv, $spacePos+1));
+        } else {
+            $result[$kv] = true;
+        }
+    }
+    return $result;
+}}
+
+/**
+ * @subpackage imap/functions
+ */
+if (!hm_exists('get_snooze_date')) {
+function get_snooze_date($format, $only_label = false) {
+    if ($format == 'later_in_day') {
+        $date_string = 'today 18:00';
+        $label = 'Later in the day';
+    } elseif ($format == 'tomorrow') {
+        $date_string = '+1 day 08:00';
+        $label = 'Tomorrow';
+    } elseif ($format == 'next_weekend') {
+        $date_string = 'next Saturday 08:00';
+        $label = 'Next weekend';
+    } elseif ($format == 'next_week') {
+        $date_string = 'next week 08:00';
+        $label = 'Next week';
+    } elseif ($format == 'next_month') {
+        $date_string = 'next month 08:00';
+        $label = 'Next month';
+    } else {
+        $date_string = $format;
+        $label = 'Certain date';
+    }
+    $time = strtotime($date_string);
+    if ($only_label) {
+        return [$label, date('D, H:i', $time)];
+    }
+    return date('D, d M Y H:i', $time);
+}}
+
+/**
+ * @subpackage imap/functions
+ */
+if (!hm_exists('snooze_formats')) {
+function snooze_formats() {
+    return array(
+        'tomorrow',
+        'next_weekend',
+        'next_week',
+        'next_month'
+    );
+}}
+
+/**
+ * @subpackage imap/functions
+ */
+if (!hm_exists('snooze_dropdown')) {
+function snooze_dropdown($output, $unsnooze = false) {
+    if (date('H') <= 16) {
+        $values = array_merge(['later_in_day'], snooze_formats());
+    }
+    $txt = '<div style="display: inline-block;">';
+    $txt .= '<a class="snooze_link hlink" id="snooze_message" href="#">'.$output->trans('Snooze').'</a>';
+    $txt .= '<div class="snooze_dropdown" style="display:none;">';
+    foreach ($values as $format) {
+        $labels = get_snooze_date($format, true);
+        $txt .= '<a href="#" class="snooze_helper" data-value="'.$format.'">'.$output->trans($labels[0]).' <span>'.$labels[1].'</span></a>';
+    }
+    $txt .= '<label for="snooze_input_date" class="snooze_date_picker">'.$output->trans('Pick a date').'</label>';
+    $txt .= '<input id="snooze_input_date" type="datetime-local" min="'.date('Y-m-d\Th:m').'" class="snooze_input_date" style="visibility: hidden; position: absolute; height: 0;">';
+    $txt .= '<input class="snooze_input" style="display:none;">';
+    if ($unsnooze) {
+        $txt .= '<a href="#" data-value="unsnooze" class="unsnooze snooze_helper">'.$output->trans('Unsnooze').'</a>';
+    }
+    $txt .= '</div></div>';
+
+    return $txt;
+}}
+

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1317,7 +1317,7 @@ function parse_snooze_header($snooze_header)
 {
     $snooze_header = str_replace('X-Snoozed: ', '', $snooze_header);
     $result = [];
-    foreach (explode(';', str_replace("\r\n", " ", $snooze_header)) as $kv)
+    foreach (explode(';', $snooze_header) as $kv)
     {
         $kv = trim($kv);
         $spacePos = strpos($kv, ' ');
@@ -1366,12 +1366,16 @@ function get_snooze_date($format, $only_label = false) {
  */
 if (!hm_exists('snooze_formats')) {
 function snooze_formats() {
-    return array(
+    $values = array(
         'tomorrow',
         'next_weekend',
         'next_week',
         'next_month'
     );
+    if (date('H') <= 16) {
+        $values = array_push($values, 'later_in_day');
+    }
+    return $values;
 }}
 
 /**
@@ -1379,9 +1383,7 @@ function snooze_formats() {
  */
 if (!hm_exists('snooze_dropdown')) {
 function snooze_dropdown($output, $unsnooze = false) {
-    if (date('H') <= 16) {
-        $values = array_merge(['later_in_day'], snooze_formats());
-    }
+    $values = snooze_formats();
     $txt = '<div style="display: inline-block;">';
     $txt .= '<a class="snooze_link hlink" id="snooze_message" href="#">'.$output->trans('Snooze').'</a>';
     $txt .= '<div class="snooze_dropdown" style="display:none;">';

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -726,7 +726,7 @@ class Hm_IMAP extends Hm_IMAP_Cache {
         if ($this->is_supported( 'X-GM-EXT-1' )) {
             $command .= 'X-GM-MSGID X-GM-THRID X-GM-LABELS ';
         }
-        $command .= "BODY.PEEK[HEADER.FIELDS (SUBJECT X-AUTO-BCC FROM DATE CONTENT-TYPE X-PRIORITY TO LIST-ARCHIVE REFERENCES MESSAGE-ID)])\r\n";
+        $command .= "BODY.PEEK[HEADER.FIELDS (SUBJECT X-AUTO-BCC FROM DATE CONTENT-TYPE X-PRIORITY TO LIST-ARCHIVE REFERENCES MESSAGE-ID X-SNOOZED)])\r\n";
         $cache_command = $command.(string)$raw;
         $cache = $this->check_cache($cache_command);
         if ($cache !== false) {
@@ -736,8 +736,8 @@ class Hm_IMAP extends Hm_IMAP_Cache {
         $res = $this->get_response(false, true);
         $status = $this->check_response($res, true);
         $tags = array('X-GM-MSGID' => 'google_msg_id', 'X-GM-THRID' => 'google_thread_id', 'X-GM-LABELS' => 'google_labels', 'UID' => 'uid', 'FLAGS' => 'flags', 'RFC822.SIZE' => 'size', 'INTERNALDATE' => 'internal_date');
-        $junk = array('X-AUTO-BCC', 'MESSAGE-ID', 'REFERENCES', 'LIST-ARCHIVE', 'SUBJECT', 'FROM', 'CONTENT-TYPE', 'TO', '(', ')', ']', 'X-PRIORITY', 'DATE');
-        $flds = array('x-auto-bcc' => 'x_auto_bcc', 'message-id' => 'message_id', 'references' => 'references', 'list-archive' => 'list_archive', 'date' => 'date', 'from' => 'from', 'to' => 'to', 'subject' => 'subject', 'content-type' => 'content_type', 'x-priority' => 'x_priority');
+        $junk = array('X-AUTO-BCC', 'MESSAGE-ID', 'REFERENCES', 'X-SNOOZED', 'LIST-ARCHIVE', 'SUBJECT', 'FROM', 'CONTENT-TYPE', 'TO', '(', ')', ']', 'X-PRIORITY', 'DATE');
+        $flds = array('x-auto-bcc' => 'x_auto_bcc', 'message-id' => 'message_id', 'references' => 'references', 'x-snoozed' => 'x_snoozed', 'list-archive' => 'list_archive', 'date' => 'date', 'from' => 'from', 'to' => 'to', 'subject' => 'subject', 'content-type' => 'content_type', 'x-priority' => 'x_priority');
         $headers = array();
         foreach ($res as $n => $vals) {
             if (isset($vals[0]) && $vals[0] == '*') {
@@ -758,6 +758,7 @@ class Hm_IMAP extends Hm_IMAP_Cache {
                 $google_thread_id = '';
                 $google_labels = '';
                 $x_auto_bcc = '';
+                $x_snoozed = '';
                 $count = count($vals);
                 for ($i=0;$i<$count;$i++) {
                     if ($vals[$i] == 'BODY[HEADER.FIELDS') {
@@ -806,7 +807,8 @@ class Hm_IMAP extends Hm_IMAP_Cache {
                                      'date' => $date, 'from' => $from, 'to' => $to, 'subject' => $subject, 'content-type' => $content_type,
                                      'timestamp' => time(), 'charset' => $cset, 'x-priority' => $x_priority, 'google_msg_id' => $google_msg_id,
                                      'google_thread_id' => $google_thread_id, 'google_labels' => $google_labels, 'list_archive' => $list_archive,
-                                     'references' => $references, 'message_id' => $message_id, 'x_auto_bcc' => $x_auto_bcc);
+                                     'references' => $references, 'message_id' => $message_id, 'x_auto_bcc' => $x_auto_bcc,
+                                     'x_snoozed'  => $x_snoozed);
 
                     if ($raw) {
                         $headers[$uid] = array_map('trim', $headers[$uid]);

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -169,7 +169,7 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
     protected function output() {
         if ($this->get('msg_headers')) {
             $txt = '';
-            $small_headers = array('subject', 'date', 'from', 'to', 'cc', 'flags');
+            $small_headers = array('subject', 'x-snoozed', 'date', 'from', 'to', 'cc', 'flags');
             $reply_args = sprintf('&amp;list_path=%s&amp;uid=%d',
                 $this->html_safe($this->get('msg_list_path')),
                 $this->html_safe($this->get('msg_text_uid'))
@@ -189,6 +189,11 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                                 $txt .= ' <img alt="" class="account_icon" src="'.Hm_Image_Sources::$star.'" width="16" height="16" /> ';
                             }
                             $txt .= $this->html_safe($value).'</th></tr>';
+                        }
+                        elseif ($fld == 'x-snoozed') {
+                            $snooze_header = parse_snooze_header($value);
+                            $txt .= '<tr class="header_'.$fld.'"><th>';
+                            $txt .= $this->trans('Snoozed').'</th><td>'.$this->trans('Until').' '.$this->html_safe($snooze_header['until']).' <a href="#" data-value="unsnooze" class="unsnooze snooze_helper">Unsnooze</a></td></tr>';
                         }
                         elseif ($fld == 'date') {
                             try {
@@ -282,7 +287,8 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             $txt .= ' | <a class="delete_link hlink" id="delete_message" href="#">'.$this->trans('Delete').'</a>';
             $txt .= ' | <a class="hlink" id="copy_message" href="#">'.$this->trans('Copy').'</a>';
             $txt .= ' | <a class="hlink" id="move_message" href="#">'.$this->trans('Move').'</a>';
-            $txt .= ' | <a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a>';
+            $txt .= ' | <a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a>';  
+            $txt .= ' | ' . snooze_dropdown($this, isset($headers['X-Snoozed']));
 
             if ($this->get('sieve_filters_enabled')) {
                 $server_id = $this->get('msg_server_id');
@@ -1099,5 +1105,18 @@ class Hm_Output_review_sent_email extends Hm_Output_Module {
         return '<tr class="general_setting"><td><label for="review_sent_email">'.
             $this->trans('Review sent message').'</label></td>'.
             '<td><input type="checkbox" '.$checked.' id="review_sent_email" name="review_sent_email" value="1" />'.$reset.'</td></tr>';
+    }
+}
+
+/**
+ * Add snooze dialog to the message list controls
+ * @subpackage imap/output
+ */
+class Hm_Output_snooze_msg_control extends Hm_Output_Module {
+    protected function output() {
+        $parts = explode('_', $this->get('list_path'));
+        $unsnooze = $parts[0] == 'imap' && hex2bin($parts[2]) == 'Snoozed';
+        $res = snooze_dropdown($this, $unsnooze);
+        $this->concat('msg_controls_extra', $res);
     }
 }

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -71,6 +71,7 @@ add_handler('search', 'imap_message_list_type', true, 'imap', 'message_list_type
 add_handler('message_list', 'imap_message_list_type', true, 'imap', 'message_list_type', 'after');
 add_output('message_list', 'imap_custom_controls', true, 'imap', 'message_list_heading', 'before');
 add_output('message_list', 'move_copy_controls', true, 'imap', 'message_list_heading', 'before');
+add_output('message_list', 'snooze_msg_control', true, 'imap', 'imap_custom_controls', 'after');
 
 /* message view page */
 add_handler('message', 'imap_download_message', true, 'imap', 'message_list_type', 'after');
@@ -284,6 +285,22 @@ add_output('ajax_imap_all_email', 'filter_all_email', true);
 add_handler('ajax_update_server_pw', 'load_imap_servers_from_config', true, 'imap', 'load_user_data', 'after');
 add_handler('ajax_update_server_pw', 'save_imap_servers', true, 'imap', 'save_user_data', 'before');
 
+/* snooze email */
+setup_base_ajax_page('ajax_imap_snooze', 'core');
+add_handler('ajax_imap_snooze', 'load_imap_servers_from_config',  true);
+add_handler('ajax_imap_snooze', 'imap_oauth2_token_check', true);
+add_handler('ajax_imap_snooze', 'close_session_early',  true, 'core');
+add_handler('ajax_imap_snooze', 'save_imap_cache',  true);
+add_handler('ajax_imap_snooze', 'imap_snooze_message',  true, 'core');
+
+/* unsnooze emails in snoozed folders */
+setup_base_ajax_page('ajax_imap_unsnooze', 'core');
+add_handler('ajax_imap_unsnooze', 'load_imap_servers_from_config',  true);
+add_handler('ajax_imap_unsnooze', 'imap_oauth2_token_check', true);
+add_handler('ajax_imap_unsnooze', 'close_session_early',  true, 'core');
+add_handler('ajax_imap_unsnooze', 'save_imap_cache',  true);
+add_handler('ajax_imap_unsnooze', 'imap_unsnooze_message',  true, 'core');
+
 /* allowed input */
 return array(
     'allowed_pages' => array(
@@ -307,6 +324,8 @@ return array(
         'ajax_imap_mark_as_read',
         'ajax_imap_move_copy_action',
         'ajax_imap_folder_status',
+        'ajax_imap_snooze',
+        'ajax_imap_unsnooze',
     ),
 
     'allowed_output' => array(
@@ -324,7 +343,8 @@ return array(
         'combined_inbox_server_ids' => array(FILTER_SANITIZE_FULL_SPECIAL_CHARS, false),
         'imap_delete_error' => array(FILTER_VALIDATE_BOOLEAN, false),
         'move_count' => array(FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_REQUIRE_ARRAY),
-        'show_pagination_links' => array(FILTER_VALIDATE_BOOLEAN, false)
+        'show_pagination_links' => array(FILTER_VALIDATE_BOOLEAN, false),
+        'snoozed_messages' => array(FILTER_VALIDATE_INT, false),
     ),
 
     'allowed_get' => array(
@@ -386,6 +406,8 @@ return array(
         'max_google_contacts_number' => FILTER_VALIDATE_INT,
         'original_folder' => FILTER_VALIDATE_BOOLEAN,
         'review_sent_email' => FILTER_VALIDATE_BOOLEAN,
+        'imap_snooze_ids' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'imap_snooze_until' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
     )
 );
 

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -97,3 +97,17 @@
 .cypht-dropdown { display: none; position: absolute; margin-top: 15px; background-color: #fff; border: 1px solid #ddd; box-shadow: 3px 3px 3px #ddd; font-variant: none;     min-width: 250px; }
 .cypht-dropdown a { padding: 8px; padding-left: 15px !important; padding-right: 15px !important; white-space: nowrap; font-size: 1rem; display: block !important; margin-right: 0; border: 0; cursor: pointer; }
 .cypht-dropdown a:hover { background-color: #eee; }
+#block_sender_form { padding: 15px; display: block; }
+#block_sender_form label, #block_sender_form select, #block_sender_form textarea, #block_sender_form button { display: block; margin: 3px 0; width: 100%; }
+#block_sender_form button { color: #fff; background-color: brown; cursor: pointer; }
+#block_sender_form label { text-transform: capitalize; }
+
+.snooze_date_picker, .snooze_helper { color: #333; text-transform: capitalize; }
+.snooze_date_picker { border-top: 1px solid #ddd; }
+.snooze_dropdown { position: absolute; margin-top: 15px; background-color: #fff; border: 1px solid #ddd; box-shadow: 3px 3px 3px #ddd; font-variant: none;     min-width: 250px; }
+.snooze_date_picker:hover, .snooze_helper:hover { background-color: #eee; }
+.header_links a.snooze_date_picker, .header_links a.snooze_helper, .msg_controls a.snooze_date_picker, .msg_controls a.snooze_helper { padding: 8px; padding-left: 15px !important; padding-right: 15px !important; white-space: nowrap; font-size: 1rem; display: block !important; margin-right: 0; border: 0; }
+.snooze_helper span { float: right; }
+.snooze_date_picker { display: block; padding: 8px 15px; color: #333; font-size: 1rem; cursor: pointer; }
+.unsnooze { color: teal; }
+.header_x-snoozed .unsnooze { margin-left: 20px; }

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -1115,7 +1115,7 @@ var imap_setup_snooze = function() {
                 if (res.snoozed_messages > 0) {
                     Hm_Folders.reload_folders(true);
                     var path = hm_list_parent()? hm_list_parent(): hm_list_path();
-                    window.location.href = '?page=message_list&list_path='+path;
+                    window.location.replace('?page=message_list&list_path='+path);
                 }
             }
         );

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -1062,6 +1062,73 @@ var imap_folder_status = function() {
     }
 };
 
+var imap_setup_snooze = function() {
+    $(document).on('click', '#snooze_message', function(e) {
+        e.preventDefault();
+        $('.snooze_dropdown').toggle();
+        $('.snooze_input').hide();
+    });
+    $(document).on('click', '.snooze_date_picker', function(e) {
+        document.querySelector('.snooze_input_date').showPicker();
+    });
+    $(document).on('click', '.snooze_helper', function(e) {
+        e.preventDefault();
+        $('.snooze_input').val($(this).attr('data-value')).trigger('change');
+    });
+    $(document).on('input', '.snooze_input_date', function(e) {
+        var now = new Date();
+        now.setMinutes(now.getMinutes() + 1);
+        $(this).attr('min', now.toJSON().slice(0, 16));
+        if (new Date($(this).val()).getTime() <= now.getTime()) {
+            $('.snooze_date_picker').css('border', '1px solid red');
+        } else {
+            $('.snooze_date_picker').css({'border': 'unset', 'border-top': '1px solid #ddd'});
+        }
+    });
+    $(document).on('change', '.snooze_input_date', function(e) {
+        if ($(this).val() && new Date().getTime() < new Date($(this).val()).getTime()) {
+            $('.snooze_input').val($(this).val()).trigger('change');
+        }
+    });
+    $(document).on('change', '.snooze_input', function(e) {
+        $('.snooze_dropdown').hide();
+        var ids = [];
+        if (hm_page_name() == 'message') {
+            var list_path = hm_list_path().split('_');
+            ids.push(list_path[1]+'_'+hm_msg_uid()+'_'+list_path[2]);
+        } else {
+            $('input[type=checkbox]').each(function() {
+                if (this.checked && this.id.search('imap') != -1) {
+                    var parts = this.id.split('_');
+                    ids.push(parts[1]+'_'+parts[2]+'_'+parts[3]);
+                }
+            });
+            if (ids.length == 0) {
+                return;
+            };
+        }
+        Hm_Ajax.request(
+            [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_snooze'},
+            {'name': 'imap_snooze_ids', 'value': ids},
+            {'name': 'imap_snooze_until', 'value': $(this).val()}],
+            function(res) {
+                if (res.snoozed_messages > 0) {
+                    Hm_Folders.reload_folders(true);
+                    var path = hm_list_parent()? hm_list_parent(): hm_list_path();
+                    window.location.href = '?page=message_list&list_path='+path;
+                }
+            }
+        );
+    });
+}
+
+var imap_unsnooze_messages = function() { 
+    Hm_Ajax.request(
+        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_unsnooze'}],
+        function() {},
+    );
+}
+
 if (hm_list_path() == 'sent') {
     Hm_Message_List.page_caches.sent = 'formatted_sent_data';
 }
@@ -1110,6 +1177,13 @@ $(function() {
     else if (hm_page_name() === 'info') {
         setTimeout(imap_status_update, 100);
     }
+    
+    if (hm_page_name() === 'message_list' || hm_page_name() === 'message') {
+        imap_setup_snooze();
+    }
+
+    imap_unsnooze_messages();
+    setInterval(imap_unsnooze_messages, 60000);
 
     if ($('.imap_move').length > 0) {
         check_select_for_imap();

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -154,8 +154,7 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
             else {
                 Hm_Msgs::add('ERRAn Error Occurred');
             }
-            $msgs = Hm_Msgs::get();
-            $this->session->secure_cookie($this->request, 'hm_msgs', base64_encode(serialize($msgs)));
+            $this->save_hm_msgs();
             Hm_Dispatch::page_redirect('?page=servers');
         }
     }
@@ -215,10 +214,7 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->session->record_unsaved('SMTP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     Hm_Msgs::add('E-mail account successfully added');
-                    $msgs = Hm_Msgs::get();
-                    if (!empty($msgs)) {
-                        $this->session->secure_cookie($this->request, 'hm_msgs', base64_encode(serialize($msgs)));
-                    }
+                    $this->save_hm_msgs();
                     $this->session->close_early();
                     $this->out('nux_account_added', true);
                     $this->out('nux_server_id', $new_id);

--- a/modules/wordpress/modules.php
+++ b/modules/wordpress/modules.php
@@ -212,8 +212,7 @@ class Hm_Handler_process_wordpress_authorization extends Hm_Handler_Module {
             else {
                 Hm_Msgs::add('ERRAn Error Occured');
             }
-            $msgs = Hm_Msgs::get();
-            $this->session->secure_cookie($this->request, 'hm_msgs', base64_encode(serialize($msgs)));
+            $this->save_hm_msgs();
             Hm_Dispatch::page_redirect('?page=servers');
         }
     }


### PR DESCRIPTION
With this merge request users can waiten emails by picking a desired date, or with some predefined helpers (later on the day, tomorrow, next weekend, next week on monday, or the first of next month). Snoozed messages go to **Snoozed** folder. All snoozed emails (with X-Snoozed header) and all emails in snoozed folder can be unsnoozed manually. Automatic unsnoozed is for now done by a script that runs every minute to unsnooze email which dates are reached.

It fixes https://github.com/jasonmunro/cypht/issues/572
And relates https://avan.tech/item59012