### PR TITLE
Fix servers count on server deletion

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -1832,6 +1832,13 @@ var reset_default_value_input = function() {
     }
 };
 
+var decrease_servers = function(section) {
+    const element = document.querySelector(`.${section}_server_setup .server_count`);
+    const parts = element.innerHTML.split(' ');
+    parts[0] = Number(parts[0]) - 1;
+    element.innerHTML = parts.join(' ');
+};
+
 /* create a default message list object */
 var Hm_Message_List = new Message_List();
 

--- a/modules/feeds/setup.php
+++ b/modules/feeds/setup.php
@@ -119,7 +119,7 @@ return array(
         'feed_msg_text' => array(FILTER_UNSAFE_RAW, false),
     ),
     'allowed_post' => array(
-        'feed_id' => FILTER_VALIDATE_INT,
+        'feed_id' => FILTER_DEFAULT,
         'delete_feed' => FILTER_VALIDATE_INT,
         'feed_connect' => FILTER_VALIDATE_INT,
         'feed_server_ids' => FILTER_DEFAULT,

--- a/modules/feeds/site.js
+++ b/modules/feeds/site.js
@@ -21,10 +21,11 @@ var feed_delete_action = function(event) {
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
-            if (res.deleted_server_id > -1 ) {
+            if (res.deleted_server_id) {
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
-                form.parent().remove();
+                form.parent().parent().remove();
+                decrease_servers('feed');
             }
         },
         {'delete_feed': 1}

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -10,8 +10,11 @@ var imap_delete_action = function(event) {
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
-            if (res.deleted_server_id > -1 ) {
-                form.parent().remove();
+            if (res.deleted_server_id) {
+                const configured_server = form.closest('.configured_server');
+                const section = configured_server.parent().parent()[0].classList.contains('imap_section') ? 'imap': 'jmap';
+                decrease_servers(section);
+                configured_server.remove();
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
             }

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -153,7 +153,7 @@ return array(
         'smtp_delete' => FILTER_VALIDATE_INT,
         'smtp_send' => FILTER_VALIDATE_INT,
         'submit_smtp_server' => FILTER_DEFAULT,
-        'smtp_server_id' => FILTER_VALIDATE_INT,
+        'smtp_server_id' => FILTER_DEFAULT,
         'smtp_user' => FILTER_DEFAULT,
         'smtp_pass' => FILTER_UNSAFE_RAW,
         'delete_uploaded_files' => FILTER_VALIDATE_BOOLEAN,

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -87,10 +87,11 @@ var smtp_delete_action = function(event) {
         form.serializeArray(),
         function(res) {
             Hm_Notices.show(res.router_user_msgs);
-            if (res.deleted_server_id > -1 ) {
-                form.parent().remove();
+            if (res.deleted_server_id) {
+                form.parent().parent().remove();
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
+                decrease_servers('smtp');
             }
         },
         {'smtp_delete': 1}


### PR DESCRIPTION
This MR fixes the total of configured smtp servers when a server is deleted. It also fixes the removal of server details when deleted. The server was still visible due to recent change from int server keys to uniqid