### PR TITLE
Issue with module name during development on Windows

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -504,9 +504,9 @@ class Hm_Output_header_css extends Hm_Output_Module {
         if (DEBUG_MODE) {
             $res .= '<link href="vendor/twbs/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css" />';
             $res .= '<link href="vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />';
-            foreach (glob(APP_PATH.'modules/**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
+            foreach (glob(APP_PATH.'modules'.DIRECTORY_SEPARATOR.'**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
                 $rel_name = str_replace(APP_PATH, '', $name);
-                $mod = str_replace(array('modules/', '/', '\\'), '', $rel_name);
+                $mod = str_replace(array('modules', DIRECTORY_SEPARATOR), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.css", $name))) {
                     $res .= '<link href="'.sprintf("%ssite.css", $rel_name).'" media="all" rel="stylesheet" type="text/css" />';
                 }
@@ -550,13 +550,13 @@ class Hm_Output_page_js extends Hm_Output_Module {
             }
             $core = false;
             $mods = $this->get('router_module_list');
-            foreach (glob(APP_PATH.'modules/**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
+            foreach (glob(APP_PATH.'modules'.DIRECTORY_SEPARATOR.'**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
                 $rel_name = str_replace(APP_PATH, '', $name);
-                if ($rel_name == 'modules/core/') {
+                if ($rel_name == 'modules'.DIRECTORY_SEPARATOR.'core'.DIRECTORY_SEPARATOR) {
                     $core = $rel_name;
                     continue;
                 }
-                $mod = str_replace(array('modules/', '/','\\'), '', $rel_name);
+                $mod = str_replace(array('modules', DIRECTORY_SEPARATOR), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.js", $name))) {
                     $res .= '<script type="text/javascript" src="'.sprintf("%ssite.js", $rel_name).'"></script>';
                 }

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -506,7 +506,7 @@ class Hm_Output_header_css extends Hm_Output_Module {
             $res .= '<link href="vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />';
             foreach (glob(APP_PATH.'modules/**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
                 $rel_name = str_replace(APP_PATH, '', $name);
-                $mod = str_replace(array('modules/', '/'), '', $rel_name);
+                $mod = str_replace(array('modules/', '/', '\\'), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.css", $name))) {
                     $res .= '<link href="'.sprintf("%ssite.css", $rel_name).'" media="all" rel="stylesheet" type="text/css" />';
                 }
@@ -556,7 +556,7 @@ class Hm_Output_page_js extends Hm_Output_Module {
                     $core = $rel_name;
                     continue;
                 }
-                $mod = str_replace(array('modules/', '/'), '', $rel_name);
+                $mod = str_replace(array('modules/', '/','\\'), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.js", $name))) {
                     $res .= '<script type="text/javascript" src="'.sprintf("%ssite.js", $rel_name).'"></script>';
                 }


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] During development (APP_DEBUG enabled) cypht dont load correctly css and js files unless i go to /site  
![image](https://github.com/cypht-org/cypht/assets/35831811/28fe3a63-113a-41bd-93e0-5d37205613f6)
![image](https://github.com/cypht-org/cypht/assets/35831811/b2bad873-bd2f-40c3-a82d-72d69ee42bd8)

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] I tested this on a windows computer, so i believe it's a platform dependent issue. To test, pull the branch an ensure the site load correctly without going to /site
![image](https://github.com/cypht-org/cypht/assets/35831811/77fc4e2d-059b-485f-897e-38a46574f777)


### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
