### PR TITLE
[FIX] Folders: fixing unable to set draft folder

### DIFF
--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -504,7 +504,7 @@ class Hm_Output_folders_sent_dialog extends Hm_Output_Module {
                         <a href="#" class="select_sent_folder">'.$this->trans('Select Folder').'</a>:
                         <span class="selected_sent"></span>
                     </div>
-                    <ul class="folders sent_folder_select" style="z-index: 10">
+                    <ul class="folders sent_folder_select">
                         <li class="sent_title">
                             <a href="#" class="close">'.$this->trans('Cancel').'</a>
                         </li>
@@ -548,7 +548,7 @@ class Hm_Output_folders_archive_dialog extends Hm_Output_Module {
                         <a href="#" class="select_archive_folder">'.$this->trans('Select Folder').'</a>:
                         <span class="selected_archive"></span>
                     </div>
-                    <ul class="folders archive_folder_select" style="z-index : 10">
+                    <ul class="folders archive_folder_select">
                         <li class="archive_title">
                             <a href="#" class="close">'.$this->trans('Cancel').'</a>
                         </li>
@@ -635,7 +635,7 @@ class Hm_Output_folders_trash_dialog extends Hm_Output_Module {
                         <a href="#" class="select_trash_folder">'.$this->trans('Select Folder').'</a>:
                         <span class="selected_trash"></span>
                     </div>
-                    <ul class="folders trash_folder_select" style="z-index : 10">
+                    <ul class="folders trash_folder_select">
                         <li class="trash_title">
                             <a href="#" class="close">'.$this->trans('Cancel').'</a>
                         </li>
@@ -677,7 +677,7 @@ class Hm_Output_folders_junk_dialog extends Hm_Output_Module {
                         <a href="#" class="select_junk_folder">'.$this->trans('Select Folder').'</a>:
                         <span class="selected_junk"></span>
                     </div>
-                    <ul class="folders junk_folder_select" style="z-index: 10">
+                    <ul class="folders junk_folder_select">
                         <li class="junk_title">
                             <a href="#" class="close">'.$this->trans('Cancel').'</a>
                         </li>

--- a/modules/imap_folders/site.css
+++ b/modules/imap_folders/site.css
@@ -2,6 +2,7 @@
 /* .folder_dialog input { display: inline-block; margin-top: 15px; } */
 .sent_folder_select, .draft_folder_select, .trash_folder_select, .folder_dialog, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select, .junk_folder_select { display: none; }
 .draft_folder_select, .sent_folder_select, .trash_folder_select, .delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .parent_folder_select, .archive_folder_select { width: 215px; position: absolute; background-color: #fff; padding: 15px; border: solid 1px #ede8e6; font-weight: normal; padding-left: 10px; min-width: 55px; padding-top: 10px; margin-left: 0px !important; margin-top: 0px; }
+.delete_folder_select, .rename_folder_select, .rename_parent_folder_select, .sent_folder_select, .archive_folder_select, .draft_folder_select, .trash_folder_select, .junk_folder_select, .parent_folder_select { z-index: 10; }
 .folder_row { margin-top: 15px; }
 .close { margin-left: 10%; font-size: 100%; color: teal !important; }
 .sp_folder_title { font-size: 110%; color: #777; }


### PR DESCRIPTION
- We were unable to set draft folder as you can see from:

https://github.com/cypht-org/cypht/assets/81784141/2dc36aff-700a-4676-a70c-470adef198f2

- There was missing `style="z-index : 10"` on ul tag....adding it fixed as well see:

https://github.com/cypht-org/cypht/assets/81784141/f2b9b6d2-a526-42eb-b1b9-c55347a8c774

