### PR TITLE
Check enable sieve and fill sieve host for providers which have sieve support

### DIFF
--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -453,11 +453,11 @@ function update_search_label_field($search_term, $output_mod) {
     <input type="hidden" name="page" value="search">
     <input type="hidden" name="search_terms" value="'. $search_term .'">
     <label class="screen_reader" for="search_terms_label">Current Search Label</label>
-    <input required="" disabled id="old_search_terms_label" type="search" value="' . $search_term . '" class="old_search_terms_label" name="old_search_terms_label">
+    <input required="" disabled id="old_search_terms_label" type="search" value="' . $search_term . '" class="old_search_terms_label form-control form-control-sm" name="old_search_terms_label">
     <label class="screen_reader" for="search_terms_label">New Search Terms</label>
-    <input required="" placeholder="New search terms label" id="search_terms_label" type="search" class="search_terms_label" name="search_terms_label">
+    <input required="" placeholder="New search terms label" id="search_terms_label" type="search" class="search_terms_label form-control form-control-sm" name="search_terms_label">
     <div>
-        <input type="button" class="search_label_update" value="Update">
+        <input type="button" class="search_label_update btn w-100 btn-primary btn-sm" value="Update">
     </div>
     </div>';
     $res .= '</div>';

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -1687,7 +1687,11 @@ var Hm_Utils = {
             path = window.location.href;
         }
         window.location.href = path;
-    }
+    },
+
+    is_valid_email: function (val) {
+        return /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(val)
+    },
 };
 
 var Hm_Crypt = {
@@ -2291,7 +2295,9 @@ function handleProviderChange(select) {
 }
 
 function setDefaultReplyTo(val) {
-    $("#srv_setup_stepper_profile_reply_to").val(val);
+    if (Hm_Utils.is_valid_email(val)) {
+        $("#srv_setup_stepper_profile_reply_to").val(val);
+    }
 }
 function display_config_step(stepNumber) {
     if(stepNumber === 2) {
@@ -2406,6 +2412,18 @@ function getServiceDetails(providerKey){
 
                     if(serverConfig.tls)$("input[name='srv_setup_stepper_imap_tls'][value='true']").prop("checked", true);
                     else $("input[name='srv_setup_stepper_imap_tls'][value='false']").prop("checked", true);
+
+                    if (serverConfig.hasOwnProperty('sieve')) {
+                        $('#srv_setup_stepper_enable_sieve')
+                            .prop('checked', true)
+                            .trigger('change');
+                        $('#srv_setup_stepper_imap_sieve_host').val(serverConfig.sieve.host + ':' + serverConfig.sieve.port);
+                    } else {
+                        $('#srv_setup_stepper_enable_sieve')
+                            .prop('checked', false)
+                            .trigger('change');;
+                        $('#srv_setup_stepper_imap_sieve_host').val('');
+                    }
                 }
             },
             [],


### PR DESCRIPTION
This PR enhances adding IMAP - JMAP - SMTP servers

In modules/nux/services.php some services have sieve key
This PR check the Enable Sieve checkbox and also fills sieve host input for those services.

It also improves the Reply-to field. It will be set only it the username field is a valid email address as it can also be a username