### PR TITLE
[FIX] Stalwart: fix jmap 0.7.0 msg_header keys(message-id,message_id)

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1896,8 +1896,13 @@ function save_imap_draft($atts, $id, $session, $mod, $mod_cache, $uploaded_files
         // Convert all header keys to lowercase
         $msg_header_lower = array_change_key_case($msg_header, CASE_LOWER);
         $mime_headers_lower = array_change_key_case($mime->get_headers(), CASE_LOWER);
-        if (isset($msg_header_lower['message-id'], $mime_headers_lower['message-id'])) {
-            if ($msg_header_lower['message-id'] === $mime_headers_lower['message-id']) {
+        if (!empty($msg_header_lower['message_id']) && !empty($mime_headers_lower['message_id'])) {
+            if (trim($msg_header_lower['message_id']) === trim($mime_headers_lower['message_id'])) {
+                return $mail['uid'];
+            }
+        }
+        if (!empty($msg_header_lower['message-id']) && !empty($mime_headers_lower['message-id'])) {
+            if (trim($msg_header_lower['message-id']) === trim($mime_headers_lower['message-id'])) {
                 return $mail['uid'];
             }
         }


### PR DESCRIPTION
### Pull Request Description

**Title:** Update Draft Saving Functionality for Stalwart 0.7.0 Compatibility

#### Description:

**Issue:**
In Stalwart release 0.5.0, the message ID field was consistently labeled as "message-id" in the response data when saving drafts. However, with the release of Stalwart 0.7.0, there has been a change where the message ID field is now labeled as "message_id". This inconsistency has caused issues when attempting to save drafts as our codebase was expecting the previous format.

**Solution:**
To ensure compatibility with Stalwart 0.7.0 and future versions, this pull request updates the draft saving functionality to handle both "message-id" and "message_id" fields in the response data. The code now checks for the existence of both keys and compares their values accordingly. This change allows our application to seamlessly handle drafts saved using both versions of Stalwart.

**Changes Made:**
- Modified the draft saving logic to accommodate both "message-id" and "message_id" fields in the response data.
- Implemented a conditional check to handle the different field names and ensure compatibility across Stalwart versions.
- Tested the updated functionality to verify correct behavior when saving drafts with Stalwart 0.7.0.

This pull request aims to resolve the compatibility issue with Stalwart 0.7.0 and improve the robustness of our draft saving feature for future releases.


```array(10) {
    [0] => array(
        "uid" => "eaaaaaba",
        "flags" => "",
        "internal_date" => "2024-04-11T16:52:40Z",
        "size" => 609,
        "date" => "2024-04-11T16:52:38Z",
        "from" => "Steven NG <steven@lab14.evoludata.com>",
        "to" => "muhngesteven@gmail.com",
        "subject" => "Test Stalwart release 0.7.0",
        "content-type" => "",
        "timestamp" => 1712854360,
        "charset" => "",
        "x-priority" => "",
        "type" => "jmap",
        "references" => "",
        "message_id" => "52336d427c7dcbbcc5cbb3d57a485d12@Stevens-MacBook-Pro.local",
        "x_auto_bcc" => ""
    ),
    [1] => array(
        "uid" => "d2aaaaa3",
        "flags" => "",
        "internal_date" => "2024-04-11T16:52:03Z",
        "size" => 615,
        "date" => "2024-04-11T16:52:02Z",
        "from" => "Steven NG <steven@lab14.evoludata.com>",
        "to" => "muhngesteven@gmail.com",
        "subject" => "Test Stalwart release 0.7.0",
        "content-type" => "",
        "timestamp" => 1712854323,
        "charset" => "",
        "x-priority" => "",
        "type" => "jmap",
        "references" => "",
        "message_id" => "db0bd6557d9ae16ebce56259ba73fbd6@Stevens-MacBook-Pro.local",
        "x_auto_bcc" => ""
    ),
    [2] => array(
        // and so on for the remaining elements...
    ),
    // Remaining elements truncated for brevity
}
```

Related Issue: [https://github.com/cypht-org/cypht/issues/931](https://github.com/cypht-org/cypht/issues/931)