### PR TITLE
Remove forgotten Hm_Environment class usage from framework.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -678,7 +678,7 @@ return [
     | Handles page layout, login/logout, and the default settings pages. This set
     | is required.
     */
-    'modules' => explode(',', env('CYPHT_MODULES')),
+    'modules' => explode(',', env('CYPHT_MODULES','core,contacts,local_contacts,ldap_contacts,gmail_contacts,feeds,jmap,imap,smtp,account,idle_timer,desktop_notifications,calendar,themes,nux,developer')),
     // 'modules' => [
     //     /*
     //     |  ----

--- a/index.php
+++ b/index.php
@@ -34,14 +34,10 @@ ob_start();
 date_default_timezone_set( 'UTC' );
 
 require VENDOR_PATH.'autoload.php';
-
-/* load env files */
-require APP_PATH.'lib/environment.php';
-$environment = Hm_Environment::getInstance();
-$environment->load();
-
 /* get includes */
 require APP_PATH.'lib/framework.php';
+$environment = Hm_Environment::getInstance();
+$environment->load();
 
 /* get configuration */
 $config = new Hm_Site_Config_File();

--- a/lib/framework.php
+++ b/lib/framework.php
@@ -28,6 +28,7 @@ require APP_PATH.'lib/output.php';
 require APP_PATH.'lib/crypt.php';
 require APP_PATH.'lib/crypt_sodium.php';
 require APP_PATH.'lib/sodium_compat.php';
+require APP_PATH.'lib/environment.php';
 require APP_PATH.'lib/db.php';
 require APP_PATH.'lib/servers.php';
 require APP_PATH.'lib/api.php';
@@ -37,10 +38,6 @@ require APP_PATH.'lib/webdav_formats.php';
 if (!function_exists('random_bytes')) {
     require VENDOR_PATH.'paragonie/random_compat/lib/random.php';
 }
-
-/* load env files */
-$environment = Hm_Environment::getInstance();
-$environment->load();
 
 /* check for and load the correct libsodium interface */
 if (!defined('LIBSODIUM')) {


### PR DESCRIPTION
In the last PR: https://github.com/cypht-org/cypht/pull/853/ I removed Hm_Environment usage from framework.php to index.php, in this PR I'm deleting the usage that has been forgotten:
```
$environment = Hm_Environment::getInstance();
$environment->load();
```