### PR TITLE
[FIX] remove preg_match from Hm_Handler_message_list_type

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -782,7 +782,7 @@ class Hm_Handler_message_list_type extends Hm_Handler_Module {
         else {
             $list_page = 1;
         }
-        if (array_key_exists('uid', $this->request->get) && preg_match("/\d+/", $this->request->get['uid'])) {
+        if (array_key_exists('uid', $this->request->get) && preg_match("/^[0-9a-z]+$/i", $this->request->get['uid'])) {
             $uid = $this->request->get['uid'];
         }
         $list_style = $this->user_config->get('list_style_setting', false);


### PR DESCRIPTION
Resolve blank page on show message with JMAP,

Stalwart has string `uid` instead of digits.

Related Issue: [https://github.com/cypht-org/cypht/issues/950](https://github.com/cypht-org/cypht/issues/950)