### PR TITLE
[FIX]Profiles: setting the default filter for the profile_id parameter

### DIFF
--- a/modules/profiles/setup.php
+++ b/modules/profiles/setup.php
@@ -28,7 +28,7 @@ return array(
     ),
     'allowed_post' => array(
         'profile_name' => FILTER_DEFAULT,
-        'profile_id' => FILTER_VALIDATE_INT,
+        'profile_id' => FILTER_DEFAULT,
         'profile_replyto' => FILTER_DEFAULT,
         'profile_smtp' => FILTER_DEFAULT,
         'profile_imap' => FILTER_DEFAULT,


### PR DESCRIPTION
After creating a profile on master, we are unable to delete or to update it. 
