### PR TITLE
fix for some attachments whose keys are exchanged

### DIFF
--- a/modules/imap/hm-imap-bodystructure.php
+++ b/modules/imap/hm-imap-bodystructure.php
@@ -308,11 +308,13 @@ class Hm_IMAP_Struct {
      */
     private function id_single_part($vals) {
         $res = array();
+        $single_format = false;
         if (isset($vals[0]) && strtolower($vals[0]) == 'text') {
             $flds = $this->text_format;
         }
         else {
             $flds = $this->single_format;
+            $single_format = true;
         }
         foreach($flds as $name => $pos) {
             if (isset($vals[$pos])) {
@@ -321,6 +323,14 @@ class Hm_IMAP_Struct {
             else {
                 $res[$name] = false;
             }
+        }
+        // This is an edge case for improperly formatted parts
+        if ($single_format && !$res['size'] && is_numeric($res['encoding'])) {
+            $res['file_attributes'] = $res['md5'];
+            $res['md5'] = $res['size'];
+            $res['size'] = $res['encoding'];
+            $res['encoding'] = $res['description'];
+            $res['description'] = false;
         }
         return $res;
     }


### PR DESCRIPTION
Hm_IMAP_Struct::single_format that defines Field order of a single non-text message part sometimes message struct comes with a different order as seen in the screenshot and lead to wrong behaviors (Corrupts PDF generation in this particular case). Here the encoding becoming description, size becoming the encoding.

<img width="1085" alt="Screenshot 2022-12-13 at 15 09 43" src="https://user-images.githubusercontent.com/80334370/207361185-ad31e19b-2702-4c2c-8669-ebee5048dc49.png">

Relates: https://avan.tech/item61844


