### PR TITLE
Switching the PDO extension suggestion to lowercase within composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "^9.3.0"
     },
     "suggest": {
-        "ext-PDO": "To use database features, this needs to be installed",
+        "ext-pdo": "To use database features, this needs to be installed",
         "ext-redis": "To use Redis for caching, this needs to be installed",
         "ext-gd": "To use 2fa, this needs to be installed for the QR code display",
         "ext-memcached": "To use Memcached for caching, this needs to be installed",


### PR DESCRIPTION
## Pullrequest
As mentioned in the issue below, even if PDO extension is installed, Composer kept stating it being missing. But, when changing the requirement to lowercase, everything seems to be working as expected

### Related Issue: [https://github.com/cypht-org/cypht/issues/836](https://github.com/cypht-org/cypht/issues/836)