### PR TITLE
Output email menu content: for just one email account All and Everything removed

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -1299,11 +1299,11 @@ class Hm_Output_main_menu_content extends Hm_Output_Module {
     protected function output() {
         $res = '';
         $email = false;
-        $single = $this->get('single_server_mode');
         if (array_key_exists('email_folders', merge_folder_list_details($this->get('folder_sources', array())))) {
             $email = true;
         }
-        if (!$single) {
+        $total_accounts = count($this->get('imap_servers', array())) + count($this->get('feeds', array()));
+        if ($total_accounts > 2) {
             $res .= '<li class="menu_combined_inbox"><a class="unread_link" href="?page=message_list&amp;list_path=combined_inbox">';
             if (!$this->get('hide_folder_icons')) {
                 $res .= '<i class="bi bi-box2-fill fs-5 me-2"></i>';
@@ -1404,7 +1404,7 @@ class Hm_Output_email_menu_content extends Hm_Output_Module {
                 $res .= '<div style="display: none;" ';
             }
             $res .= 'class="'.$this->html_safe($src).'"><ul class="folders">';
-            if ($name == 'Email' && !$single) {
+            if ($name == 'Email' && count($this->get('imap_servers', array()))  > 1) {
                 $res .= '<li class="menu_email"><a class="unread_link" href="?page=message_list&amp;list_path=email">';
                 if (!$this->get('hide_folder_icons')) {
                     $res .= '<i class="bi bi-globe-americas fs-5 me-2"></i>';

--- a/modules/feeds/modules.php
+++ b/modules/feeds/modules.php
@@ -790,11 +790,14 @@ class Hm_Output_filter_feed_folders extends Hm_Output_Module {
         $res = '';
         $folders = $this->get('feed_folders', array());
         if (is_array($folders) && !empty($folders)) {
-            $res .= '<li class="menu_feeds"><a class="unread_link" href="?page=message_list&amp;list_path=feeds">';
-            if (!$this->get('hide_folder_icons')) {
-                $res .= '<i class="bi bi-rss-fill fs-5 me-2"></i>';
+            if(count($this->get('feeds', array()))  > 1) {
+                $res .= '<li class="menu_feeds"><a class="unread_link" href="?page=message_list&amp;list_path=feeds">';
+                if (!$this->get('hide_folder_icons')) {
+                    $res .= '<i class="bi bi-rss-fill fs-5 me-2"></i>';
+                }
+                $res .= $this->trans('All');
+                $res .= '</a> <span class="unread_feed_count"></span></li>';
             }
-            $res .= $this->trans('All').'</a> <span class="unread_feed_count"></span></li>';
             foreach ($this->get('feed_folders') as $id => $folder) {
                 $res .= '<li class="feeds_'.$this->html_safe($id).'">'.
                     '<a data-id="feeds_'.$this->html_safe($id).'" href="?page=message_list&list_path=feeds_'.$this->html_safe($id).'">';


### PR DESCRIPTION
If I only have a single account, I won't require access to 'Everything,' 'All,' or the corresponding box or container. These options are more relevant when dealing with multiple accounts.