### PR TITLE
[UX]Profiles: adding table-responsive class to profiles table so it l…

### DIFF
--- a/modules/profiles/modules.php
+++ b/modules/profiles/modules.php
@@ -249,7 +249,7 @@ class Hm_Output_profile_content extends Hm_Output_Module {
         $res = '';
         if (count($profiles) > 0) {
             $smtp_servers = $this->get('smtp_servers', array());
-            $res .= '<div class="p-3"><table class="table table-striped"><tr>'.
+            $res .= '<div class="table-responsive p-3"><table class="table table-striped"><tr>'.
                 '<th>'.$this->trans('Display Name').'</th>'.
                 '<th class="d-none d-sm-table-cell">'.$this->trans('IMAP Server').'</th>'.
                 '<th class="d-none d-sm-table-cell">'.$this->trans('Username').'</th>'.


### PR DESCRIPTION
-  [UX]Profiles: adding table-responsive class to profiles table so it looks nice
- The profiles table was not responsive see:

https://github.com/cypht-org/cypht/assets/81784141/1fc5a155-8792-449d-862a-02b216ef0621

- Then I fixed, adding `table-responsive` class to the table div see result:

https://github.com/cypht-org/cypht/assets/81784141/e52d0e2f-fa54-4ddf-8237-c7c766441eef

