### PR TITLE
Backporting menus (junk, trash and drafts) to 1.4.x

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -895,3 +895,80 @@ class Hm_Handler_process_search_terms extends Hm_Handler_Module {
     }
 }
 
+/**
+ * Process input from the max per source setting for the Junk page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_junk_source_max_setting extends Hm_Handler_Module {
+    /**
+     * Allowed values are greater than zero and less than MAX_PER_SOURCE
+     */
+    public function process() {
+        process_site_setting('junk_per_source', $this, 'max_source_setting_callback', DEFAULT_PER_SOURCE);
+    }
+}
+
+/**
+ * Process "since" setting for the junk page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_junk_since_setting extends Hm_Handler_Module {
+    /**
+     * valid values are defined in the process_since_argument function
+     */
+    public function process() {
+        process_site_setting('junk_since', $this, 'since_setting_callback');
+    }
+}
+
+/**
+ * Process input from the max per source setting for the Trash page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_trash_source_max_setting extends Hm_Handler_Module {
+    /**
+     * Allowed values are greater than zero and less than MAX_PER_SOURCE
+     */
+    public function process() {
+        process_site_setting('trash_per_source', $this, 'max_source_setting_callback', DEFAULT_PER_SOURCE);
+    }
+}
+
+/**
+ * Process "since" setting for the trash page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_trash_since_setting extends Hm_Handler_Module {
+    /**
+     * valid values are defined in the process_since_argument function
+     */
+    public function process() {
+        process_site_setting('trash_since', $this, 'since_setting_callback');
+    }
+}
+
+/**
+ * Process input from the max per source setting for the Draft page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_drafts_source_max_setting extends Hm_Handler_Module {
+    /**
+     * Allowed values are greater than zero and less than MAX_PER_SOURCE
+     */
+    public function process() {
+        process_site_setting('drafts_per_source', $this, 'max_source_setting_callback', DEFAULT_PER_SOURCE);
+    }
+}
+
+/**
+ * Process "since" setting for the Drafts page in the settings page
+ * @subpackage core/handler
+ */
+class Hm_Handler_process_drafts_since_setting extends Hm_Handler_Module {
+    /**
+     * valid values are defined in the process_since_argument function
+     */
+    public function process() {
+        process_site_setting('drafts_since', $this, 'since_setting_callback');
+    }
+}

--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -44,6 +44,24 @@ function get_message_list_settings($path, $handler) {
         $per_source_limit = $handler->user_config->get('all_per_source_setting', DEFAULT_PER_SOURCE);
         $mailbox_list_title = array('Everything');
     }
+    elseif ($path == 'junk') {
+        $list_path = 'junk';
+        $message_list_since = $handler->user_config->get('junk_since_setting', DEFAULT_SINCE);
+        $per_source_limit = $handler->user_config->get('junk_per_source_setting', DEFAULT_PER_SOURCE);
+        $mailbox_list_title = array('Junk');
+    }
+    elseif ($path == 'trash') {
+        $list_path = 'trash';
+        $message_list_since = $handler->user_config->get('trash_since_setting', DEFAULT_SINCE);
+        $per_source_limit = $handler->user_config->get('trash_per_source_setting', DEFAULT_PER_SOURCE);
+        $mailbox_list_title = array('Trash');
+    }
+    elseif ($path == 'drafts') {
+        $list_path = 'drafts';
+        $message_list_since = $handler->user_config->get('drafts_since_setting', DEFAULT_SINCE);
+        $per_source_limit = $handler->user_config->get('drafts_per_source_setting', DEFAULT_PER_SOURCE);
+        $mailbox_list_title = array('Drafts');
+    }
     return array($list_path, $mailbox_list_title, $message_list_since, $per_source_limit);
 }}
 

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -1246,6 +1246,21 @@ class Hm_Output_main_menu_content extends Hm_Output_Module {
             $res .= '<img class="account_icon" src="'.$this->html_safe(Hm_Image_Sources::$star).'" alt="" width="16" height="16" /> ';
         }
         $res .= $this->trans('Flagged').'</a> <span class="flagged_count"></span></li>';
+        $res .= '<li class="menu_junk"><a class="unread_link" href="?page=message_list&amp;list_path=junk">';
+        if (!$this->get('hide_folder_icons')) {
+            $res .= '<img class="account_icon" src="'.$this->html_safe(Hm_Image_Sources::$junk).'" alt="" width="16" height="16" /> ';
+        }
+        $res .= $this->trans('Junk').'</a></li>';
+        $res .= '<li class="menu_trash"><a class="unread_link" href="?page=message_list&amp;list_path=trash">';
+        if (!$this->get('hide_folder_icons')) {
+            $res .= '<img class="account_icon" src="'.$this->html_safe(Hm_Image_Sources::$trash).'" alt="" width="16" height="16" /> ';
+        }
+        $res .= $this->trans('Trash').'</a></li>';
+        $res .= '<li class="menu_drafts"><a class="unread_link" href="?page=message_list&amp;list_path=drafts">';
+        if (!$this->get('hide_folder_icons')) {
+            $res .= '<img class="account_icon" src="'.$this->html_safe(Hm_Image_Sources::$draft).'" alt="" width="16" height="16" /> ';
+        }
+        $res .= $this->trans('Drafts').'</a></li>';
 
         if ($this->format == 'HTML5') {
             return $res;
@@ -1788,5 +1803,182 @@ class Hm_Output_search_move_copy_controls extends Hm_Output_Module {
         $res .= '<input type="hidden" class="move_to_string3" value="'.$this->trans('Removed non-IMAP messages from selection. They cannot be moved or copied').'" />';
         // $res = "<strong>COPY/MOVE</strong>";
         $this->concat('msg_controls_extra', $res);
+    }
+}
+
+/**
+ * Starts the Junk section on the settings page
+ * @subpackage core/output
+ */
+class Hm_Output_start_junk_settings extends Hm_Output_Module {
+    /**
+     * Settings in this section control the flagged messages view
+     */
+    protected function output() {
+        return '<tr><td data-target=".junk_setting" colspan="2" class="settings_subtitle">'.
+            '<img alt="" src="'.Hm_Image_Sources::$junk.'" width="16" height="16" />'.
+            $this->trans('Junk').'</td></tr>';
+    }
+}
+
+/**
+ * Option for the maximum number of messages per source for the Junk page
+ * @subpackage core/output
+ */
+class Hm_Output_junk_source_max_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_all_source_max_setting
+     */
+    protected function output() {
+        $sources = DEFAULT_PER_SOURCE;
+        $settings = $this->get('user_settings', array());
+        $reset = '';
+        if (array_key_exists('junk_per_source', $settings)) {
+            $sources = $settings['junk_per_source'];
+        }
+        if ($sources != 20) {
+            $reset = '<span class="tooltip_restore" restore_aria_label="Restore default value"><img alt="Refresh" class="refresh_list reset_default_value_input" src="'.Hm_Image_Sources::$refresh.'" /></span>';
+        }
+        return '<tr class="junk_setting"><td><label for="junk_per_source">'.
+            $this->trans('Max messages per source').'</label></td>'.
+            '<td><input type="text" size="2" id="junk_per_source" name="junk_per_source" value="'.$this->html_safe($sources).'" />'.$reset.'</td></tr>';
+    }
+}
+
+/**
+ * Option for the "junk since" date range for the Junk page
+ * @subpackage core/output
+ */
+class Hm_Output_junk_since_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_junk_since_setting
+     */
+    protected function output() {
+        $since = DEFAULT_SINCE;
+        $settings = $this->get('user_settings', array());
+        if (array_key_exists('junk_since', $settings) && $settings['junk_since']) {
+            $since = $settings['junk_since'];
+        }
+        return '<tr class="junk_setting"><td><label for="junk_since">'.
+            $this->trans('Show junk messages since').'</label></td>'.
+            '<td>'.message_since_dropdown($since, 'junk_since', $this).'</td></tr>';
+    }
+}
+
+/**
+ * Starts the Trash section on the settings page
+ * @subpackage core/output
+ */
+class Hm_Output_start_trash_settings extends Hm_Output_Module {
+    /**
+     * Settings in this section control the flagged messages view
+     */
+    protected function output() {
+        return '<tr><td data-target=".trash_setting" colspan="2" class="settings_subtitle">'.
+            '<img alt="" src="'.Hm_Image_Sources::$trash.'" width="16" height="16" />'.
+            $this->trans('Trash').'</td></tr>';
+    }
+}
+
+/**
+ * Option for the maximum number of messages per source for the Trash page
+ * @subpackage core/output
+ */
+class Hm_Output_trash_source_max_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_all_source_max_setting
+     */
+    protected function output() {
+        $sources = DEFAULT_PER_SOURCE;
+        $settings = $this->get('user_settings', array());
+        $reset = '';
+        if (array_key_exists('trash_per_source', $settings)) {
+            $sources = $settings['trash_per_source'];
+        }
+        if ($sources != 20) {
+            $reset = '<span class="tooltip_restore" restore_aria_label="Restore default value"><img alt="Refresh" class="refresh_list reset_default_value_input" src="'.Hm_Image_Sources::$refresh.'" /></span>';
+        }
+        return '<tr class="trash_setting"><td><label for="trash_per_source">'.
+            $this->trans('Max messages per source').'</label></td>'.
+            '<td><input type="text" size="2" id="trash_per_source" name="trash_per_source" value="'.$this->html_safe($sources).'" />'.$reset.'</td></tr>';
+    }
+}
+
+/**
+ * Option for the "trash since" date range for the Trash page
+ * @subpackage core/output
+ */
+class Hm_Output_trash_since_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_trash_since_setting
+     */
+    protected function output() {
+        $since = DEFAULT_SINCE;
+        $settings = $this->get('user_settings', array());
+        if (array_key_exists('trash_since', $settings) && $settings['trash_since']) {
+            $since = $settings['trash_since'];
+        }
+        return '<tr class="trash_setting"><td><label for="trash_since">'.
+            $this->trans('Show trash messages since').'</label></td>'.
+            '<td>'.message_since_dropdown($since, 'trash_since', $this).'</td></tr>';
+    }
+}
+
+/**
+ * Starts the Draft section on the settings page
+ * @subpackage core/output
+ */
+class Hm_Output_start_drafts_settings extends Hm_Output_Module {
+    /**
+     * Settings in this section control the flagged messages view
+     */
+    protected function output() {
+        return '<tr><td data-target=".drafts_setting" colspan="2" class="settings_subtitle">'.
+            '<img alt="" src="'.Hm_Image_Sources::$draft.'" width="16" height="16" />'.
+            $this->trans('Drafts').'</td></tr>';
+    }
+}
+
+/**
+ * Option for the maximum number of messages per source for the Draft page
+ * @subpackage core/output
+ */
+class Hm_Output_drafts_source_max_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_all_source_max_setting
+     */
+    protected function output() {
+        $sources = DEFAULT_PER_SOURCE;
+        $settings = $this->get('user_settings', array());
+        $reset = '';
+        if (array_key_exists('drafts_per_source', $settings)) {
+            $sources = $settings['drafts_per_source'];
+        }
+        if ($sources != 20) {
+            $reset = '<span class="tooltip_restore" restore_aria_label="Restore default value"><img alt="Refresh" class="refresh_list reset_default_value_input" src="'.Hm_Image_Sources::$refresh.'" /></span>';
+        }
+        return '<tr class="drafts_setting"><td><label for="drafts_per_source">'.
+            $this->trans('Max messages per source').'</label></td>'.
+            '<td><input type="text" size="2" id="drafts_per_source" name="drafts_per_source" value="'.$this->html_safe($sources).'" />'.$reset.'</td></tr>';
+    }
+}
+
+/**
+ * Option for the "draft since" date range for the Draft page
+ * @subpackage core/output
+ */
+class Hm_Output_drafts_since_setting extends Hm_Output_Module {
+    /**
+     * Processed by Hm_Handler_process_draft_since_setting
+     */
+    protected function output() {
+        $since = DEFAULT_SINCE;
+        $settings = $this->get('user_settings', array());
+        if (array_key_exists('drafts_since', $settings) && $settings['drafts_since']) {
+            $since = $settings['drafts_since'];
+        }
+        return '<tr class="drafts_setting"><td><label for="drafts_since">'.
+            $this->trans('Show draft messages since').'</label></td>'.
+            '<td>'.message_since_dropdown($since, 'drafts_since', $this).'</td></tr>';
     }
 }

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -44,6 +44,12 @@ add_handler('settings', 'process_all_source_max_setting', true, 'core', 'date', 
 add_handler('settings', 'process_all_since_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_all_email_since_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_all_email_source_max_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_junk_since_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_junk_source_max_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_trash_since_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_trash_source_max_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_drafts_since_setting', true, 'core', 'date', 'after');
+add_handler('settings', 'process_drafts_source_max_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_hide_folder_icons', true, 'core', 'date', 'after');
 add_handler('settings', 'process_delete_prompt_setting', true, 'core', 'date', 'after');
 add_handler('settings', 'process_no_password_setting', true, 'core', 'date', 'after');
@@ -73,7 +79,16 @@ add_output('settings', 'unread_source_max_setting', true, 'core', 'unread_since_
 add_output('settings', 'start_flagged_settings', true, 'core', 'unread_source_max_setting', 'after');
 add_output('settings', 'flagged_since_setting', true, 'core', 'start_flagged_settings', 'after');
 add_output('settings', 'flagged_source_max_setting', true, 'core', 'flagged_since_setting', 'after');
-add_output('settings', 'start_everything_settings', true, 'core', 'flagged_source_max_setting', 'after');
+add_output('settings', 'start_junk_settings', true, 'core', 'flagged_source_max_setting', 'after');
+add_output('settings', 'junk_since_setting', true, 'core', 'start_junk_settings', 'after');
+add_output('settings', 'junk_source_max_setting', true, 'core', 'junk_since_setting', 'after');
+add_output('settings', 'start_trash_settings', true, 'core', 'junk_source_max_setting', 'after');
+add_output('settings', 'trash_since_setting', true, 'core', 'start_trash_settings', 'after');
+add_output('settings', 'trash_source_max_setting', true, 'core', 'trash_since_setting', 'after');
+add_output('settings', 'start_drafts_settings', true, 'core', 'trash_source_max_setting', 'after');
+add_output('settings', 'drafts_since_setting', true, 'core', 'start_drafts_settings', 'after');
+add_output('settings', 'drafts_source_max_setting', true, 'core', 'drafts_since_setting', 'after');
+add_output('settings', 'start_everything_settings', true, 'core', 'drafts_source_max_setting', 'after');
 add_output('settings', 'all_since_setting', true, 'core', 'start_everything_settings', 'after');
 add_output('settings', 'all_source_max_setting', true, 'core', 'all_since_setting', 'after');
 add_output('settings', 'start_all_email_settings', true, 'core', 'all_source_max_setting', 'after');
@@ -265,7 +280,13 @@ return array(
         'no_password_save' => FILTER_VALIDATE_BOOLEAN,
         'start_page' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'default_sort_order' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-        'stay_logged_in' => FILTER_VALIDATE_BOOLEAN
+        'stay_logged_in' => FILTER_VALIDATE_BOOLEAN,
+        'junk_per_source' => FILTER_VALIDATE_INT,
+        'junk_since' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'trash_per_source' => FILTER_VALIDATE_INT,
+        'trash_since' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'drafts_per_source' => FILTER_VALIDATE_INT,
+        'drafts_since' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
     )
 );
 

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -141,7 +141,7 @@ textarea, select, input, button { border: solid 1px #ddd; background-color: #fff
 .hide_folders img { opacity: .4; }
 .section_caret { opacity: .15; vertical-align: 4px; padding-right: 10px; }
 .server_count { float: right; margin-right: 120px; font-size: 90%; }
-.email_setting, .all_setting, .unread_setting, .flagged_setting, .general_setting { display: none; }
+.email_setting, .all_setting, .unread_setting, .flagged_setting, .general_setting, .junk_setting, .trash_setting, .drafts_setting { display: none; }
 .configured_server, .add_server { margin-top: 10px; color: #666; background-color: #fff; margin-bottom: 20px; padding: 10px; width: 200px; }
 .message_list { min-height: 600px; background-color: #fff; height: 100%; padding-bottom: 20px; }
 .configured_server { float: left; margin-left: 25px; width: 230px; }

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -414,7 +414,10 @@ function Message_List() {
         'combined_inbox': 'formatted_combined_inbox',
         'email': 'formatted_all_mail',
         'unread': 'formatted_unread_data',
-        'flagged': 'formatted_flagged_data'
+        'flagged': 'formatted_flagged_data',
+        'junk': 'formatted_junk_data',
+        'trash': 'formatted_trash_data',
+        'drafts': 'formatted_drafts_data'
     };
 
     this.run_callbacks = function (completed) {
@@ -1063,6 +1066,9 @@ function Message_List() {
     this.set_flagged_state = function() { self.set_message_list_state('formatted_flagged_data'); };
     this.set_unread_state = function() { self.set_message_list_state('formatted_unread_data'); };
     this.set_search_state = function() { self.set_message_list_state('formatted_search_data'); };
+    this.set_junk_state = function() { self.set_message_list_state('formatted_junk_data'); };
+    this.set_trash_state = function() { self.set_message_list_state('formatted_trash_data'); };
+    this.set_draft_state = function() { self.set_message_list_state('formatted_drafts_data'); };
 };
 
 /* folder list */
@@ -1438,7 +1444,7 @@ var Hm_Utils = {
         var results = {}
         var i;
         var hash = window.location.hash;
-        var sections = ['.wp_notifications_setting', '.github_all_setting', '.tfa_setting', '.sent_setting', '.general_setting', '.unread_setting', '.flagged_setting', '.all_setting', '.email_setting'];
+        var sections = ['.wp_notifications_setting', '.github_all_setting', '.tfa_setting', '.sent_setting', '.general_setting', '.unread_setting', '.flagged_setting', '.all_setting', '.email_setting', '.junk_setting', '.trash_setting', '.drafts_setting'];
         for (i=0;i<sections.length;i++) {
             dsp = Hm_Utils.get_from_local_storage(sections[i]);
             if (hash) {

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -18,17 +18,18 @@ if (!defined('DEBUG_MODE')) { die(); }
  * @param string $inbox include inbox in search for auto-bcc messages
  * @return array
  */
-if (!hm_exists('imap_sent_sources')) {
-function imap_sent_sources($callback, $mod) {
+if (!hm_exists('imap_sources')) {
+function imap_sources($callback, $mod, $folder = 'sent') {
     $inbox = $mod->user_config->get('smtp_auto_bcc_setting', false);
     $sources = array();
+    $folder = $folder == 'drafts' ? 'draft': $folder;
     foreach (Hm_IMAP_List::dump() as $index => $vals) {
         if (array_key_exists('hide', $vals) && $vals['hide']) {
             continue;
         }
         $folders = get_special_folders($mod, $index);
-        if (array_key_exists('sent', $folders) && $folders['sent']) {
-            $sources[] = array('callback' => $callback, 'folder' => bin2hex($folders['sent']), 'type' => 'imap', 'name' => $vals['name'], 'id' => $index);
+        if (array_key_exists($folder, $folders) && $folders[$folder]) {
+            $sources[] = array('callback' => $callback, 'folder' => bin2hex('Drafts'), 'type' => 'imap', 'name' => $vals['name'], 'id' => $index);
         }
         elseif ($inbox) {
             $sources[] = array('callback' => $callback, 'folder' => bin2hex('INBOX'), 'type' => 'imap', 'name' => $vals['name'], 'id' => $index);

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -758,16 +758,16 @@ class Hm_Output_filter_unread_data extends Hm_Output_Module {
 }
 
 /**
- * Format message headers for the Sent E-mail page
+ * Format message headers for the Sent, Junk, Draft, Trash E-mail page
  * @subpackage imap/output
  */
-class Hm_Output_filter_sent_data extends Hm_Output_Module {
+class Hm_Output_filter_data extends Hm_Output_Module {
     /**
      * Build ajax response for the All E-mail message list
      */
     protected function output() {
-        if ($this->get('imap_sent_data')) {
-            prepare_imap_message_list($this->get('imap_sent_data'), $this, 'sent');
+        if ($this->get('imap_'.$this->get('list_path').'_data')) {
+            prepare_imap_message_list($this->get('imap_'.$this->get('list_path').'_data'), $this, $this->get('list_path'));
         }
         else {
             $this->out('formatted_message_list', array());

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -132,15 +132,16 @@ add_output('ajax_imap_message_content', 'filter_message_body', true);
 add_output('ajax_imap_message_content', 'filter_message_struct', true);
 
 /* ajax sent callback data */
-setup_base_ajax_page('ajax_imap_sent', 'core');
-add_handler('ajax_imap_sent', 'message_list_type', true, 'core');
-add_handler('ajax_imap_sent', 'imap_message_list_type', true);
-add_handler('ajax_imap_sent', 'load_imap_servers_from_config',  true);
-add_handler('ajax_imap_sent', 'imap_oauth2_token_check', true);
-add_handler('ajax_imap_sent', 'close_session_early',  true, 'core');
-add_handler('ajax_imap_sent', 'imap_sent',  true);
-add_handler('ajax_imap_sent', 'save_imap_cache',  true);
-add_output('ajax_imap_sent', 'filter_sent_data', true);
+setup_base_ajax_page('ajax_imap_folder_data', 'core');
+add_handler('ajax_imap_folder_data', 'message_list_type', true, 'core');
+add_handler('ajax_imap_folder_data', 'imap_message_list_type', true);
+add_handler('ajax_imap_folder_data', 'load_imap_servers_from_config',  true);
+add_handler('ajax_imap_folder_data', 'imap_oauth2_token_check', true);
+add_handler('ajax_imap_folder_data', 'close_session_early',  true, 'core');
+add_handler('ajax_imap_folder_data', 'imap_folder_data',  true);
+add_handler('ajax_imap_folder_data', 'save_imap_cache',  true);
+add_output('ajax_imap_folder_data', 'filter_data', true);
+
 
 /* ajax folder status callback data */
 setup_base_ajax_page('ajax_imap_folder_status', 'core');
@@ -283,7 +284,7 @@ return array(
         'ajax_imap_debug',
         'ajax_imap_status',
         'ajax_imap_unread',
-        'ajax_imap_sent',
+        'ajax_imap_folder_data',
         'ajax_imap_flagged',
         'ajax_imap_folder_expand',
         'ajax_imap_folder_display',

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -318,13 +318,9 @@ var add_auto_folder = function(folder) {
     $('.src_count').html(count);
 };
 
-var imap_sent_content = function(id, folder) {
-    return imap_message_list_content(id, folder, 'ajax_imap_sent', cache_sent_data);
-};
-
-var cache_sent_data = function() {
-    if (hm_list_path() == 'sent') {
-        Hm_Message_List.set_message_list_state('formatted_sent_data');
+var cache_folder_data = function() {
+    if (['sent', 'drafts', 'junk', 'trash'].includes(hm_list_path())) {
+        Hm_Message_List.set_message_list_state('formatted_'+hm_list_path()+'_data');
     }
 };
 
@@ -380,6 +376,10 @@ var imap_combined_flagged_content = function(id, folder) {
 
 var imap_combined_inbox_content = function(id, folder) {
     return imap_message_list_content(id, folder, 'ajax_imap_combined_inbox', Hm_Message_List.set_combined_inbox_state);
+};
+
+var imap_folder_content = function(id, folder) {
+    return imap_message_list_content(id, folder, 'ajax_imap_folder_data', cache_folder_data);
 };
 
 var cache_imap_page = function() {
@@ -688,6 +688,15 @@ var imap_message_view_finished = function(msg_uid, detail, skip_links) {
         }
         else if (hm_list_parent() === 'sent') {
             Hm_Message_List.prev_next_links('formatted_sent_data', class_name);
+        }
+        else if (hm_list_parent() === 'junk') {
+            Hm_Message_List.prev_next_links('formatted_junk_data', class_name);
+        }
+        else if (hm_list_parent() === 'trash') {
+            Hm_Message_List.prev_next_links('formatted_trash_data', class_name);
+        }
+        else if (hm_list_parent() === 'drafts') {
+            Hm_Message_List.prev_next_links('formatted_drafts_data', class_name);
         }
         else {
             var key = 'imap_'+Hm_Utils.get_url_page_number()+'_'+hm_list_path();


### PR DESCRIPTION
Backporting menus (all junk, all trash and all drafts) to 1.4.x

Cherry picked from: [https://github.com/cypht-org/cypht/commit/b622c291c8d82f01936f25145339e09de8a60988](https://github.com/cypht-org/cypht/commit/b622c291c8d82f01936f25145339e09de8a60988)