### PR TITLE
Resolve php82 & php83 exception: Creation of dynamic property is deprecated

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -222,6 +222,7 @@ class Hm_Redis {
     use Hm_Cache_Base;
     private $type = 'Redis';
     private $db_index;
+    private $socket;
 
     /**
      * @param Hm_Config $config site config object

--- a/lib/modules_exec.php
+++ b/lib/modules_exec.php
@@ -128,6 +128,7 @@ trait Hm_Handler_Module_Exec {
     public $handler_response = array();
     public $page = '';
     public $session;
+    public $cache;
 
     /**
      * Setup a default language translation

--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -436,7 +436,7 @@ class HTMLToText {
 
     function __construct($html) {
         $doc = new DOMDocument();
-        $doc->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $doc->loadHTML(htmlentities($html, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
         if (trim($html) && $doc->hasChildNodes()) {
             $this->parse_nodes($doc->childNodes);
         }

--- a/tests/phpunit/auth.php
+++ b/tests/phpunit/auth.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 class Hm_Test_Auth extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->config = new Hm_Mock_Config();

--- a/tests/phpunit/cache.php
+++ b/tests/phpunit/cache.php
@@ -66,6 +66,7 @@ class Hm_Test_Uid_Cache extends TestCase {
  */
 class Hm_Test_Hm_Memcache extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->config = new Hm_Mock_Config();
@@ -174,6 +175,7 @@ class Hm_Test_Hm_Memcache extends TestCase {
  */
 class Hm_Test_Hm_Redis extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->config = new Hm_Mock_Config();
@@ -276,6 +278,7 @@ class Hm_Test_Hm_Redis extends TestCase {
  */
 class Hm_Test_Hm_Cache extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->config = new Hm_Mock_Config();

--- a/tests/phpunit/config.php
+++ b/tests/phpunit/config.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_User_Config_File extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php'; 
         $mock_config = new Hm_Mock_Config();
@@ -161,6 +162,7 @@ class Hm_Test_User_Config_File extends TestCase {
  */
 class Hm_Test_Site_Config_File extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php'; 
         $mock_config = new Hm_Mock_Config();
@@ -202,6 +204,7 @@ class Hm_Test_Site_Config_File extends TestCase {
  */
 class Hm_Test_User_Config_DB extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php'; 
         $mock_config = new Hm_Mock_Config();
@@ -291,6 +294,7 @@ class Hm_Test_User_Config_DB extends TestCase {
 
 class Hm_Test_User_Config_Functions extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php'; 
         $mock_config = new Hm_Mock_Config();

--- a/tests/phpunit/db.php
+++ b/tests/phpunit/db.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_DB extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->config = new Hm_Mock_Config();

--- a/tests/phpunit/dispatch.php
+++ b/tests/phpunit/dispatch.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 class Hm_Test_Dispatch extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         require 'helpers.php';

--- a/tests/phpunit/format.php
+++ b/tests/phpunit/format.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_Format extends TestCase {
 
+    public $json;
+    public $html5;
     public function setUp(): void {
         require 'bootstrap.php';
         $config = new Hm_Mock_Config();

--- a/tests/phpunit/helpers.php
+++ b/tests/phpunit/helpers.php
@@ -5,6 +5,9 @@ class Output_Test {
     public $active_session = true;
     public $req_obj = false;
     public $rtype = 'HTTP';
+    public $mod;
+    public $set;
+    public $module_exec;
 
     public function __construct($name, $set) {
         $this->mod = $name;
@@ -41,6 +44,8 @@ class Handler_Test {
     public $session = array();
     public $req_obj = false;
     public $ses_obj = false;
+    public $set;
+    public $module_exec;
 
     public function __construct($name, $set) {
         $this->mod = $name;

--- a/tests/phpunit/mocks.php
+++ b/tests/phpunit/mocks.php
@@ -6,6 +6,7 @@ class Hm_Mock_Session {
     public $auth_state = true;
     public $cookie_set = false;
     public $data = array();
+    public $lifetime;
     public function get($id, $default=false) {
         if ($id == 'saved_pages') {
             return array('foo' => array('bar', false));
@@ -172,6 +173,7 @@ class Hm_Mock_Config {
 }
 class Hm_Mock_Request {
     public $invalid_input_detected;
+    public $invalid_input_fields;
     public $post = array('hm_page_key' => 'asdf', 'fld1' => '0', 'fld2' => '1', 'fld3' => 0, 'fld4' => NULL);
     public $get = array();
     public $cookie = array();

--- a/tests/phpunit/module.php
+++ b/tests/phpunit/module.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_Modules_Output extends TestCase {
 
+    public $parent;
+    public $handler_mod;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->parent = build_parent_mock();
@@ -100,6 +102,8 @@ class Hm_Test_Modules_Output extends TestCase {
  */
 class Hm_Test_Handler_Module extends TestCase {
 
+    public $parent;
+    public $handler_mod;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->parent = build_parent_mock();
@@ -191,6 +195,8 @@ class Hm_Test_Handler_Module extends TestCase {
  */
 class Hm_Test_Handler_Module_Debug extends TestCase {
 
+    public $parent;
+    public $handler_mod;
     public function setUp(): void {
         define('DEBUG_MODE', true);
         require 'bootstrap.php';
@@ -212,6 +218,7 @@ class Hm_Test_Handler_Module_Debug extends TestCase {
  */
 class Hm_Test_Output_Module extends TestCase {
 
+    public $output_mod;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->output_mod = new Hm_Output_Test(array('foo' => 'bar', 'bar' => 'foo'), array('bar'));

--- a/tests/phpunit/modules.php
+++ b/tests/phpunit/modules.php
@@ -135,6 +135,7 @@ class Hm_Test_Modules extends TestCase {
  */
 class Hm_Test_Module_Exec extends TestCase {
 
+    public $module_exec;
     public function setUp(): void {
         require 'bootstrap.php';
         $config = new Hm_Mock_Config();
@@ -294,6 +295,7 @@ class Hm_Test_Module_Exec extends TestCase {
 
 class Hm_Test_Module_Exec_Debug extends TestCase {
 
+    public $module_exec;
     public function setUp(): void {
         define('DEBUG_MODE', true);
         require 'bootstrap.php';

--- a/tests/phpunit/oauth2.php
+++ b/tests/phpunit/oauth2.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class Hm_Test_Oauth2 extends TestCase {
 
+    public $oauth2;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->oauth2 = new Hm_Oauth2('client_id', 'secret', 'uri');

--- a/tests/phpunit/output.php
+++ b/tests/phpunit/output.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_Output extends TestCase {
 
+    public $http;
     public function setUp(): void {
         require 'bootstrap.php';
         $this->http = new Hm_Output_HTTP();

--- a/tests/phpunit/request.php
+++ b/tests/phpunit/request.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
  * tests for the Hm_Request class
  */
 class Hm_Test_Request extends TestCase {
-
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         define('CONFIG_FILE', APP_PATH.'hm3.rc');

--- a/tests/phpunit/session.php
+++ b/tests/phpunit/session.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_PHP_Session extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         ini_set('session.use_cookies', '0');
@@ -273,6 +274,7 @@ class Hm_Test_PHP_Session extends TestCase {
  */
 class Hm_Test_Redis_Session extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         ini_set('session.use_cookies', '0');
@@ -298,6 +300,7 @@ class Hm_Test_Redis_Session extends TestCase {
  */
 class Hm_Test_Memcached_Session extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         ini_set('session.use_cookies', '0');
@@ -400,6 +403,7 @@ class Hm_Test_Memcached_Session extends TestCase {
  */
 class Hm_Test_DB_Session extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php';
         ini_set('session.use_cookies', '0');
@@ -557,6 +561,7 @@ class Hm_Test_DB_Session extends TestCase {
 
 class Hm_Test_Session_Functions extends TestCase {
 
+    public $config;
     public function setUp(): void {
         require 'bootstrap.php'; 
         $this->config = new Hm_Mock_Config();

--- a/tests/phpunit/stubs.php
+++ b/tests/phpunit/stubs.php
@@ -52,6 +52,7 @@ class Hm_Test_Module_List_Functions {
 }
 
 class Hm_Test_Server {
+    public $state;
     public function disconnect() {
         return true;
     }


### PR DESCRIPTION
**Description:**
This Pull Request addresses the deprecation warnings in PHP 8.2 and 8.3 related to dynamic property creation. The changes ensure compatibility with the latest PHP versions.

**Testing:**
- Tested first on PHP 7.4 environment.
- Tested on PHP 8.2 and 8.3 environments.

**Related Issues:**
Issue #829
