### PR TITLE
Fix: HTML to text process is broken

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -435,7 +435,7 @@ class HTMLToText {
 
     function __construct($html) {
         $doc = new DOMDocument();
-        $doc->loadHTML(htmlentities($html, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        $doc->loadHTML(html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
         if (trim($html) && $doc->hasChildNodes()) {
             $this->parse_nodes($doc->childNodes);
         }


### PR DESCRIPTION
Fixing Issue: https://github.com/cypht-org/cypht/issues/850

This commit addresses an issue caused by the previous commit (Commit: https://github.com/cypht-org/cypht/commit/811966cba0dc7ec935310c06fa32498fc134de38#diff-fb847a047f39596c5eb56b8d842486eec3cc7cc15a7aa2417dd6cf8625da75e4) that resolved a deprecation error. The error was fixed, but the incorrect function, `htmlentities`, was used instead of the correct function, `html_entity_decode`. This commit corrects that and ensures the proper function is used to address the deprecation error.

Related Issue:
- https://github.com/cypht-org/cypht/issues/850
- Fixes:  https://github.com/cypht-org/cypht/issues/837
