### PR TITLE
Updated URLs from jasonmunro to cypht-org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Please take a look at the issue templates at
-https://github.com/jasonmunro/cypht/issues/new/choose
+https://github.com/cypht-org/cypht/issues/new/choose
 before submitting a new issue.
 Following one of the issue templates will ensure maintainers can route your request efficiently.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 We appreciate all feedback and support of the project.
 Please use the issue tracker at Github to submit bug reports or feature requests:
 
-https://github.com/jasonmunro/cypht/issues
+https://github.com/cypht-org/cypht/issues
 
 If you have questions you can always E-mail me directly at jason at cypht dot org,
 or jump in our IRC channel at #hastymail on freenode.net or our chat at: https://gitter.im/cypht-org/community

--- a/INSTALL
+++ b/INSTALL
@@ -38,7 +38,7 @@ mkdir cypht-temp
 cd cypht-temp
 
 # grab latest code
-wget https://github.com/jasonmunro/cypht/archive/master.zip
+wget https://github.com/cypht-org/cypht/archive/master.zip
 
 # unpack the archive
 unzip master.zip
@@ -181,7 +181,7 @@ Cypht can connect to github and aggregate notification data about repository
 activity.
 
 Example github.ini file:
-https://github.com/jasonmunro/cypht/blob/master/modules/github/github.ini
+https://github.com/cypht-org/cypht/blob/master/modules/github/github.ini
 
 Authorize an application for github:
 https://github.com/settings/developers
@@ -192,7 +192,7 @@ preferable to normal IMAP authentication because Cypht never has access to your
 account password.
 
 Example oauth2 ini file:
-https://github.com/jasonmunro/cypht/blob/master/modules/imap/oauth2.ini
+https://github.com/cypht-org/cypht/blob/master/modules/imap/oauth2.ini
 
 Authorize an application for gmail
 https://console.developers.google.com/project
@@ -204,13 +204,13 @@ LDAP contacts
 Cypht can use an LDAP server for contacts.
 
 Example ldap.ini file:
-https://github.com/jasonmunro/cypht/blob/master/modules/ldap_contacts/ldap.ini
+https://github.com/cypht-org/cypht/blob/master/modules/ldap_contacts/ldap.ini
 
 WordPress
 Cypht can aggregate WordPress.com notifications.
 
 Example wordpress.ini file:
-https://github.com/jasonmunro/cypht/blob/master/modules/wordpress/wordpress.ini
+https://github.com/cypht-org/cypht/blob/master/modules/wordpress/wordpress.ini
 
 Authorize an application for WordPress.com:
 https://developer.wordpress.com/apps/
@@ -219,7 +219,7 @@ Custom themes
 You can create your own themes for Cypht. Edit the themes.ini file to include
 your theme, and put the css file in modules/themes/assets.
 
-https://github.com/jasonmunro/cypht/blob/master/modules/themes/themes.ini
+https://github.com/cypht-org/cypht/blob/master/modules/themes/themes.ini
 
 Having problems?
 

--- a/modules/api_login/README.md
+++ b/modules/api_login/README.md
@@ -4,4 +4,4 @@ This module set helps make it easier to integrate Cypht with other web
 applications making "single sign on" possible. More information about
 how this works can be found here:
 
-https://github.com/jasonmunro/cypht/wiki/API-Login
+https://github.com/cypht-org/cypht/wiki/API-Login

--- a/modules/developer/modules.php
+++ b/modules/developer/modules.php
@@ -7,7 +7,7 @@
  */
 
 if (!defined('DEBUG_MODE')) { die(); }
-define('COMMITS_URL', 'https://github.com/jasonmunro/cypht/commit/');
+define('COMMITS_URL', 'https://github.com/cypht-org/cypht/commit/');
 
 require_once VENDOR_PATH.'autoload.php';
 use Webklex\ComposerInfo\ComposerInfo;
@@ -98,7 +98,7 @@ class Hm_Output_dev_content extends Hm_Output_Module {
             'not yet complete, has a lot of useful information'.
             '<br /><br />&nbsp;&nbsp;&nbsp;<a href="http://cypht.org/docs/code_docs/index.html">http://cypht.org/docs/code_docs/index.html</a>'.
             '<br /><br />Finally there is a "hello world" module with lots of comments included in the project download and browsable at github'.
-            '<br /><br />&nbsp;&nbsp;&nbsp;<a href="https://github.com/jasonmunro/cypht/tree/master/modules/hello_world">https://github.com/jasonmunro/cypht/tree/master/modules/hello_world</a>'.
+            '<br /><br />&nbsp;&nbsp;&nbsp;<a href="https://github.com/cypht-org/cypht/tree/master/modules/hello_world">https://github.com/cypht-org/cypht/tree/master/modules/hello_world</a>'.
             '</div></div>';
     }
 }

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -307,7 +307,7 @@ class Hm_Output_nux_dev_news extends Hm_Output_Module {
     protected function output() {
         $res = '<div class="nux_dev_news"><div class="nux_title">'.$this->trans('Development Updates').'</div><table>';
         foreach ($this->get('nux_dev_news', array()) as $vals) {
-            $res .= sprintf('<tr><td><a href="https://github.com/jasonmunro/cypht/commit/%s">%s</a>'.
+            $res .= sprintf('<tr><td><a href="https://github.com/cypht-org/cypht/commit/%s">%s</a>'.
                 '</td><td class="msg_date">%s</td><td>%s</td><td>%s</td></tr>',
                 $this->html_safe($vals['hash']),
                 $this->html_safe($vals['shash']),

--- a/modules/pop3/README.md
+++ b/modules/pop3/README.md
@@ -4,4 +4,4 @@ This module set allows users to access E-mail accounts using the POP3 protocol.
 This protocol is inferior to the IMAP protocol, and Cypht does not support as
 many features for E-mail management as compared to IMAP because of that.
 
-POP3 support will be removed from Cypht: https://github.com/jasonmunro/cypht/issues/452
+POP3 support will be removed from Cypht: https://github.com/cypht-org/cypht/issues/452


### PR DESCRIPTION
As Cypht as been moved, this merge request updates URLs from https://github.com/jasonmunro/cypht to https://github.com/cypht-org/cypht.