### PR TITLE
Fixed Plain text showing as attachment

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -664,9 +664,12 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         );
 
         /* parse attachments */
-        $uploaded_files = explode(',', $this->request->post['send_uploaded_files']);
-        foreach($uploaded_files as $key => $file) {
-            $uploaded_files[$key] = $this->config->get('attachment_dir').'/'.md5($this->session->get('username', false)).'/'.$file;
+        $uploaded_files = [];
+        if (!empty($this->request->post['send_uploaded_files'])) {
+            $uploaded_files = explode(',', $this->request->post['send_uploaded_files']);
+            foreach($uploaded_files as $key => $file) {
+                $uploaded_files[$key] = $this->config->get('attachment_dir').'/'.md5($this->session->get('username', false)).'/'.$file;
+            }
         }
 
         $uploaded_files = get_uploaded_files_from_array(


### PR DESCRIPTION
Fixes https://github.com/cypht-org/cypht/issues/794

Using php explode function on empty string creates an array with 1 key. Which makes the attachment array to have at least one key.