### PR TITLE
Fix: broken icon image when trying to switch to a theme that alters icon colors

### DIFF
--- a/modules/themes/modules.php
+++ b/modules/themes/modules.php
@@ -190,7 +190,7 @@ function hm_theme_icons($color='white') {
             $raw = rawurldecode(Hm_Image_Sources::$$name);
             $pre = substr($raw, 0, 19);
             $img = substr($raw, 19);
-            Hm_Image_Sources::$$name = $pre.rawurlencode(str_replace('/>', 'fill="'.$color.'" />', $img));
+            Hm_Image_Sources::$$name = $pre.rawurlencode(str_replace('/>', ' fill="'.$color.'" />', $img));
         }
     }
 }}


### PR DESCRIPTION
This PR fixes the icon image by adding a space before the ***fill*** attribute on the svg icon image as described in the related issue below.

### Related issues
- [https://github.com/cypht-org/cypht/issues/741)](https://github.com/cypht-org/cypht/issues/741)
