### PR TITLE
Fix Warn about potential missing attachment when sending an email

### DIFF
--- a/language/az.php
+++ b/language/az.php
@@ -580,6 +580,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'qoşmalar,fayl,qoşma,qoşulub,qoşulur,qapalı,CV,qoşma məktub'
 ); 
 
 ?>

--- a/language/de.php
+++ b/language/de.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'anbei,im anhang,siehe anhang,angehängt,angefügt,beigefügt,beiliegend'
 );
 
 ?>

--- a/language/en.php
+++ b/language/en.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 ); 
 
 ?>

--- a/language/es.php
+++ b/language/es.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 ); 
 
 ?>

--- a/language/et.php
+++ b/language/et.php
@@ -585,6 +585,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 ); 
 
 ?>

--- a/language/fa.php
+++ b/language/fa.php
@@ -629,6 +629,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'ضمیمه،فایل،ضمیمه کردن،ضمیمه شده،در حال ضمیمه کردن، الصاق شده،CV،عنوان نامه'
 );
 
 ?>

--- a/language/fr.php
+++ b/language/fr.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => 'Capacités du serveur Sieve',
     'Connection To Sieve Server Failed' => 'Échec de la connexion au serveur Sieve',
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'pièce jointe,fichier joint,fichier,joindre,joins,joint,attaché,inclus,ci-inclus,CV,lettre d’accompagnement,PJ,P.J'
 ); 
 
 ?>

--- a/language/hu.php
+++ b/language/hu.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'csatolmány,file,csatolás,csatolt,csatolni,közrezárt,CV,kisérőlevél'
 );
 
 ?>

--- a/language/id.php
+++ b/language/id.php
@@ -584,6 +584,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'lampiran,file,terlampir,dilampirkan,melampirkan,lampiran tertutup,CV,sampul surat'
 ); 
 
 ?>

--- a/language/it.php
+++ b/language/it.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'allegato,allegati,allegata,allegate,allega,allego,alleghi,attaccato,file,attachment,attach'
 ); 
 
 ?>

--- a/language/ja.php
+++ b/language/ja.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => '添付,ファイル,添付ファイル,同封,添え状'
 ); 
 
 ?>

--- a/language/nl.php
+++ b/language/nl.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 );
 
 ?>

--- a/language/pt-BR.php
+++ b/language/pt-BR.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 );
 
 ?>

--- a/language/ro.php
+++ b/language/ro.php
@@ -577,6 +577,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => 'atașament,atasament,atas,atasat,ataș,attach,fisier,fișier,attach,atach,attache'
 ); 
 
 ?>

--- a/language/ru.php
+++ b/language/ru.php
@@ -579,6 +579,8 @@ return array(
     'Sieve server capabilities' => false,
     'Connection To Sieve Server Failed' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 ); 
 
 ?>

--- a/language/zh-Hans.php
+++ b/language/zh-Hans.php
@@ -576,4 +576,6 @@ return array(
     'Move To Blocked Folder' => false,
     'Sieve server capabilities' => false,
     'Warn for unsaved changes' => false,
+    'We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.' => false,
+    'attachment,file,attach,attached,attaching,enclosed,CV,cover letter' => false
 ); 

--- a/lib/module.php
+++ b/lib/module.php
@@ -501,6 +501,29 @@ abstract class Hm_Output_Module {
         return str_replace('\n', '<br />', strip_tags($string));
     }
 
+    /**
+     * Return all translations for earch supported language
+     * @return array translations
+     */
+    public function all_trans() {
+        // Get all files in the language directory
+        $language_files = glob(APP_PATH.'language/'. '*.php');
+        $translations = [];
+
+        foreach ($language_files as $file) {
+            // Extract the language code from the file name
+            $language_code = pathinfo($file, PATHINFO_FILENAME);
+
+            // Read the content of the file
+            $content = include $file;
+
+            // Store the content in the translations array
+            $translations[$language_code] = $content;
+        }
+
+        return $translations;
+    }
+
 
     /**
      * Return a translated string of numbers if possible and if language is farsi

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -595,9 +595,9 @@ class Hm_Output_js_data extends Hm_Output_Module {
             'window.hm_current_lang = ' . json_encode($this->lang) . ';' .
             'window.hm_translations = ' . json_encode($this->all_trans()) . ';' .
             'var hm_trans = function(key, lang = window.hm_current_lang) {' .
-            '    const translation = window.translations[lang][key];' .
-            '    if (translation !== undefined && translation !== false) {' .
-            '        return translation;' .
+            '    const langTranslations = window.translations && window.translations[lang];' .
+            '    if (langTranslations && langTranslations[key] !== undefined && langTranslations[key] !== false) {' .
+            '        return langTranslations[key];' .
             '    }' .
             '    return key;' .
             '};' .

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -592,6 +592,15 @@ class Hm_Output_js_data extends Hm_Output_Module {
     protected function output() {
         $res = '<script type="text/javascript">'.
             'var globals = {};'.
+            'window.hm_current_lang = ' . json_encode($this->lang) . ';' .
+            'window.hm_translations = ' . json_encode($this->all_trans()) . ';' .
+            'var hm_trans = function(key, lang = window.hm_current_lang) {' .
+            '    const translation = window.translations[lang][key];' .
+            '    if (translation !== undefined && translation !== false) {' .
+            '        return translation;' .
+            '    }' .
+            '    return key;' .
+            '};' .
             'var hm_empty_folder = function() { return "'.$this->trans('So alone').'"; };'.
             'var hm_mobile = function() { return '.($this->get('is_mobile') ? '1' : '0').'; };'.
             'var hm_debug = function() { return "'.(DEBUG_MODE ? '1' : '0').'"; };'.

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -646,8 +646,11 @@ if (!hm_exists('get_mime_type')) {
 class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
     public function process() {       
         /* not sending */
-        if (!array_key_exists('compose_smtp_id', $this->request->post)) {
+        if (!array_key_exists('smtp_send', $this->request->post)) {
             $this->out('enable_attachment_reminder', $this->user_config->get('enable_attachment_reminder_setting', false));
+            return;
+        }
+        if (!array_key_exists('compose_smtp_id', $this->request->post)) {
             return;
         }
 

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -646,7 +646,8 @@ if (!hm_exists('get_mime_type')) {
 class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
     public function process() {       
         /* not sending */
-        if (!array_key_exists("compose_smtp_id", $this->request->post)) {
+        if (!array_key_exists('compose_smtp_id', $this->request->post)) {
+            $this->out('enable_attachment_reminder', $this->user_config->get('enable_attachment_reminder_setting', false));
             return;
         }
 
@@ -820,6 +821,13 @@ class Hm_Handler_smtp_auto_bcc_check extends Hm_Handler_Module {
     }
 }
 
+class Hm_Handler_process_enable_attachment_reminder_setting extends Hm_Handler_Module {
+    public function process() {
+        function enable_attachment_reminder_callback($val) { return $val; }
+        process_site_setting('enable_attachment_reminder', $this, 'enable_attachment_reminder_callback', false, true);
+    }
+}
+
 /**
  * @subpackage smtp/handler
  */
@@ -885,6 +893,27 @@ class Hm_Output_attachment_setting extends Hm_Output_Module {
 /**
  * @subpackage smtp/output
  */
+class Hm_Output_enable_attachment_reminder_setting extends Hm_Output_Module {
+    protected function output() {
+        $settings = $this->get('user_settings');
+        if (array_key_exists('enable_attachment_reminder', $settings) && $settings['enable_attachment_reminder']) {
+            $checked = ' checked="checked"';
+            $reset = '<span class="tooltip_restore" restore_aria_label="Restore default value"><img alt="Refresh" class="refresh_list reset_default_value_checkbox"  src="'.Hm_Image_Sources::$refresh.'" /></span>';
+        }
+        else {
+            $checked = '';
+            $reset='';
+        }
+        return '<tr class="general_setting"><td><label for="enable_attachment_reminder">'.
+            $this->trans('Enable Attachment Reminder').'</label></td>'.
+            '<td><input type="checkbox" '.$checked.
+            ' value="1" id="enable_attachment_reminder" name="enable_attachment_reminder" />'.$reset.'</td></tr>';
+    }
+}
+
+/**
+ * @subpackage smtp/output
+ */
 class Hm_Output_sent_folder_link extends Hm_Output_Module {
     protected function output() {
         $res = '<li class="menu_sent"><a class="unread_link" href="?page=message_list&amp;list_path=sent">';
@@ -901,8 +930,8 @@ class Hm_Output_sent_folder_link extends Hm_Output_Module {
  */
 class Hm_Output_compose_form_start extends Hm_Output_Module {
     protected function output() {
-        return'<div class="compose_page"><div class="content_title">'.$this->trans('Compose').'</div>'.
-            '<form class="compose_form" method="post" action="?page=compose">';
+        return '<div class="compose_page"><div class="content_title">'.$this->trans('Compose').'</div>' .
+    '<form class="compose_form" method="post" action="?page=compose" data-reminder="' . $this->get('enable_attachment_reminder', 0) . '">';
     }
 }
 

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -39,6 +39,8 @@ add_output('settings', 'auto_bcc_setting', true, 'smtp', 'compose_type_setting',
 add_handler('settings', 'attachment_dir', true, 'smtp', 'save_user_settings', 'after');
 add_output('settings', 'attachment_setting', true, 'smtp', 'compose_type_setting', 'after');
 
+add_output('settings', 'enable_attachment_reminder_setting', true, 'smtp', 'attachment_setting', 'after');
+add_handler('settings', 'process_enable_attachment_reminder_setting', true, 'smtp', 'save_user_settings', 'before');
 
 /* ajax server setup callback data */
 add_handler('ajax_smtp_debug', 'login', false, 'core');
@@ -104,6 +106,7 @@ return array(
         'ajax_smtp_save_draft',
         'ajax_smtp_delete_draft',
         'ajax_profiles_status',
+        'ajax_attachment_reminder_check',
         'ajax_get_test_chunk',
         'ajax_upload_chunk'
     ),
@@ -135,6 +138,7 @@ return array(
         'profile_value' => array(FILTER_SANITIZE_FULL_SPECIAL_CHARS, false),
         'msg_sent_and_archived' => array(FILTER_VALIDATE_BOOLEAN, false),
         'sent_msg_id' => array(FILTER_VALIDATE_BOOLEAN, false),
+        'enable_attachment_reminder' => array(FILTER_VALIDATE_BOOLEAN, false),
     ),
     'allowed_post' => array(
         'post_archive' => FILTER_VALIDATE_INT,
@@ -176,7 +180,8 @@ return array(
         'profile_value' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'uploaded_files' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
         'send_uploaded_files' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-        'next_email_post' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
+        'next_email_post' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'enable_attachment_reminder' => FILTER_VALIDATE_INT
     )
 );
 

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -388,14 +388,52 @@ var is_valid_recipient = function(recipient) {
     return recipient.match(valid_regex);
 };
 
-$(function() {    
+var process_compose_form = function(){
+    var msg_uid = hm_msg_uid();
+    var detail = Hm_Utils.parse_folder_path(hm_list_path(), 'imap');
+    var class_name = 'imap_' + detail.server_id + '_' + msg_uid + '_' + detail.folder;
+    var key = 'imap_' + Hm_Utils.get_url_page_number() + '_' + hm_list_path();
+    var next_message = Hm_Message_List.prev_next_links(key, class_name)[1];
+
+    if (next_message) {
+        $('.compose_next_email_data').val(next_message);
+    }
+
+    var uploaded_files = $("input[name='uploaded_files[]']").map(function () { return $(this).val(); }).get();
+    $('#send_uploaded_files').val(uploaded_files);
+    Hm_Ajax.show_loading_icon();
+    $('.smtp_send').addClass('disabled_input');
+    $('.smtp_send_archive').addClass('disabled_input');
+    $('.smtp_send').on("click", function () { return false; });
+}
+var force_send_message = function(){
+    // Check if the force_send input already exists
+    var forceSendInput = document.getElementById('force_send');
+    if (!forceSendInput) {
+        // Create a hidden input element
+        var hiddenInput = document.createElement('input');
+        hiddenInput.type = 'hidden';
+        hiddenInput.name = 'force_send';
+        hiddenInput.value = '1';
+        hiddenInput.id = 'force_send';
+        hiddenInput.classList.add('force_send');
+        // Append the hidden input to the form
+        var form = document.querySelector('.compose_form');
+        form.appendChild(hiddenInput);
+
+    }
+    // Trigger the click event for the "Send" button
+    document.querySelector('.smtp_send').click()
+}
+
+$(function () {
     if (hm_page_name() === 'settings') {
         $('#clear_chunks_button').on('click', function(e) {
             e.preventDefault();
             Hm_Ajax.request(
                 [{'name': 'hm_ajax_hook', 'value': 'ajax_clear_attachment_chunks'}],
                 function(res) {
-                    
+
                 },
                 []
             );
@@ -468,7 +506,7 @@ $(function() {
             }
 
             function handleSendAnyway() {
-                e.target.submit();
+                // e.target.submit();
                 handleFiles();
             };
 
@@ -491,6 +529,36 @@ $(function() {
                 Hm_Ajax.show_loading_icon(); $('.smtp_send').addClass('disabled_input');
                 $('.smtp_send_archive').addClass('disabled_input');
                 $('.smtp_send').on("click", function () { return false; });
+            const compose_body_value = document.getElementById('compose_body').value;
+            const force_send = document.getElementById('force_send')?.value;
+            var reminder_value = $('.compose_form').data('reminder');
+            if (reminder_value === 1) {
+                const uploaded_files = $("input[name='uploaded_files[]']").map(function () { return $(this).val(); }).get();
+                let all_translated_keywords = [];
+                for (let lang in window.hm_translations) {
+                    if (window.hm_translations.hasOwnProperty(lang)) {
+                        // Get translated keywords for the current language
+                        const translated_keywords = hm_trans('attachment,file,attach,attached,attaching,enclosed,CV,cover letter', lang).split(',');
+                        // Concatenate translated keywords with the array
+                        all_translated_keywords = all_translated_keywords.concat(translated_keywords);
+                    }
+                }
+                const additional_keywords = ['.doc', '.pdf'];
+                // Split the translated keywords into an array && Add additional keywords or file extensions
+                const combined_keywords = all_translated_keywords.concat(additional_keywords);
+                // Build the regex pattern
+                const pattern = new RegExp('(' + combined_keywords.map(keyword => keyword.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|') + ')', 'i');
+                // Check if the pattern is found in the message
+                if (pattern.test(compose_body_value) && uploaded_files.length === 0 && force_send !== '1') {
+                    if (confirm(trans('We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.'))) {
+                        force_send_message();
+                    }
+                    e.preventDefault();
+                } else {
+                    process_compose_form();
+                }
+            } else {
+                process_compose_form();
             }
         });
         if ($('.compose_cc').val() || $('.compose_bcc').val()) {

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -516,49 +516,37 @@ $(function () {
             };
 
             function handleFiles() {
-                var msg_uid = hm_msg_uid();
-                var detail = Hm_Utils.parse_folder_path(hm_list_path(), 'imap');
-                var class_name = 'imap_' + detail.server_id + '_' + msg_uid + '_' + detail.folder;
-                var key = 'imap_' + Hm_Utils.get_url_page_number() + '_' + hm_list_path();
-                var next_message = Hm_Message_List.prev_next_links(key, class_name)[1];
-                if (next_message) {
-                    $('.compose_next_email_data').val(next_message);
-                }
                 var uploaded_files = $("input[name='uploaded_files[]']").map(function () { return $(this).val(); }).get();
-                $('#send_uploaded_files').val(uploaded_files);
-                Hm_Ajax.show_loading_icon(); $('.smtp_send').addClass('disabled_input');
-                $('.smtp_send_archive').addClass('disabled_input');
-                $('.smtp_send').on("click", function () { return false; });
-            const compose_body_value = document.getElementById('compose_body').value;
-            const force_send = document.getElementById('force_send')?.value;
-            var reminder_value = $('.compose_form').data('reminder');
-            if (reminder_value === 1) {
-                const uploaded_files = $("input[name='uploaded_files[]']").map(function () { return $(this).val(); }).get();
-                let all_translated_keywords = [];
-                for (let lang in window.hm_translations) {
-                    if (window.hm_translations.hasOwnProperty(lang)) {
-                        // Get translated keywords for the current language
-                        const translated_keywords = hm_trans('attachment,file,attach,attached,attaching,enclosed,CV,cover letter', lang).split(',');
-                        // Concatenate translated keywords with the array
-                        all_translated_keywords = all_translated_keywords.concat(translated_keywords);
+                const compose_body_value = document.getElementById('compose_body').value;
+                const force_send = document.getElementById('force_send')?.value;
+                var reminder_value = $('.compose_form').data('reminder');
+                if (reminder_value === 1) {
+                    let all_translated_keywords = [];
+                    for (let lang in window.hm_translations) {
+                        if (window.hm_translations.hasOwnProperty(lang)) {
+                            // Get translated keywords for the current language
+                            const translated_keywords = hm_trans('attachment,file,attach,attached,attaching,enclosed,CV,cover letter', lang).split(',');
+                            // Concatenate translated keywords with the array
+                            all_translated_keywords = all_translated_keywords.concat(translated_keywords);
+                        }
                     }
-                }
-                const additional_keywords = ['.doc', '.pdf'];
-                // Split the translated keywords into an array && Add additional keywords or file extensions
-                const combined_keywords = all_translated_keywords.concat(additional_keywords);
-                // Build the regex pattern
-                const pattern = new RegExp('(' + combined_keywords.map(keyword => keyword.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|') + ')', 'i');
-                // Check if the pattern is found in the message
-                if (pattern.test(compose_body_value) && uploaded_files.length === 0 && force_send !== '1') {
-                    if (confirm(trans('We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.'))) {
-                        force_send_message();
+                    const additional_keywords = ['.doc', '.pdf'];
+                    // Split the translated keywords into an array && Add additional keywords or file extensions
+                    const combined_keywords = all_translated_keywords.concat(additional_keywords);
+                    // Build the regex pattern
+                    const pattern = new RegExp('(' + combined_keywords.map(keyword => keyword.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|') + ')', 'i');
+                    // Check if the pattern is found in the message
+                    if (pattern.test(compose_body_value) && uploaded_files.length === 0 && force_send !== '1') {
+                        if (confirm(hm_trans('We couldn\'t find the attachment you referred to. Please confirm if you attached it or provide the details again.'))) {
+                            force_send_message();
+                        }
+                        e.preventDefault();
+                    } else {
+                        process_compose_form();
                     }
-                    e.preventDefault();
                 } else {
                     process_compose_form();
                 }
-            } else {
-                process_compose_form();
             }
         });
         if ($('.compose_cc').val() || $('.compose_bcc').val()) {


### PR DESCRIPTION
## Warn about potential missing attachment when sending an email #684

### Description
Introduce a feature to warn users about potential missing attachments when composing and sending an email. This includes a configuration setting to toggle the feature, JavaScript implementation for keyword checking, modal notification, and an option to force send.

### Implementation Steps
1. **Configuration Setting**
   - [ ] Introduce `enable_attachment_reminder` configuration value.

2. **JavaScript Implementation**
   - [ ] Implement keyword checking in the email body.
   - [ ] Store keywords in the `translated_keywords` variable.

3. **Modal Notification**
   - [ ] Display a modal notification when keywords suggest a missing attachment.
   - [ ] Include information about the potential missing attachment.

4. **Force Send Option**
   - [ ] Provide a "Send Anyway" button within the modal.

5. **Testing**
   - [ ] Test the feature in various scenarios.
   - [ ] Ensure the modal appears only when necessary.

### Additional Information
- **Issue:** #684
