### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -58,9 +58,6 @@ class Hm_API_Curl {
         Hm_Functions::c_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         Hm_Functions::c_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         Hm_Functions::c_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        if ($this->format == 'binary') {
-            Hm_Functions::c_setopt($ch, CURLOPT_BINARYTRANSFER, 1);
-        }
     }
 
     /**


### PR DESCRIPTION
## Pullrequest
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)

### Issues

- [X] None

### Checklist

- [X] None

### How2Test

- [X] None

### Todo

- [X] None
