### PR TITLE
Fixed invalid argument passed to foreach

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1373,7 +1373,7 @@ function snooze_formats() {
         'next_month'
     );
     if (date('H') <= 16) {
-        $values = array_push($values, 'later_in_day');
+        array_push($values, 'later_in_day');
     }
     return $values;
 }}


### PR DESCRIPTION
Relates: https://github.com/cypht-org/cypht/issues/734#issuecomment-1711102910

Assign return of array push to $values lead to invalid passing int to foreach.