### PR TITLE
Reset sieve script textarea when adding script

### DIFF
--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -561,7 +561,7 @@ $(function () {
         });
         $('.add_script').on('click', function () {
             $('.script_modal_title').html('Add Script');
-            $('.modal_sieve_script_textarea').html('');
+            $('.modal_sieve_script_textarea').val('');
             $('.modal_sieve_script_name').val('');
             $('.modal_sieve_script_priority').val('');
             is_editing_script = false;


### PR DESCRIPTION
### To reproduce issue
- Go to /?page=sieve_filters
- Click Add script of a mailbox
- Type something in Sieve Script textarea field
- Close the modal
- Click again on Add script button of any mailbox and you see typed text.

This merge request fixes this behavior
