### PR TITLE
Fixed JS translation not working

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -625,7 +625,7 @@ class Hm_Output_js_data extends Hm_Output_Module {
         $res .= 'window.hm_current_lang = "'.$this->lang.'";'.
             'window.hm_translations = '.json_encode($this->all_trans()).';'.
             'var hm_trans = function(key, lang = window.hm_current_lang) {'.
-            '    const langTranslations = window.translations && window.translations[lang];'.
+            '    const langTranslations = window.hm_translations && window.hm_translations[lang];'.
             '    if (langTranslations && langTranslations[key] !== undefined && langTranslations[key] !== false) {'.
             '        return langTranslations[key];'.
             '    }'.


### PR DESCRIPTION
JS function hm_trans was not working due to variable mispelling inside it.