### PR TITLE
Fixed TypeError in ajax_imap_folder_display

### DIFF
--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -241,9 +241,9 @@ add_output('ajax_imap_folder_expand', 'filter_expanded_folder_data', true);
 
 /* select folder */
 setup_base_ajax_page('ajax_imap_folder_display', 'core');
+add_handler('ajax_imap_folder_display', 'load_imap_servers_from_config',  true);
 add_handler('ajax_imap_folder_display', 'message_list_type', true, 'core');
 add_handler('ajax_imap_folder_display', 'imap_message_list_type', true);
-add_handler('ajax_imap_folder_display', 'load_imap_servers_from_config',  true);
 add_handler('ajax_imap_folder_display', 'imap_oauth2_token_check', true);
 add_handler('ajax_imap_folder_display', 'imap_folder_page',  true);
 add_handler('ajax_imap_folder_display', 'save_imap_cache',  true);


### PR DESCRIPTION
Fixed Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in /path/to/vendor/jason-munro/cypht/lib/repository.php:79

Ajax page ajax_imap_folder_display called imap_message_list_type which uses Hm_IMAP_List class while placement of load_imap_servers_from_config was after it leading to have empty entites in Hm_Repository which can pass as second parameter of array_key_exists.