### PR TITLE
Allow cypht integration to save message away from imap server

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -734,7 +734,7 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
 
         /* check for associated IMAP server to save a copy */
         if ($imap_server !== false) {
-            $this->out('save_sent_server', $imap_server);
+            $this->out('save_sent_server', $imap_server, false);
             $this->out('save_sent_msg', $mime);
         }
         else {


### PR DESCRIPTION
Relates: https://gitlab.com/tikiwiki/tiki/-/merge_requests/3425

This helps cypht integration to store messages in other place than imap server.