### PR TITLE
Fix server configuration action buttons (test, delete,forget,hide)

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1039,7 +1039,7 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
                     $imapTls,
                     null,
                     false,
-                    'imap',
+                    'jmap',
                     $this,
                     $jmapHideFromCPage
                 );

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -2088,18 +2088,19 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
         if($hasImapActivated){
             $imap_servers_count = count(array_filter($this->get('imap_servers', array()), function($v) { return !array_key_exists('type', $v) || $v['type'] != 'jmap'; }));
             $accordionTitle .= 'IMAP';
-            $configuredText .= $imap_servers_count .' IMAP';
+            $configuredText .=  '<span class="imap_server_count"> ' . $imap_servers_count .'</span> IMAP';
             $hasEssentialModuleActivated = true;
         }
 
         if($hasJmapActivated){
+            
             $jmap_servers_count = count(array_filter($this->get('imap_servers', array()), function($v) { return array_key_exists('type', $v) && $v['type'] == 'jmap'; }));
             if($accordionTitle != ''){
                 $accordionTitle .= ' - ';
                 $configuredText .= ' / ';
             }
             $accordionTitle .= 'JMAP';
-            $configuredText .= $jmap_servers_count .' JMAP';
+            $configuredText .= '<span class="jmap_server_count">' . $jmap_servers_count .'</span> JMAP';
             $hasEssentialModuleActivated = true;
         }
 
@@ -2110,7 +2111,7 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
                 $configuredText .= ' / ';
             }
             $accordionTitle .= 'SMTP';
-            $configuredText .= $smtp_servers_count .' SMTP';
+            $configuredText .= '<span class="smtp_server_count">' . $smtp_servers_count .'</span> SMTP';
             $hasEssentialModuleActivated = true;
         }
 

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -25,7 +25,9 @@ $.fn.serializeArray = function() {
     var args = this.serialize().split('&');
     for (var i in args) {
         parts = args[i].split('=');
-        res.push({'name': parts[0], 'value': parts[1]});
+        if (parts[0] && parts[1]) {
+            res.push({'name': parts[0], 'value': parts[1]});
+        }
     }
     return res.map(function(x) {return {name: x.name, value: decodeURIComponent(x.value.replace(/\+/g, " "))}});
 };
@@ -35,6 +37,18 @@ $.fn.sort = function(sort_function) {
         list.push(this[i]);
     }
     return $(list.sort(sort_function));
+};
+$.fn.fadeOut = function(timeout = 600) {
+    return this.css("opacity", 0)
+    .css("transition", `opacity ${timeout}ms`)
+};
+$.fn.fadeOutAndRemove = function(timeout = 600) {
+    this.fadeOut(timeout)
+    var tm = setTimeout(() => {
+        this.remove();
+        clearTimeout(tm)
+    }, timeout);
+    return this;
 };
 
 /* swipe event handler */
@@ -1836,10 +1850,11 @@ var reset_default_value_input = function() {
 };
 
 var decrease_servers = function(section) {
-    const element = document.querySelector(`.${section}_server_setup .server_count`);
-    const parts = element.innerHTML.split(' ');
-    parts[0] = Number(parts[0]) - 1;
-    element.innerHTML = parts.join(' ');
+    const element = document.querySelector(`.server_count .${section}_server_count`);
+    const value = parseInt(element.textContent);
+    if (value > 0) {
+        element.innerHTML  = value - 1;
+    }
 };
 
 var err_msg = function(msg) {

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -428,7 +428,7 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
             return '';
         }
 
-        $res = '<div class="subtitle mt-4">Imap & JMAP Servers</div>';
+        $res = '<div class="subtitle mt-4 fw-bold">'.$this->trans('IMAP and JMAP Servers').'</div>';
         foreach ($list as $index => $vals) {
             $server_id = $vals['id'];
             $type = 'IMAP';
@@ -509,7 +509,7 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
             $res .= '<input type="submit" '.(!$hidden ? 'style="display: none;" ' : '').'value="'.$this->trans('Unhide').'" class="unhide_imap_connection btn btn-outline-secondary btn-sm me-2" />';
 
             $res .= '<input type="hidden" value="ajax_imap_debug" name="hm_ajax_hook" />';
-            $res .= '</div></div></form>';
+            $res .= '</div></div></form></div>';
         }
         $res .= '';
         return $res;

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -428,7 +428,7 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
             return '';
         }
 
-        $res = '<div class="subtitle mt-4 fw-bold">'.$this->trans('IMAP and JMAP Servers').'</div>';
+        $res = '<div class="subtitle mt-4">Imap & JMAP Servers</div>';
         foreach ($list as $index => $vals) {
             $server_id = $vals['id'];
             $type = 'IMAP';
@@ -460,6 +460,7 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
                 $disabled = '';
                 $pass_value = '';
             }
+            $res .= '<div class="' . strtolower($type) . '_server">';
             $res .= '<form class="imap_connect" method="POST">';
             $res .= '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />';
             $res .= '<input type="hidden" name="imap_server_id" class="imap_server_id" value="'.$this->html_safe($server_id).'" />';

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -6,17 +6,16 @@ var imap_delete_action = function(event) {
     }
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
             if (res.deleted_server_id) {
-                const configured_server = form.closest('.configured_server');
-                const section = configured_server.parent().parent()[0].classList.contains('imap_section') ? 'imap': 'jmap';
+                const section = form.parent().hasClass('imap_server') ? 'imap': 'jmap';
                 decrease_servers(section);
-                configured_server.remove();
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
+                form.parent().fadeOutAndRemove()
             }
         },
         {'imap_delete': 1}
@@ -45,7 +44,7 @@ var imap_hide_action = function(form, server_id, hide) {
 var imap_hide = function(event) {
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
     var server_id = $('.imap_server_id', form).val();
     imap_hide_action(form, server_id, 1);
 };
@@ -53,7 +52,7 @@ var imap_hide = function(event) {
 var imap_unhide = function(event) {
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
     var server_id = $('.imap_server_id', form).val();
     imap_hide_action(form, server_id, 0);
 };
@@ -61,14 +60,15 @@ var imap_unhide = function(event) {
 var imap_forget_action = function(event) {
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
+    var btnContainer = $(this).parent();
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
             if (res.just_forgot_credentials) {
                 form.find('.credentials').prop('disabled', false);
                 form.find('.credentials').val('');
-                form.append('<input type="submit" value="Save" class="save_imap_connection btn btn-primary-warning btn-sm" />');
+                btnContainer.append('<input type="submit" value="Save" class="save_imap_connection btn btn-outline-secondary btn-sm me-2" />');
                 $('.save_imap_connection').on('click', imap_save_action);
                 $('.forget_imap_connection', form).hide();
                 Hm_Utils.set_unsaved_changes(1);
@@ -82,7 +82,8 @@ var imap_forget_action = function(event) {
 var imap_save_action = function(event) {
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
+    var btnContainer = $(this).parent();
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
@@ -91,7 +92,7 @@ var imap_save_action = function(event) {
                 form.find('.save_imap_connection').hide();
                 form.find('.imap_password').val('');
                 form.find('.imap_password').attr('placeholder', '[saved]');
-                form.append('<input type="submit" value="Forget" class="forget_imap_connection btn btn-outline-warning btn-sm" />');
+                btnContainer.append('<input type="submit" value="Forget" class="forget_imap_connection btn btn-outline-warning btn-sm me-2" />');
                 $('.forget_imap_connection').on('click', imap_forget_action);
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
@@ -105,7 +106,7 @@ var imap_test_action = function(event) {
     $('.imap_folder_data').empty();
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.imap_connect');
     Hm_Ajax.request(
         form.serializeArray(),
         false,

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1419,7 +1419,7 @@ class Hm_Output_display_configured_smtp_servers extends Hm_Output_Module {
                 }
                 $res .= '<input type="hidden" value="ajax_smtp_debug" name="hm_ajax_hook" />';
             }
-            $res .= '</div></div></form>';
+            $res .= '</div></div></form></div>';
         }
         return $res;
     }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1382,6 +1382,7 @@ class Hm_Output_display_configured_smtp_servers extends Hm_Output_Module {
                 $disabled = '';
                 $pass_value = '';
             }
+            $res .= '<div class="smtp_server">';
 
             $res .= '<form class="smtp_connect" method="POST">';
             $res .= '<input type="hidden" name="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />';

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -84,7 +84,6 @@ var smtp_delete_action = function(event) {
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
-            Hm_Notices.show(res.router_user_msgs);
             if (res.deleted_server_id) {
                 form.parent().fadeOutAndRemove()
                 Hm_Utils.set_unsaved_changes(1);

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -20,7 +20,7 @@ var check_attachment_dir_access = function() {
 
 var smtp_test_action = function(event) {
     event.preventDefault();
-    var form = $(this).parent();
+    var form = $(this).closest('.smtp_connect');
     Hm_Notices.hide(true);
     Hm_Ajax.request(
         form.serializeArray(),
@@ -31,18 +31,18 @@ var smtp_test_action = function(event) {
 
 var smtp_save_action = function(event) {
     event.preventDefault();
-    var form = $(this).parent();
+    var form = $(this).closest('.smtp_connect');
+    var btnContainer = $(this).parent();
     Hm_Notices.hide(true);
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
-            Hm_Notices.show(res.router_user_msgs);
             if (res.just_saved_credentials) {
                 form.find('.credentials').attr('disabled', true);
                 form.find('.save_smtp_connection').hide();
                 form.find('.smtp_password').val('');
                 form.find('.smtp_password').attr('placeholder', '[saved]');
-                form.append('<input type="submit" value="Forget" class="forget_smtp_connection btn btn-outline-secondary btn-sm" />');
+                btnContainer.append('<input type="submit" value="Forget" class="forget_smtp_connection btn btn-outline-secondary btn-sm me-2" />');
                 $('.forget_smtp_connection').on('click', smtp_forget_action);
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
@@ -54,16 +54,16 @@ var smtp_save_action = function(event) {
 
 var smtp_forget_action = function(event) {
     event.preventDefault();
-    var form = $(this).parent();
+    var form = $(this).closest('.smtp_connect');
+    var btnContainer = $(this).parent();
     Hm_Notices.hide(true);
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
-            Hm_Notices.show(res.router_user_msgs);
             if (res.just_forgot_credentials) {
                 form.find('.credentials').prop('disabled', false);
                 form.find('.credentials').val('');
-                form.append('<input type="submit" value="Save" class="save_smtp_connection" />');
+                btnContainer.append('<input type="submit" value="Save" class="save_smtp_connection btn btn-outline-secondary btn-sm me-2" />');
                 $('.save_smtp_connection').on('click', smtp_save_action);
                 $('.forget_smtp_connection', form).remove();
                 Hm_Utils.set_unsaved_changes(1);
@@ -80,13 +80,13 @@ var smtp_delete_action = function(event) {
     }
     event.preventDefault();
     Hm_Notices.hide(true);
-    var form = $(this).parent();
+    var form = $(this).closest('.smtp_connect');
     Hm_Ajax.request(
         form.serializeArray(),
         function(res) {
             Hm_Notices.show(res.router_user_msgs);
             if (res.deleted_server_id) {
-                form.parent().parent().remove();
+                form.parent().fadeOutAndRemove()
                 Hm_Utils.set_unsaved_changes(1);
                 Hm_Folders.reload_folders(true);
                 decrease_servers('smtp');


### PR DESCRIPTION
## Pullrequest

This PR fixes server configuration buttons (test, delete,forget,hide), as those where not working after this refactor [https://github.com/cypht-org/cypht/pull/855](https://github.com/cypht-org/cypht/pull/855)

![actions-screenshot](https://github.com/cypht-org/cypht/assets/14950700/75f6a5bb-2f32-4643-8658-aa0b04bdf3a9)

