### PR TITLE
Fixed adding one server multiple times [Only nux module]

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1369,7 +1369,7 @@ class Hm_Handler_process_add_imap_server extends Hm_Handler_Module {
                     $this->session->record_unsaved('IMAP server added');
                 }
                 else {
-                    Hm_Msgs::add(sprintf('ERRCound not add server: %s', $errstr));
+                    Hm_Msgs::add(sprintf('ERRCould not add server: %s', $errstr));
                 }
             }
         }

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -184,6 +184,11 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                 $servers = Hm_IMAP_List::dump(false, true);
                 $ids = array_keys($servers);
                 $new_id = array_pop($ids);
+                if (in_server_list('Hm_IMAP_List', $new_id, $form['nux_email'])) {
+                    Hm_IMAP_List::del($new_id);
+                    Hm_Msgs::add('ERRThis IMAP server and username are already configured');
+                    return;
+                }
                 $imap = Hm_IMAP_List::connect($new_id, false);
                 if ($imap && $imap->get_state() == 'authenticated') {
                     if (isset($details['smtp'])) {
@@ -197,7 +202,14 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                         ));
                         $this->session->record_unsaved('SMTP server added');
                         $smtp_servers = Hm_SMTP_List::dump(false, true);
-                        $this->user_config->set('smtp_servers', $smtp_servers);
+                        $ids = array_keys($servers);
+                        $new_smtp_id = array_pop($ids);
+                        if (in_server_list('Hm_SMTP_List', $new_smtp_id, $form['nux_email'])) {
+                            Hm_SMTP_List::del($new_smtp_id);
+                            Hm_Msgs::add('ERRThis SMTP server and username are already configured');
+                        } else {
+                            $this->user_config->set('smtp_servers', $smtp_servers);
+                        }
                     }
                     $this->user_config->set('imap_servers', $servers);
                     Hm_IMAP_List::clean_up();


### PR DESCRIPTION
There was a bug on nux module as no check was done when adding server. One server could be added many times contrarily to adding server from iMAP or SMTP sections. With this merge request now if IMAP server is already added an error is returned and process is stop but if a smtp server is already added we don't add it again.