### PR TITLE
Fixed printing js data to browser

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -635,7 +635,7 @@ class Hm_Output_js_data extends Hm_Output_Module {
             '        return langTranslations[key];'.
             '    }'.
             '    return key;'.
-            '};'.
+            '};';
         $res .= '</script>';
         return $res;
     }


### PR DESCRIPTION
A part of Hm_Output_js_data was printed to the browser. This MR this that.

<img width="1440" alt="Screenshot 2024-02-13 at 22 28 26" src="https://github.com/cypht-org/cypht/assets/80334370/450e0ba8-9d44-43b3-9abe-1724ac9f3fb8">
