### PR TITLE
Format html message (adding target blank to external links)

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -18,6 +18,9 @@ function format_msg_html($str, $images=false) {
     $str = str_ireplace('</body>', '', $str);
     $config = HTMLPurifier_Config::createDefault();
     $config->set('Cache.DefinitionImpl', null);
+    $config->set('HTML.TargetBlank', true);
+    $config->set('HTML.TargetNoopener', true);
+    $config->set('HTML.Allowed', 'a[href|target]');
     if (!$images) {
         $config->set('URI.DisableExternalResources', true);
     }


### PR DESCRIPTION
This PR adds target="_blank" to links when formatting html message;
It is related to this: [https://github.com/cypht-org/cypht/pull/859](https://github.com/cypht-org/cypht/pull/859)