### PR TITLE
Fixed saving smtp servers

### DIFF
--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -35,8 +35,8 @@ class Hm_SMTP_List {
         }
         self::$server_list[$id]['object'] = new Hm_SMTP($config);
 
-        if (!end(self::$server_list)['object']->connect()) {
-            return end(self::$server_list)['object'];
+        if (!self::$server_list[$id]['object']->connect()) {
+            return self::$server_list[$id]['object'];
         }
         return false;
     }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -440,7 +440,6 @@ class Hm_Handler_smtp_save extends Hm_Handler_Module {
                     Hm_Msgs::add('ERRThis server and username are already configured');
                     return;
                 }
-                $form['smtp_server_id'] = uniqid();
                 $smtp = Hm_SMTP_List::connect($form['smtp_server_id'], false, $form['smtp_user'], $form['smtp_pass'], true);
                 if (smtp_authed($smtp)) {
                     $just_saved_credentials = true;

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -153,7 +153,7 @@ return array(
         'smtp_delete' => FILTER_VALIDATE_INT,
         'smtp_send' => FILTER_VALIDATE_INT,
         'submit_smtp_server' => FILTER_DEFAULT,
-        'smtp_server_id' => FILTER_VALIDATE_INT,
+        'smtp_server_id' => FILTER_DEFAULT,
         'smtp_user' => FILTER_DEFAULT,
         'smtp_pass' => FILTER_UNSAFE_RAW,
         'delete_uploaded_files' => FILTER_VALIDATE_BOOLEAN,


### PR DESCRIPTION
Fixed issue in hm-smtp after migrating to uniqid saving a server wasn't working.