### PR TITLE
[FIX] disable drag and drop of messages on mobile devices

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -1865,7 +1865,7 @@ function listControlsMenu() {
 
 // Sortablejs
 const tableBody = document.querySelector('.message_table_body');
-if(tableBody) {
+if(tableBody && !hm_mobile()) {
     const allFoldersClassNames = [];
     let targetFolder;
     let movingElement;


### PR DESCRIPTION
## Description

Disable the drag-and-drop action of messages on mobile devices.

### Issue

The drag-and-drop action of messages on mobile devices doesn't achieve the intended effect (moving messages between folders specifically on non-mobile devices); instead, it prevents the click event from being triggered when the message is clicked, resulting in the inability to fully read the email. This issue is demonstrated in the following video.

https://github.com/cypht-org/cypht/assets/68013195/0669bcac-4b32-422e-bc83-a3ac078c3d18

