### PR TITLE
Fix ldap_contacts error running under php8.2 & remove unused and correct ldap .env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,6 @@ DB_SOCKET=/var/lib/mysqld/mysqld.sock
 
 SESSION_TYPE=PHP
 AUTH_TYPE=DB
-LDAP_AUTH_SERVER=localhost
-LDAP_AUTH_PORT=389
-LDAP_AUTH_TLS=
-LDAP_AUTH_BASE_DN=example,dc=com
 
 IMAP_AUTH_NAME=localhost
 IMAP_AUTH_SERVER=localhost
@@ -169,16 +165,23 @@ OUTLOOK_AUTH_URI=https://login.live.com/oauth20_authorize.srf
 OUTLOOK_TOKEN_URI=https://login.live.com/oauth20_token.srf
 OUTLOOK_REFRESH_URI=https://login.live.com/oauth20_token.srf
 
-#ldap
+#ldap.php
 LDAP_SERVER=localhost
 LDAP_ENABLE_TLS=true
 LDAP_PORT=389
 LDAP_BASE_DN="dc=example,dc=com"
 LDAP_SEARCH_TERM="objectclass=inetOrgPerson"
-LDAP_SEARCH_TERM=false
+LDAP_AUTH=false
 LDAP_USER=''
 LDAP_PASS=''
+LDAP_OBJECT_CLASS="top,person,organizationalperson,inetorgperson"
 LDAP_READ_WRITE=true
+
+#app.php
+LDAP_AUTH_PORT=389
+LDAP_AUTH_SERVER=localhost
+LDAP_AUTH_TLS=
+LDAP_AUTH_BASE_DN="example,dc=com"
 
 #WordPress
 WORDPRESS_CLIENT_ID=

--- a/config/carddav.php
+++ b/config/carddav.php
@@ -2,7 +2,7 @@
 
 return [
     /* 
-    | [Personal]
+    | 
     | ----------------------------------------
     | Constants used for CardDav communication
     | ----------------------------------------
@@ -18,5 +18,7 @@ return [
     | 
     | 
     */
-    'server' => env('CARD_DAV_SERVER', 'http://localhost:5232'),
+    'Personal' => [
+        'server' => env('CARD_DAV_SERVER', 'http://localhost:5232'),
+    ]
 ];

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -14,60 +14,57 @@ return [
     | 
     | Create one section for each LDAP backend you want to support. The section name
     | will be used in the UI for the name of this addressbook
-    | [Personal]
+    |
     */
     'ldap' => [
-        /*
-        | LDAP Server hostname or IP address
-        */
-        'server' => env('LDAP_SERVER', 'localhost'),
-        
-        /*
-        | Flag to enable or disable TLS connections
-        */
-        'enable_tls' => env('LDAP_ENABLE_TLS', true),
-
-        /*
-        | Port to connect to
-        */
-        'port' => env('LDAP_PORT', 389),
-
-        /*
-        | Base DN
-        */
-        'base_dn' => env('LDAP_BASE_DN', 'dc=example,dc=com'),
-
-        /*
-        | Base DN
-        */
-        'search_term' => env('LDAP_SEARCH_TERM', 'objectclass=inetOrgPerson'),
-
-        /*
-        | Flag to enable user binding. Anonymous binding is used when set to false
-        */
-        'auth' => env('LDAP_SEARCH_TERM', false),
-
-        /*
-        | Global username and password to bind with if auth is set to true. If left
-        | blank, users will have a setting on the Settings -> Site page for this
-        | connection to enter their own
-        */
-        'user' => env('LDAP_USER', ''),
-        'pass' => env('LDAP_PASS', ''),
-
-        /*
-        | Object classes for the addressbook entries
-        */
-        'objectclass' => [
-            'top',
-            'person',
-            'organizationalperson',
-            'inetorgperson'
+        'Personal' => [
+            /*
+            | LDAP Server hostname or IP address
+            */
+            'server' => env('LDAP_SERVER', 'localhost'),
+            
+            /*
+            | Flag to enable or disable TLS connections
+            */
+            'enable_tls' => env('LDAP_ENABLE_TLS', true),
+    
+            /*
+            | Port to connect to
+            */
+            'port' => env('LDAP_PORT', 389),
+    
+            /*
+            | Base DN
+            */
+            'base_dn' => env('LDAP_BASE_DN', 'dc=example,dc=com'),
+    
+            /*
+            | Base DN
+            */
+            'search_term' => env('LDAP_SEARCH_TERM', 'objectclass=inetOrgPerson'),
+    
+            /*
+            | Flag to enable user binding. Anonymous binding is used when set to false
+            */
+            'auth' => env('LDAP_AUTH', false),
+    
+            /*
+            | Global username and password to bind with if auth is set to true. If left
+            | blank, users will have a setting on the Settings -> Site page for this
+            | connection to enter their own
+            */
+            'user' => env('LDAP_USER', ''),
+            'pass' => env('LDAP_PASS', ''),
+    
+            /*
+            | Object classes for the addressbook entries
+            */
+            'objectclass' => explode(',', env('LDAP_OBJECT_CLASS','top,person,organizationalperson,inetorgperson')),
+    
+            /*
+            | Flag to allow editing of the addressbook contents
+            */
+            'read_write' => env('LDAP_READ_WRITE', true),
         ],
-
-        /*
-        | Flag to allow editing of the addressbook contents
-        */
-        'read_write' => env('LDAP_READ_WRITE', true),
     ],
 ];


### PR DESCRIPTION
## Issue: Resolve Array Key Exists Error in Cypht with PHP 8.2

### Problem Description:
Under the PHP 8.2 environment in Cypht, an error is encountered in the ldap_contacts module, specifically on line 320. The error is related to `array_key_exists()` where a string is given instead of an array. Notably, this error is not displayed under PHP 7.4. The issue occurs on pages such as settings and compose, leading to an error page.

### Steps to Reproduce:
1. Set up Cypht with PHP 8.2.
2. Navigate to the settings or compose page.
3. Observe the error related to `array_key_exists()` on line 320 in the ldap_contacts module.

### Proposed Changes:

#### Code Modification:
- Investigate and resolve the issue causing the `array_key_exists()` error in the ldap_contacts module under PHP 8.2.
- Ensure compatibility with PHP 8.2, and 8.3 without compromising functionality in PHP 7.4.

#### Cleanup:
- Remove unused environment variables from the `.env.example` file.
- Rename the LDAP_AUTH variable in `.env.example` according to `config/ldap.php` file.

### Additional Information:
- The error seems specific to the interaction between Cypht and PHP 8.2.
- No such error is observed when using PHP 7.4.
- Clean up the environment variable configuration for better maintenance.

### Environment:
- PHP 8.2
- Cypht
- Ubuntu server on Digital Ocean

### Steps to Test:
1. Apply the code modifications.
2. Confirm the error is resolved under PHP 8.2.
3. Verify that functionality remains intact under PHP 7.4.
4. Test the cleanup changes related to environment variables.

### Related Issues:
N/A


