### PR TITLE
Fixed broken message list sort options design

### DIFF
--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -317,6 +317,6 @@ div.unseen, .unseen .subject { font-weight: 700; }
     padding: 0px 5px 5px 10px;
     background-color: #fff;
 }
-#list_controls_menu.show{display: flex;}
-.imap_keyword, .imap_sort, .imap_filter {width: 100%;}
+.mobile #list_controls_menu.show { display: flex; }
+.mobile .imap_sort { width: 100%; }
 .snoozed_date { color: teal !important; }


### PR DESCRIPTION
<img width="1209" alt="Screenshot 2023-10-26 at 14 50 10" src="https://github.com/cypht-org/cypht/assets/80334370/6ad906a9-395e-45d4-bcd5-b01bfc32b3fd">

Right message list menu was broken