### PR TITLE
Fix start_page setting not being saved

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -655,7 +655,7 @@ class Hm_Output_default_sort_order_setting extends Hm_Output_Module {
         }
         $res = '<tr class="general_setting"><td><label for="default_sort_order">'.
             $this->trans('Default message sort order').'</label></td>'.
-            '<td><select id="start_page" name="default_sort_order">';
+            '<td><select id="default_sort_order" name="default_sort_order">';
         foreach ($options as $val => $label) {
             $res .= '<option ';
             if ($default_sort_order == $val) {

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -278,7 +278,7 @@ return array(
         'server_pw_id' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'message_list_since' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'no_password_save' => FILTER_VALIDATE_BOOLEAN,
-        'start_page' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'start_page' => FILTER_SANITIZE_URL,
         'default_sort_order' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'stay_logged_in' => FILTER_VALIDATE_BOOLEAN,
         'junk_per_source' => FILTER_VALIDATE_INT,


### PR DESCRIPTION
### Description:
The **start_page** setting was not being saved because special characters in certain URLs were being escaped by FILTER_SANITIZE_FULL_SPECIAL_CHARS. As a result, during the verification with the allowed_urls for that setting, they were no longer able to match.

Related Issue: [https://github.com/cypht-org/cypht/issues/783](https://github.com/cypht-org/cypht/issues/783)

