### PR TITLE
use CONFIG_PATH defined in FC consistently throughout

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -25,7 +25,7 @@ abstract class Hm_Config {
 
     /* flag to save config after page handling */
     public $save_on_login = false;
-    
+
     /**
      * This method must be overriden by classes extending this one
      * @param string $source source or identifier to determine the source
@@ -81,9 +81,9 @@ abstract class Hm_Config {
      */
     public function reset_factory() {
         $this->config = array(
-            "version"=>$this->config["version"], 
-            "feeds"=>$this->config["feeds"], 
-            "imap_servers"=>$this->config["imap_servers"], 
+            "version"=>$this->config["version"],
+            "feeds"=>$this->config["feeds"],
+            "imap_servers"=>$this->config["imap_servers"],
             "smtp_servers"=>$this->config["smtp_servers"]
         );
     }
@@ -303,9 +303,9 @@ class Hm_User_Config_File extends Hm_Config {
      */
     public function reset_factory() {
         $this->config = array(
-            "version"=>$this->config["version"], 
-            "feeds"=>$this->config["feeds"], 
-            "imap_servers"=>$this->config["imap_servers"], 
+            "version"=>$this->config["version"],
+            "feeds"=>$this->config["feeds"],
+            "imap_servers"=>$this->config["imap_servers"],
             "smtp_servers"=>$this->config["smtp_servers"]
         );
         if (!$this->crypt) {
@@ -458,9 +458,9 @@ class Hm_User_Config_DB extends Hm_Config {
      */
     public function reset_factory() {
         $this->config = array(
-            "version"=>$this->config["version"], 
-            "feeds"=>$this->config["feeds"], 
-            "imap_servers"=>$this->config["imap_servers"], 
+            "version"=>$this->config["version"],
+            "feeds"=>$this->config["feeds"],
+            "imap_servers"=>$this->config["imap_servers"],
             "smtp_servers"=>$this->config["smtp_servers"]
         );
         if (!$this->crypt) {

--- a/lib/config.php
+++ b/lib/config.php
@@ -481,7 +481,7 @@ class Hm_Site_Config_File extends Hm_Config {
      * @param string $source source location for site configuration
      */
     public function __construct($all_configs = []) {
-        $this->load(empty($all_configs) ? merge_config_files(APP_PATH.'config') : $all_configs, false);
+        $this->load(empty($all_configs) ? merge_config_files(CONFIG_PATH) : $all_configs, false);
     }
 
     /**

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -88,7 +88,7 @@ function build_config() {
     }
 
     /* get the site settings */
-    $settings = merge_config_files(APP_PATH.'config');
+    $settings = merge_config_files(CONFIG_PATH);
 
     if (is_array($settings) && !empty($settings)) {
         $settings['version'] = VERSION;

--- a/scripts/update_password.php
+++ b/scripts/update_password.php
@@ -30,7 +30,7 @@ require APP_PATH.'lib/framework.php';
 $environment = Hm_Environment::getInstance();
 $environment->load();
 /* get config object */
-$config = new Hm_Site_Config_File(merge_config_files(APP_PATH.'config'));
+$config = new Hm_Site_Config_File(merge_config_files(CONFIG_PATH));
 
 /* check config for db auth */
 if ($config->get('auth_type') != 'DB') {

--- a/tests/phpunit/dispatch.php
+++ b/tests/phpunit/dispatch.php
@@ -8,7 +8,7 @@ class Hm_Test_Dispatch extends TestCase {
     public function setUp(): void {
         require 'bootstrap.php';
         require 'helpers.php';
-        define('CONFIG_FILE', merge_config_files(APP_PATH.'config'));
+        define('CONFIG_FILE', merge_config_files(CONFIG_PATH));
         $this->config = new Hm_Mock_Config();
     }
     /**
@@ -143,7 +143,7 @@ class Hm_Test_Debug_Page_Redirect extends TestCase {
     public function setUp(): void {
         define('DEBUG_MODE', true);
         require 'bootstrap.php';
-        define('CONFIG_FILE', merge_config_files(APP_PATH.'config'));
+        define('CONFIG_FILE', merge_config_files(CONFIG_PATH));
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/request.php
+++ b/tests/phpunit/request.php
@@ -9,7 +9,7 @@ class Hm_Test_Request extends TestCase {
     public $config;
     public function setUp(): void {
         require 'bootstrap.php';
-        define('CONFIG_FILE', merge_config_files(APP_PATH.'config'));
+        define('CONFIG_FILE', merge_config_files(CONFIG_PATH));
         $this->config = new Hm_Mock_Config();
     }
     /**


### PR DESCRIPTION
## Pullrequest

The front controller (index.php) defines a CONFIG_PATH constant, but this is not used throughout when accessing the directory. This commit corrects that so the path is set just once.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
