### PR TITLE
Restored correct default modules

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -678,7 +678,7 @@ return [
     | Handles page layout, login/logout, and the default settings pages. This set
     | is required.
     */
-    'modules' => explode(',', env('CYPHT_MODULES','core,contacts,local_contacts,ldap_contacts,gmail_contacts,feeds,jmap,imap,smtp,account,idle_timer,desktop_notifications,calendar,themes,nux,developer')),
+    'modules' => explode(',', env('CYPHT_MODULES','core,contacts,local_contacts,feeds,imap,smtp,account,idle_timer,calendar,themes,nux,developer,history,saved_searches,advanced_search,highlights,profiles,inline_message,imap_folders,keyboard_shortcuts')),
     // 'modules' => [
     //     /*
     //     |  ----


### PR DESCRIPTION
Default modules were changed while switching to .env. This link https://github.com/cypht-org/cypht/blob/a843480138682f36b0dc99142d70d147b838ceb6/hm3.sample.ini list default loaded modules.