### PR TITLE
Fixed attachments not forwarded with emails

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -134,13 +134,17 @@ class Hm_Handler_load_smtp_is_imap_forward extends Hm_Handler_Module
                 $attached_files = [];
                 $this->session->set('uploaded_files', array());
                 if (array_key_exists(0, $msg_struct) && array_key_exists('subs', $msg_struct[0])) {
+                    $file_dir = $this->config->get('attachment_dir') . DIRECTORY_SEPARATOR . md5($this->session->get('username', false)) . DIRECTORY_SEPARATOR;
+                    if (!is_dir($file_dir)) {
+                        mkdir($file_dir);
+                    }
                     foreach ($msg_struct[0]['subs'] as $ind => $sub) {
                         if ($ind != '0.1') {
                             $new_attachment['basename'] = $sub['description'];
-                            $new_attachment['name'] = $sub['description'];
+                            $new_attachment['name'] = $sub['attributes']['name'];
                             $new_attachment['size'] = $sub['size'];
                             $new_attachment['type'] = $sub['type'];
-                            $file_path = $this->config->get('attachment_dir') . DIRECTORY_SEPARATOR . $new_attachment['name'];
+                            $file_path = $file_dir . $new_attachment['name'];
                             $content = Hm_Crypt::ciphertext($imap->get_message_content($this->request->get['uid'], $ind), Hm_Request_Key::generate());
                             file_put_contents($file_path, $content);
                             $new_attachment['tmp_name'] = $file_path;


### PR DESCRIPTION
Fixes https://github.com/cypht-org/cypht/issues/764

Errors came from missing username in attachment file pathes. When Hm_Handler_process_compose_form_submit tried to find them I couldn't because their pathes were supposed to include username.