### PR TITLE
use WEB_ROOT consistently in output_modules.php

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -18,7 +18,7 @@ class Hm_Output_search_from_folder_list extends Hm_Output_Module {
         $res = '<li class="menu_search"><form method="get">';
         $res .= '<div class="d-flex align-items-center">';
         if (!$this->get('hide_folder_icons')) {
-            $res .= '<div class="ps-1 pe-2"><a class="unread_link" href="?page=search">';
+            $res .= '<div class="ps-1 pe-2"><a class="unread_link" href="'.WEB_ROOT.'?page=search">';
             $res .= '<i class="bi bi-search"></i></a></div>';
         }
         $res .= '<div class=""><input type="hidden" name="page" value="search" />'.
@@ -70,7 +70,7 @@ class Hm_Output_save_reminder extends Hm_Output_Module {
         $changed = $this->get('changed_settings', array());
         if (!empty($changed)) {
             return '<div class="save_reminder"><a title="'.$this->trans('You have unsaved changes').
-                '" href="?page=save"><i class="bi bi-save2-fill fs-2"></i></a></div>';
+                '" href="'.WEB_ROOT.'?page=save"><i class="bi bi-save2-fill fs-2"></i></a></div>';
         }
         return '';
     }
@@ -205,7 +205,7 @@ class Hm_Output_login_start extends Hm_Output_Module {
                     '.user-icon_signin{display:block; background-color:white; border-radius:100%; padding:10px; height:40px; margin-top:-120px; box-shadow: #6eb549 .4px 2.4px 6.2px; }'.
                     '.label_signin{width:210px; margin:0px 0px -18px 0px;color:#fff;opacity:0.7;} @media (max-height : 500px){ .user-icon_signin{display:none;}}
                     </style>';
-    
+
                 return $css.'<div class="form-container"><form class="login_form" method="POST">';
             }
             else {
@@ -275,7 +275,7 @@ class Hm_Output_login extends Hm_Output_Module {
             if (!$single && count($settings) > 0) {
                 $changed = 1;
             }
-           
+
         return '<div class="modal fade" id="confirmLogoutModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="confirmLogoutModalLabel" aria-hidden="true">
                 <div class="modal-dialog">
                 <div class="modal-content">
@@ -285,7 +285,7 @@ class Hm_Output_login extends Hm_Output_Module {
                     </div>
                     <div class="modal-body">
                         <input type="hidden" name="hm_page_key" value="'.Hm_Request_Key::generate().'" />
-                        <p class="text-wrap">'.$this->trans('Unsaved changes will be lost! Re-enter your password to save and exit.').' <a href="?page=save">'.$this->trans('More info').'</a></p>
+                        <p class="text-wrap">'.$this->trans('Unsaved changes will be lost! Re-enter your password to save and exit.').' <a href="'.WEB_ROOT.'?page=save">'.$this->trans('More info').'</a></p>
                         <input type="text" value="'.$this->html_safe($this->get('username', 'cypht_user')).'" autocomplete="username" style="display: none;"/>
                         <div class="my-3 form-floating">
                             <input id="logout_password" autocomplete="current-password" name="password" class="form-control" type="password" placeholder="'.$this->trans('Password').'">
@@ -442,7 +442,7 @@ class Hm_Output_content_start extends Hm_Output_Module {
             $res .= '<input type="hidden" id="hm_page_key" value="'.$this->html_safe(Hm_Request_Key::generate()).'" />';
         }
         if (!$this->get('single_server_mode') && count($this->get('changed_settings', array())) > 0) {
-            $res .= '<a class="unsaved_icon" href="?page=save" title="'.$this->trans('Unsaved Changes').
+            $res .= '<a class="unsaved_icon" href="'.WEB_ROOT.'?page=save" title="'.$this->trans('Unsaved Changes').
                 '"><i class="bi bi-save2-fill fs-5 unsaved_reminder"></i></a>';
         }
         return $res;
@@ -505,21 +505,21 @@ class Hm_Output_header_css extends Hm_Output_Module {
             $res .= '<link href="' . WEB_ROOT . 'modules/themes/assets/default/css/default.css?v=' . CACHE_ID . '" media="all" rel="stylesheet" type="text/css" />';
         }
         if (DEBUG_MODE) {
-            $res .= '<link href="vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />';
+            $res .= '<link href="'.WEB_ROOT.'vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />';
             foreach (glob(APP_PATH.'modules'.DIRECTORY_SEPARATOR.'**', GLOB_ONLYDIR | GLOB_MARK) as $name) {
                 $rel_name = str_replace(APP_PATH, '', $name);
                 $mod = str_replace(array('modules', DIRECTORY_SEPARATOR), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.css", $name))) {
-                    $res .= '<link href="'.sprintf("%ssite.css", $rel_name).'" media="all" rel="stylesheet" type="text/css" />';
+                    $res .= '<link href="'.WEB_ROOT.sprintf("%ssite.css", $rel_name).'" media="all" rel="stylesheet" type="text/css" />';
                 }
             }
             // load pcss3t.cs only if one of: ['contacts','local_contacts','ldap_contacts','gmail_contacts'] is enabled
             if(count(array_intersect(['contacts','local_contacts','ldap_contacts','gmail_contacts'], $mods)) > 0){
-                $res .= '<link href="third_party/contact-group.css" media="all" rel="stylesheet" type="text/css" />';
+                $res .= '<link href="'.WEB_ROOT.'third_party/contact-group.css" media="all" rel="stylesheet" type="text/css" />';
             }
         }
         else {
-            $res .= '<link href="site.css?v='.CACHE_ID.'" ';
+            $res .= '<link href="'.WEB_ROOT.'site.css?v='.CACHE_ID.'" ';
             if (defined('CSS_HASH') && CSS_HASH) {
                 $res .= 'integrity="'.CSS_HASH.'" ';
             }
@@ -544,14 +544,14 @@ class Hm_Output_page_js extends Hm_Output_Module {
     protected function output() {
         if (DEBUG_MODE) {
             $res = '';
-            $js_lib = '<script type="text/javascript" src="vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js"></script>';
-            $js_lib .= '<script type="text/javascript" src="third_party/cash.min.js"></script>';
-            $js_lib .= '<script type="text/javascript" src="third_party/resumable.min.js"></script>';
-            $js_lib .= '<script type="text/javascript" src="third_party/ays-beforeunload-shim.js"></script>';
-            $js_lib .= '<script type="text/javascript" src="third_party/jquery.are-you-sure.js"></script>';
-            $js_lib .= '<script type="text/javascript" src="third_party/sortable.min.js"></script>';
+            $js_lib = '<script type="text/javascript" src="'.WEB_ROOT.'vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js"></script>';
+            $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/cash.min.js"></script>';
+            $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/resumable.min.js"></script>';
+            $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/ays-beforeunload-shim.js"></script>';
+            $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/jquery.are-you-sure.js"></script>';
+            $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/sortable.min.js"></script>';
             if ($this->get('encrypt_ajax_requests', '') || $this->get('encrypt_local_storage', '')) {
-                $js_lib .= '<script type="text/javascript" src="third_party/forge.min.js"></script>';
+                $js_lib .= '<script type="text/javascript" src="'.WEB_ROOT.'third_party/forge.min.js"></script>';
             }
             $core = false;
             $mods = $this->get('router_module_list');
@@ -563,11 +563,11 @@ class Hm_Output_page_js extends Hm_Output_Module {
                 }
                 $mod = str_replace(array('modules', DIRECTORY_SEPARATOR), '', $rel_name);
                 if (in_array($mod, $mods, true) && is_readable(sprintf("%ssite.js", $name))) {
-                    $res .= '<script type="text/javascript" src="'.sprintf("%ssite.js", $rel_name).'"></script>';
+                    $res .= '<script type="text/javascript" src="'.WEB_ROOT.sprintf("%ssite.js", $rel_name).'"></script>';
                 }
             }
             if ($core) {
-                $res = '<script type="text/javascript" src="'.sprintf("%ssite.js", $core).'"></script>'.$res;
+                $res = '<script type="text/javascript" src="'.WEB_ROOT.sprintf("%ssite.js", $core).'"></script>'.$res;
             }
             return $js_lib.$res;
         }
@@ -576,7 +576,7 @@ class Hm_Output_page_js extends Hm_Output_Module {
             if (defined('JS_HASH') && JS_HASH) {
                 $res .= 'integrity="'.JS_HASH.'" ';
             }
-            $res .= 'src="site.js?v='.CACHE_ID.'" async></script>';
+            $res .= 'src="'.WEB_ROOT.'site.js?v='.CACHE_ID.'" async></script>';
             return $res;
         }
     }
@@ -1116,7 +1116,7 @@ class Hm_Output_all_since_setting extends Hm_Output_Module {
      * Processed by Hm_Handler_process_all_since_setting
      */
     protected function output() {
-        $since = DEFAULT_SINCE; 
+        $since = DEFAULT_SINCE;
         $settings = $this->get('user_settings', array());
         if (array_key_exists('all_since', $settings) && $settings['all_since']) {
             $since = $settings['all_since'];
@@ -1306,33 +1306,33 @@ class Hm_Output_main_menu_content extends Hm_Output_Module {
         }
         $total_accounts = count($this->get('imap_servers', array())) + count($this->get('feeds', array()));
         if ($total_accounts > 2) {
-            $res .= '<li class="menu_combined_inbox"><a class="unread_link" href="?page=message_list&amp;list_path=combined_inbox">';
+            $res .= '<li class="menu_combined_inbox"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=combined_inbox">';
             if (!$this->get('hide_folder_icons')) {
                 $res .= '<i class="bi bi-box2-fill fs-5 me-2"></i>';
             }
             $res .= $this->trans('Everything').'</a><span class="combined_inbox_count"></span></li>';
         }
-        $res .= '<li class="menu_unread d-flex align-items-center"><a class="unread_link d-flex align-items-center" href="?page=message_list&amp;list_path=unread">';
+        $res .= '<li class="menu_unread d-flex align-items-center"><a class="unread_link d-flex align-items-center" href="'.WEB_ROOT.'?page=message_list&amp;list_path=unread">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-envelope-fill fs-5 me-2"></i>';
         }
         $res .= $this->trans('Unread').'</a><span class="total_unread_count badge rounded-pill text-bg-info ms-2 px-1"></span></li>';
-        $res .= '<li class="menu_flagged"><a class="unread_link" href="?page=message_list&amp;list_path=flagged">';
+        $res .= '<li class="menu_flagged"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=flagged">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-flag-fill fs-5 me-2"></i>';
         }
         $res .= $this->trans('Flagged').'</a> <span class="flagged_count"></span></li>';
-        $res .= '<li class="menu_junk"><a class="unread_link" href="?page=message_list&amp;list_path=junk">';
+        $res .= '<li class="menu_junk"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=junk">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-envelope-x-fill fs-5 me-2"></i>';
         }
         $res .= $this->trans('Junk').'</a></li>';
-        $res .= '<li class="menu_trash"><a class="unread_link" href="?page=message_list&amp;list_path=trash">';
+        $res .= '<li class="menu_trash"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=trash">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-trash3-fill fs-5 me-2"></i>';
         }
         $res .= $this->trans('Trash').'</a></li>';
-        $res .= '<li class="menu_drafts"><a class="unread_link" href="?page=message_list&amp;list_path=drafts">';
+        $res .= '<li class="menu_drafts"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=drafts">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-pencil-square fs-5 me-2"></i>';
         }
@@ -1407,7 +1407,7 @@ class Hm_Output_email_menu_content extends Hm_Output_Module {
             }
             $res .= 'class="'.$this->html_safe($src).'"><ul class="folders">';
             if ($name == 'Email' && count($this->get('imap_servers', array()))  > 1) {
-                $res .= '<li class="menu_email"><a class="unread_link" href="?page=message_list&amp;list_path=email">';
+                $res .= '<li class="menu_email"><a class="unread_link" href="'.WEB_ROOT.'?page=message_list&amp;list_path=email">';
                 if (!$this->get('hide_folder_icons')) {
                     $res .= '<i class="bi bi-globe-americas fs-5 me-2"></i>';
                 }
@@ -1434,7 +1434,7 @@ class Hm_Output_settings_menu_start extends Hm_Output_Module {
         $res = '<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">'.$this->trans('Settings').
             '<i class="bi bi-chevron-down"></i></div>'.
             '</div><ul style="display: none;" class="settings folders">';
-        $res .= '<li class="menu_home"><a class="unread_link" href="?page=home">';
+        $res .= '<li class="menu_home"><a class="unread_link" href="'.WEB_ROOT.'?page=home">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-house-door-fill fs-5 me-2"></i>';
         }
@@ -1497,7 +1497,7 @@ class Hm_Output_settings_servers_link extends Hm_Output_Module {
      * Outputs links to the Servers settings pages
      */
     protected function output() {
-        $res = '<li class="menu_servers"><a class="unread_link" href="?page=servers">';
+        $res = '<li class="menu_servers"><a class="unread_link" href="'.WEB_ROOT.'?page=servers">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-pc-display-horizontal fs-5 me-2"></i>';
         }
@@ -1515,7 +1515,7 @@ class Hm_Output_settings_site_link extends Hm_Output_Module {
      * Outputs links to the Site Settings pages
      */
     protected function output() {
-        $res = '<li class="menu_settings"><a class="unread_link" href="?page=settings">';
+        $res = '<li class="menu_settings"><a class="unread_link" href="'.WEB_ROOT.'?page=settings">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-gear-wide-connected fs-5 me-2"></i>';
         }
@@ -1536,7 +1536,7 @@ class Hm_Output_settings_save_link extends Hm_Output_Module {
         if ($this->get('single_server_mode')) {
             return;
         }
-        $res = '<li class="menu_save"><a class="unread_link" href="?page=save">';
+        $res = '<li class="menu_save"><a class="unread_link" href="'.WEB_ROOT.'?page=save">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-download fs-5 me-2"></i>';
         }
@@ -1647,20 +1647,20 @@ class Hm_Output_message_start extends Hm_Output_Module {
             else {
                 $page = 'message_list';
             }
-            $title = '<a href="?page='.$page.'&amp;list_path='.$this->html_safe($this->get('list_parent')).'">'.$list_name.'</a>';
+            $title = '<a href="'.WEB_ROOT.'?page='.$page.'&amp;list_path='.$this->html_safe($this->get('list_parent')).'">'.$list_name.'</a>';
             if (count($this->get('mailbox_list_title', array())) > 0) {
                 $mb_title = array_map( function($v) { return $this->trans($v); }, $this->get('mailbox_list_title', array()));
                 if (($key = array_search($list_name, $mb_title)) !== false) {
                     unset($mb_title[$key]);
                 }
                 $title .= '<i class="bi bi-caret-right-fill path_delim"></i>'.
-                    '<a href="?page=message_list&amp;list_path='.$this->html_safe($this->get('list_path')).'">'.
+                    '<a href="'.WEB_ROOT.'?page=message_list&amp;list_path='.$this->html_safe($this->get('list_path')).'">'.
                     implode('<i class="bi bi-caret-right-fill path_delim"></i>',
                     array_map( function($v) { return $this->trans($v); }, $mb_title)).'</a>';
             }
         }
         elseif ($this->get('mailbox_list_title')) {
-            $url = '?page=message_list&amp;list_path='.$this->html_safe($this->get('list_path'));
+            $url = WEB_ROOT.'?page=message_list&amp;list_path='.$this->html_safe($this->get('list_path'));
             if ($this->get('list_page', 0)) {
                 $url .= '&list_page='.$this->html_safe($this->get('list_page'));
             }
@@ -1778,7 +1778,7 @@ class Hm_Output_home_password_dialogs extends Hm_Output_Module {
             $res = '<div class="home_password_dialogs">';
             $res .= '<div class="nux_title">Passwords</div>'.$this->trans('You have elected to not store passwords between logins.').
                 ' '.$this->trans('Enter your passwords below to gain access to these services during this session.').'<br /><br />';
-                
+
             foreach ($missing as $vals) {
                 $id = $this->html_safe(sprintf('%s_%s', strtolower($vals['type']), $vals['id']));
                 $res .= '<div class="div_'.$id.'" >'.$this->html_safe($vals['type']).' '.$this->html_safe($vals['name']).
@@ -1816,7 +1816,7 @@ class Hm_Output_message_list_heading extends Hm_Output_Module {
             else {
                 $path = $this->get('list_path');
             }
-            $config_link = '<a title="'.$this->trans('Configure').'" href="?page=settings#'.$path.'_setting"><i class="bi bi-gear-wide refresh_list"></i></a>';
+            $config_link = '<a title="'.$this->trans('Configure').'" href="'.WEB_ROOT.'?page=settings#'.$path.'_setting"><i class="bi bi-gear-wide refresh_list"></i></a>';
             $refresh_link = '<a class="refresh_link" title="'.$this->trans('Refresh').'" href="#"><i class="bi bi-arrow-clockwise refresh_list"></i></a>';
             //$search_field = '<form method="GET">
             //<input type="hidden" name="page" value="message_list" />
@@ -2093,7 +2093,7 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
         }
 
         if($hasJmapActivated){
-            
+
             $jmap_servers_count = count(array_filter($this->get('imap_servers', array()), function($v) { return array_key_exists('type', $v) && $v['type'] == 'jmap'; }));
             if($accordionTitle != ''){
                 $accordionTitle .= ' - ';
@@ -2138,7 +2138,7 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
                       <a href="#" class="pe-auto">
                           <i class="bi bi-envelope-fill me-3"></i>
                           <b> '.$accordionTitle.'</b>
-                      </a> 
+                      </a>
                       <div class="server_count">'.$configuredText.'</div>
                   </div>
              <div class="server_config_section px-4 pt-3 me-0">


### PR DESCRIPTION
## Pullrequest
Take two! 

Use WEB_ROOT consistently throughout `core/output_modules.php`. In some setups, this allows `vendor` and `third_party` assets to load correctly. Should not have any compatibility issues.

Please advise if moving from a relative to a root-relative path is less than ideal.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Config Update
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Changelog
-->
- [X] None
