### PR TITLE
Adding bulk-import accounts using csv sample file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "paragonie/random_compat": "^2.0.18",
         "php": ">=8.1",
         "symfony/dotenv": "^4.3 || 5.4",
-        "symfony/yaml": "^5.4",
+        "symfony/yaml": "~6.4.3",
         "thomaspark/bootswatch": "^5.3",
         "twbs/bootstrap": "^5.3",
         "twbs/bootstrap-icons": "^1.11",

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "paragonie/random_compat": "^2.0.18",
         "php": ">=8.1",
         "symfony/dotenv": "^4.3 || 5.4",
+        "symfony/yaml": "^5.4",
         "thomaspark/bootswatch": "^5.3",
         "twbs/bootstrap": "^5.3",
         "twbs/bootstrap-icons": "^1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8de6d181041346fe7a32bd3994050781",
+    "content-hash": "e11d399af68ed7416340c63ab7a213d6",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1647,31 +1647,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.39",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "bc780e16879000f77a1022163c052f5323b5e640"
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/bc780e16879000f77a1022163c052f5323b5e640",
-                "reference": "bc780e16879000f77a1022163c052f5323b5e640",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/52903de178d542850f6f341ba92995d3d63e60c9",
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/console": "^5.4|^6.0|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -1702,7 +1699,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.39"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -1718,7 +1715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-23T11:57:27+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "thomaspark/bootswatch",

--- a/composer.lock
+++ b/composer.lock
@@ -1327,6 +1327,85 @@
             "time": "2021-11-23T10:19:22+00:00"
         },
         {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
             "name": "symfony/polyfill-iconv",
             "version": "v1.29.0",
             "source": {
@@ -1565,6 +1644,81 @@
                 }
             ],
             "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v5.4.39",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "bc780e16879000f77a1022163c052f5323b5e640"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/bc780e16879000f77a1022163c052f5323b5e640",
+                "reference": "bc780e16879000f77a1022163c052f5323b5e640",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.3"
+            },
+            "require-dev": {
+                "symfony/console": "^5.3|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.4.39"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-23T11:57:27+00:00"
         },
         {
             "name": "thomaspark/bootswatch",

--- a/language/az.php
+++ b/language/az.php
@@ -636,4 +636,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/az.php
+++ b/language/az.php
@@ -637,4 +637,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/de.php
+++ b/language/de.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/de.php
+++ b/language/de.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/en.php
+++ b/language/en.php
@@ -652,4 +652,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/en.php
+++ b/language/en.php
@@ -651,4 +651,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/es.php
+++ b/language/es.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/es.php
+++ b/language/es.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/et.php
+++ b/language/et.php
@@ -642,4 +642,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/et.php
+++ b/language/et.php
@@ -641,4 +641,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/fa.php
+++ b/language/fa.php
@@ -686,4 +686,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/fa.php
+++ b/language/fa.php
@@ -685,4 +685,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/fr.php
+++ b/language/fr.php
@@ -633,4 +633,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/fr.php
+++ b/language/fr.php
@@ -632,4 +632,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/hu.php
+++ b/language/hu.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/hu.php
+++ b/language/hu.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/id.php
+++ b/language/id.php
@@ -640,4 +640,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/id.php
+++ b/language/id.php
@@ -641,4 +641,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/it.php
+++ b/language/it.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/it.php
+++ b/language/it.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/ja.php
+++ b/language/ja.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/ja.php
+++ b/language/ja.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/nl.php
+++ b/language/nl.php
@@ -634,4 +634,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/nl.php
+++ b/language/nl.php
@@ -633,4 +633,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/pt-BR.php
+++ b/language/pt-BR.php
@@ -633,4 +633,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/pt-BR.php
+++ b/language/pt-BR.php
@@ -632,4 +632,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/ro.php
+++ b/language/ro.php
@@ -633,4 +633,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/ro.php
+++ b/language/ro.php
@@ -632,4 +632,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/ru.php
+++ b/language/ru.php
@@ -635,4 +635,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/language/ru.php
+++ b/language/ru.php
@@ -634,4 +634,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/zh-Hans.php
+++ b/language/zh-Hans.php
@@ -654,4 +654,5 @@ return array(
     'Server capabilities' => false,
     'Capabilities' => false,
     'Screen %s first emails' => false,
+    'Yaml File' => false,
 );

--- a/language/zh-Hans.php
+++ b/language/zh-Hans.php
@@ -655,4 +655,5 @@ return array(
     'Capabilities' => false,
     'Screen %s first emails' => false,
     'Yaml File' => false,
+    'Please ensure your YAML or CSV  file follows the correct format' => false,
 );

--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -609,3 +609,17 @@ function get_special_folders($mod, $id) {
     }
     return array();
 }
+
+/**
+ * @subpackage core/functions
+ */
+if (!hm_exists('check_file_upload')) {
+function check_file_upload($request, $key) {
+    if (!is_array($request->files) || !array_key_exists($key, $request->files)) {
+        return false;
+    }
+    if (!is_array($request->files[$key]) || !array_key_exists('tmp_name', $request->files[$key])) {
+        return false;
+    }
+    return true;
+}}

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -2183,12 +2183,12 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
                                             <span id="srv_setup_stepper_profile_name-error" class="invalid-feedback"></span>
                                         </div>
                                         <div class="form-floating mb-3">
-                                            <input required type="text" id="srv_setup_stepper_email" name="srv_setup_stepper_email" class="txt_fld form-control warn_on_paste" autocomplete="username" value="" placeholder="'.$this->trans('Email or Username').'">
+                                            <input required type="text" id="srv_setup_stepper_email" name="srv_setup_stepper_email" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Email or Username').'">
                                             <label class="" for="srv_setup_stepper_email">'.$this->trans('Email or Username').'</label>
                                             <span id="srv_setup_stepper_email-error" class="invalid-feedback"></span>
                                         </div>
                                         <div class="form-floating mb-3">
-                                            <input required type="password" id="srv_setup_stepper_password" name="srv_setup_stepper_password" autocomplete="current-password" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Password').'">
+                                            <input required type="password" id="srv_setup_stepper_password" name="srv_setup_stepper_password" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Password').'">
                                             <label class="" for="srv_setup_stepper_password">'.$this->trans('Password').'</label>
                                             <span id="srv_setup_stepper_password-error" class="invalid-feedback"></span>
                                         </div>

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -2183,12 +2183,12 @@ class Hm_Output_server_config_stepper extends Hm_Output_Module {
                                             <span id="srv_setup_stepper_profile_name-error" class="invalid-feedback"></span>
                                         </div>
                                         <div class="form-floating mb-3">
-                                            <input required type="text" id="srv_setup_stepper_email" name="srv_setup_stepper_email" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Email or Username').'">
+                                            <input required type="text" id="srv_setup_stepper_email" name="srv_setup_stepper_email" class="txt_fld form-control warn_on_paste" autocomplete="username" value="" placeholder="'.$this->trans('Email or Username').'">
                                             <label class="" for="srv_setup_stepper_email">'.$this->trans('Email or Username').'</label>
                                             <span id="srv_setup_stepper_email-error" class="invalid-feedback"></span>
                                         </div>
                                         <div class="form-floating mb-3">
-                                            <input required type="password" id="srv_setup_stepper_password" name="srv_setup_stepper_password" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Password').'">
+                                            <input required type="password" id="srv_setup_stepper_password" name="srv_setup_stepper_password" autocomplete="current-password" class="txt_fld form-control warn_on_paste" value="" placeholder="'.$this->trans('Password').'">
                                             <label class="" for="srv_setup_stepper_password">'.$this->trans('Password').'</label>
                                             <span id="srv_setup_stepper_password-error" class="invalid-feedback"></span>
                                         </div>

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1563,7 +1563,7 @@ if (!hm_exists('connect_to_imap_server')) {
             $context->user_config->get('enable_sieve_filter_setting', DEFAULT_ENABLE_SIEVE_FILTER)) {
             try {
 
-                include APP_PATH.'modules/sievefilters/hm-sieve.php';
+                include_once APP_PATH.'modules/sievefilters/hm-sieve.php';
                 $sieveClientFactory = new Hm_Sieve_Client_Factory();
                 $client = $sieveClientFactory->init(null, $server);
 

--- a/modules/nux/assets/data/server_accounts_sample.csv
+++ b/modules/nux/assets/data/server_accounts_sample.csv
@@ -1,2 +1,2 @@
-server_name;support_jmap;jmap_server;username;password;imap_port;imap_tls;imap_server;support_smtp;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
-Exemple;FALSE;;email@exemple.org;secret;993;TRUE;imap.exemple.org;TRUE;smtp.exemple.org;465;TRUE;tls://imap.exemple.org;4190
+server_name;jmap_server;jmap_hide_from_combined_view;username;password;imap_port;imap_tls;imap_hide_from_combined_view;imap_server;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
+Exemple;;FALSE;email@exemple.org;secret;993;TRUE;FALSE;imap.exemple.org;smtp.exemple.org;465;TRUE;tls://imap.exemple.org;4190

--- a/modules/nux/assets/data/server_accounts_sample.csv
+++ b/modules/nux/assets/data/server_accounts_sample.csv
@@ -1,2 +1,3 @@
-server_name;jmap_server;jmap_hide_from_combined_view;username;password;imap_port;imap_tls;imap_hide_from_combined_view;imap_server;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
-Exemple;;FALSE;email@exemple.org;secret;993;TRUE;FALSE;imap.exemple.org;smtp.exemple.org;465;TRUE;tls://imap.exemple.org;4190
+server_name;username;password;jmap_server;jmap_hide_from_combined_view;imap_server;imap_port;imap_tls;imap_hide_from_combined_view;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port;profile_reply_to;profile_signature;profile_is_default
+Mailbox 1;email@example.org;secret;;FALSE;imap.example.org;993;TRUE;FALSE;smtp.example.org;465;TRUE;tls://imap.exemple.org;4190;email@example.org;;FALSE
+Mailbox 2;test@example2.org;secret2;jmap.example2.org;FALSE;;;;;smtp.example2.org;465;TRUE;tls://jmap.example2.org;4190;test@example2.org;my-signature;TRUE

--- a/modules/nux/assets/data/server_accounts_sample.csv
+++ b/modules/nux/assets/data/server_accounts_sample.csv
@@ -1,0 +1,2 @@
+server_name;support_jmap;jmap_server;username;password;imap_port;imap_tls;imap_server;support_smtp;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
+Exemple;FALSE;;email@exemple.org;secret;993;TRUE;imap.exemple.org;TRUE;smtp.exemple.org;465;TRUE;tls://imap.exemple.org;4190

--- a/modules/nux/assets/data/server_accounts_sample.csv
+++ b/modules/nux/assets/data/server_accounts_sample.csv
@@ -1,2 +1,0 @@
-server_name;jmap_server;username;password;imap_port;imap_tls;imap_server;support_smtp;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
-Migadu;FALSE;;;993;TRUE;;;;465;TRUE;tls://imap.migadu.com;4190

--- a/modules/nux/assets/data/server_accounts_sample.csv
+++ b/modules/nux/assets/data/server_accounts_sample.csv
@@ -1,0 +1,2 @@
+server_name;jmap_server;username;password;imap_port;imap_tls;imap_server;support_smtp;smtp_server;smtp_port;smtp_tls;sieve_host;sieve_port
+Migadu;FALSE;;;993;TRUE;;;;465;TRUE;tls://imap.migadu.com;4190

--- a/modules/nux/assets/data/server_accounts_sample.yaml
+++ b/modules/nux/assets/data/server_accounts_sample.yaml
@@ -1,36 +1,36 @@
 Test1:
   jmap:
-    jmap_server:
+    server:
+    hide_from_combined_view: false
   user:
     username: email@example.org
     password: secret
   imap:
     port: 993
     tls: true
-    imap_server: imap.example.org
+    hide_from_combined_view: false
+    server: imap.example.org
   smtp:
-    support_smtp: true
-    smtp_server: smtp.example.org
-    smtp_port: 465
-    smtp_tls: true
+    server: smtp.example.org
+    port: 465
+    tls: true
   sieve:
-    sieve_host: tls://imap.example.org
-    sieve_port: 4190
+    host: tls://imap.example.org
+    port: 4190
 Test2:
   jmap:
-    jmap_server: 
+    server: 
   user:
     username: email@example.org
     password: secret
   imap:
     port: 993
     tls: true
-    imap_server: mail.example.org
+    server: mail.example.org
   smtp:
-    support_smtp: true
-    smtp_server: mail.example.org
-    smtp_port: 465
-    smtp_tls: true
+    server: mail.example.org
+    port: 465
+    tls: true
   sieve:
-    sieve_host: tls://mail.example.org
-    sieve_port: 4190
+    host: tls://mail.example.org
+    port: 4190

--- a/modules/nux/assets/data/server_accounts_sample.yaml
+++ b/modules/nux/assets/data/server_accounts_sample.yaml
@@ -1,36 +1,36 @@
-Migadu.com:
+Test1:
   jmap:
     jmap_server:
   user:
-    username: test@email.com
+    username: email@example.org
     password: secret
   imap:
     port: 993
     tls: true
-    imap_server: imap.migadu.com
+    imap_server: imap.example.org
   smtp:
     support_smtp: true
-    smtp_server: smtp.migadu.com
+    smtp_server: smtp.example.org
     smtp_port: 465
     smtp_tls: true
   sieve:
-    sieve_host: tls://imap.migadu.com
+    sieve_host: tls://imap.example.org
     sieve_port: 4190
-Postale.io:
+Test2:
   jmap:
     jmap_server: 
   user:
-    username: test@email.com
+    username: email@example.org
     password: secret
   imap:
     port: 993
     tls: true
-    imap_server: mail.postale.io
+    imap_server: mail.example.org
   smtp:
     support_smtp: true
-    smtp_server: mail.postale.io
+    smtp_server: mail.example.org
     smtp_port: 465
     smtp_tls: true
   sieve:
-    sieve_host: tls://mail.postale.io
+    sieve_host: tls://mail.example.org
     sieve_port: 4190

--- a/modules/nux/assets/data/server_accounts_sample.yaml
+++ b/modules/nux/assets/data/server_accounts_sample.yaml
@@ -1,0 +1,36 @@
+Migadu.com:
+  jmap:
+    jmap_server: 
+  user:
+    username: test@enterprisedepartment.com
+    password: 8xiK&z5TsQaJ!t
+  imap:
+    port: 993
+    tls: true
+    imap_server: imap.migadu.com
+  smtp:
+    support_smtp: true
+    smtp_server: smtp.migadu.com
+    smtp_port: 587
+    smtp_tls: true
+  sieve:
+    sieve_host: tls://imap.migadu.com
+    sieve_port: 4190
+Postale.io:
+  jmap:
+    jmap_server: 
+  user:
+    username: test@notrewiki.com
+    password: FuMxdfhCLD3vEuP5
+  imap:
+    port: 993
+    tls: true
+    imap_server: mail.postale.io
+  smtp:
+    support_smtp: true
+    smtp_server: mail.postale.io
+    smtp_port: 465
+    smtp_tls: true
+  sieve:
+    sieve_host: tls://mail.postale.io
+    sieve_port: 4190

--- a/modules/nux/assets/data/server_accounts_sample.yaml
+++ b/modules/nux/assets/data/server_accounts_sample.yaml
@@ -1,9 +1,9 @@
 Migadu.com:
   jmap:
-    jmap_server: 
+    jmap_server:
   user:
-    username: test@enterprisedepartment.com
-    password: 8xiK&z5TsQaJ!t
+    username: test@email.com
+    password: secret
   imap:
     port: 993
     tls: true
@@ -11,7 +11,7 @@ Migadu.com:
   smtp:
     support_smtp: true
     smtp_server: smtp.migadu.com
-    smtp_port: 587
+    smtp_port: 465
     smtp_tls: true
   sieve:
     sieve_host: tls://imap.migadu.com
@@ -20,8 +20,8 @@ Postale.io:
   jmap:
     jmap_server: 
   user:
-    username: test@notrewiki.com
-    password: FuMxdfhCLD3vEuP5
+    username: test@email.com
+    password: secret
   imap:
     port: 993
     tls: true

--- a/modules/nux/assets/data/server_accounts_sample.yaml
+++ b/modules/nux/assets/data/server_accounts_sample.yaml
@@ -1,15 +1,14 @@
-Test1:
+Mailbox 1:
+  username: email@example.org
+  password: secret
   jmap:
     server:
-    hide_from_combined_view: false
-  user:
-    username: email@example.org
-    password: secret
+    hide_from_combined_view:
   imap:
+    server: imap.example.org
     port: 993
     tls: true
     hide_from_combined_view: false
-    server: imap.example.org
   smtp:
     server: smtp.example.org
     port: 465
@@ -17,20 +16,29 @@ Test1:
   sieve:
     host: tls://imap.example.org
     port: 4190
-Test2:
+  profile:
+    reply_to: email@example.org
+    signature:
+    is_default: false
+Mailbox 2:
+  username: test@example2.org
+  password: secret2
   jmap:
-    server: 
-  user:
-    username: email@example.org
-    password: secret
+    server: jmap.example2.org
+    hide_from_combined_view: false
   imap:
-    port: 993
-    tls: true
-    server: mail.example.org
+    server:
+    port:
+    tls:
+    hide_from_combined_view:
   smtp:
-    server: mail.example.org
+    server: smtp.example2.org
     port: 465
     tls: true
   sieve:
-    host: tls://mail.example.org
+    host: tls://jmap.example2.org
     port: 4190
+  profile:
+    reply_to: test@example2.org
+    signature: my-signature
+    is_default: true

--- a/modules/nux/functions.php
+++ b/modules/nux/functions.php
@@ -1,0 +1,120 @@
+<?php
+use SplFileObject;
+
+/**
+ * NUX modules
+ * @package modules
+ * @subpackage nux
+ */
+
+if (!defined('DEBUG_MODE')) { die(); }
+
+/**
+ * Build a source list for sent folders
+ * @subpackage nux/functions
+ * @param string $file_path file path
+ * @param string $delimiter csv delimiter with default ;
+ * @return array
+ */
+if (!hm_exists('parse_csv_with_headers')) {
+function parse_csv_with_headers($file_path, $delimiter = ';') {
+    // Open the file
+    $file = new SplFileObject($file_path);
+    // Set the file to read as CSV
+    $file->setFlags(SplFileObject::DROP_NEW_LINE);
+
+    // Initialize an array to hold the rows
+    $rows = [];
+    $is_first_line = true;
+    $header = [];
+    // Loop through each line in the CSV file
+    while (!$file->eof()) {
+        // Get the line as a string
+        $line = $file->fgets();
+
+        // Skip empty lines (e.g., due to trailing newlines)
+        if ($line === [null] || $line === false) {
+            continue;
+        }
+
+        // Split the line into an array using the specified delimiter
+        $fields = explode($delimiter, $line);
+        // Process the header line
+        if ($is_first_line) {
+            $header = $fields;
+            $is_first_line = false;
+        } else {
+            // Ensure that the number of fields matches the header count
+            if (count($fields) === count($header)) {
+                // Combine the header and fields into an associative array
+                $rows[] = array_combine($header, $fields);
+            }
+        }
+    }
+    return $rows;
+}}
+
+/**
+ * @subpackage nux/functions
+ */
+if (!hm_exists('oauth2_form')) {
+    function oauth2_form($details, $mod)
+    {
+        $oauth2 = new Hm_Oauth2($details['client_id'], $details['client_secret'], $details['redirect_uri']);
+        $url = $oauth2->request_authorization_url($details['auth_uri'], $details['scope'], 'nux_authorization', $details['email']);
+        $res = '<input type="hidden" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
+        $res .= '<div class="nux_step_two_title fw-bold">' . $mod->html_safe($details['name']) . '</div><div class="mb-3">';
+        $res .= $mod->trans('This provider supports Oauth2 access to your account.');
+        $res .= $mod->trans(' This is the most secure way to access your E-mail. Click "Enable" to be redirected to the provider site to allow access.');
+        $res .= '</div><div class="mb-3"><a class="enable_auth2 btn btn-sm btn-success me-2" href="' . $url . '">' . $mod->trans('Enable') . '</a>';
+        $res .= '<a href="" class="reset_nux_form btn btn-sm btn-secondary">Reset</a></div>';
+        return $res;
+    }
+}
+
+/**
+ * @subpackage nux/functions
+ */
+if (!hm_exists('credentials_form')) {
+    function credentials_form($details, $mod)
+    {
+        $res = '<input type="hidden" id="nux_service" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
+        $res .= '<input type="hidden" name="nux_name" class="nux_name" value="' . $mod->html_safe($details['name']) . '" />';
+        $res .= '<div class="nux_step_two_title"><b>' . $mod->html_safe($details['name']) . '</b></div>';
+        $res .= $mod->trans('Enter your password for this E-mail provider to complete the connection process');
+
+        $res .= '<div class="row"><div class="col col-lg-4">';
+        // E-mail Address Field
+        $res .= '<div class="form-floating mb-3 mt-3">';
+        $res .= '<input type="email" class="form-control" id="nux_email" name="nux_email" placeholder="' . $mod->trans('E-mail Address') . '" value="' . $mod->html_safe($details['email']) . '">';
+        $res .= '<label for="nux_email">' . $mod->trans('E-mail Address') . '</label></div>';
+
+        // E-mail Password Field
+        $res .= '<div class="form-floating mb-3">';
+        $res .= '<input type="password" class="form-control nux_password" id="nux_password" name="nux_password" placeholder="' . $mod->trans('E-Mail Password') . '">';
+        $res .= '<label for="nux_password">' . $mod->trans('E-mail Password') . '</label></div>';
+
+        // Connect Button
+        $res .= '<input type="button" class="nux_submit px-5 btn btn-primary me-3" value="' . $mod->trans('Connect') . '">';
+
+        // Reset Link
+        $res .= '<a href="" class="reset_nux_form px-5 btn btn-secondary">Reset</a>';
+
+        $res .= '</div></div>';
+
+        return $res;
+    }
+}
+
+/**
+ * @subpackage nux/functions
+ */
+if (!hm_exists('data_source_available')) {
+    function data_source_available($mods, $types)
+    {
+        if (!is_array($types)) {
+            $types = array($types);
+        }
+        return count(array_intersect($types, $mods)) == count($types);
+    }
+}

--- a/modules/nux/functions.php
+++ b/modules/nux/functions.php
@@ -1,5 +1,4 @@
 <?php
-use SplFileObject;
 
 /**
  * NUX modules
@@ -47,11 +46,25 @@ function parse_csv_with_headers($file_path, $delimiter = ';') {
             // Ensure that the number of fields matches the header count
             if (count($fields) === count($header)) {
                 // Combine the header and fields into an associative array
-                $rows[] = array_combine($header, $fields);
+                $line_data = array_combine($header, $fields);
+                foreach ($line_data as $key => $value) {
+                    $line_data[$key] = convert_to_boolean($value);
+                }
+                $rows[] = $line_data;
             }
         }
     }
     return $rows;
+}}
+
+if (!hm_exists('convert_to_boolean')) {
+function convert_to_boolean($value) {
+    if (in_array($value, ['true', '1', 'yes'])) {
+        return true;
+    } elseif (in_array($value, ['false', '0', 'no'])) {
+        return false;
+    }
+    return $value;
 }}
 
 /**

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -1,5 +1,8 @@
 <?php
 
+use SplFileObject;
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * NUX modules
  * @package modules
@@ -7,10 +10,12 @@
  * @todo filter/disable features depending on imap module sets
  */
 
-if (!defined('DEBUG_MODE')) { die(); }
+if (!defined('DEBUG_MODE')) {
+    die();
+}
 
-require_once APP_PATH.'modules/nux/services.php';
-require_once APP_PATH.'modules/profiles/hm-profiles.php';
+require_once APP_PATH . 'modules/nux/services.php';
+require_once APP_PATH . 'modules/profiles/hm-profiles.php';
 
 /**
  * @subpackage nux/handler
@@ -38,7 +43,7 @@ class Hm_Handler_nux_dev_news extends Hm_Handler_Module {
                     return;
                 }
                 $json_commits = json_decode($curl_result);
-                foreach($json_commits as $c) {
+                foreach ($json_commits as $c) {
                     $msg = trim($c->commit->message);
                     $res[] = array(
                     'hash' => $c->sha,
@@ -58,8 +63,10 @@ class Hm_Handler_nux_dev_news extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_nux_homepage_data extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_nux_homepage_data extends Hm_Handler_Module
+{
+    public function process()
+    {
 
         $imap_servers = NULL;
         $smtp_servers = NULL;
@@ -94,8 +101,10 @@ class Hm_Handler_nux_homepage_data extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module
+{
+    public function process()
+    {
         if (array_key_exists('state', $this->request->get) && $this->request->get['state'] == 'nux_authorization') {
             if (array_key_exists('code', $this->request->get)) {
                 $details = $this->session->get('nux_add_service_details');
@@ -133,15 +142,12 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
                     $this->session->record_unsaved('IMAP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     $this->session->close_early();
-                }
-                else {
+                } else {
                     Hm_Msgs::add('ERRAn Error Occurred');
                 }
-            }
-            elseif (array_key_exists('error', $this->request->get)) {
-                Hm_Msgs::add('ERR'.ucwords(str_replace('_', ' ', $this->request->get['error'])));
-            }
-            else {
+            } elseif (array_key_exists('error', $this->request->get)) {
+                Hm_Msgs::add('ERR' . ucwords(str_replace('_', ' ', $this->request->get['error'])));
+            } else {
                 Hm_Msgs::add('ERRAn Error Occurred');
             }
             $this->save_hm_msgs();
@@ -153,16 +159,18 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_process_nux_add_service extends Hm_Handler_Module
+{
+    public function process()
+    {
         list($success, $form) = $this->process_form(array('nux_pass', 'nux_service', 'nux_email', 'nux_name'));
         if ($success) {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
                 $details = Nux_Quick_Services::details($form['nux_service']);
                 $details['name'] = $form['nux_name'];
                 if ($form['nux_service'] == 'all-inkl') {
-                    $details['server'] = $this->request->post['nux_all_inkl_login'].$details['server'];
-                    $details['smtp']['server'] = $this->request->post['nux_all_inkl_login'].$details['smtp']['server'] ;
+                    $details['server'] = $this->request->post['nux_all_inkl_login'] . $details['server'];
+                    $details['smtp']['server'] = $this->request->post['nux_all_inkl_login'] . $details['smtp']['server'];
                 }
                 $imap_list = array(
                     'name' => $details['name'],
@@ -202,12 +210,9 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->save_hm_msgs();
                     $this->session->close_early();
                     $this->out('nux_account_added', true);
-                    if ($this->module_is_supported('imap_folders')) {
-                        $this->out('nux_server_id', $new_id);
-                        $this->out('nux_service_name', $form['nux_service']);
-                    }
-                }
-                else {
+                    $this->out('nux_server_id', $new_id);
+                    $this->out('nux_service_name', $form['nux_service']);
+                } else {
                     Hm_IMAP_List::del($new_id);
                     Hm_Msgs::add('ERRAuthentication failed');
                 }
@@ -219,8 +224,10 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_setup_nux extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_setup_nux extends Hm_Handler_Module
+{
+    public function process()
+    {
         Nux_Quick_Services::oauth2_setup($this->config);
     }
 }
@@ -228,8 +235,10 @@ class Hm_Handler_setup_nux extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_nux_service extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_process_nux_service extends Hm_Handler_Module
+{
+    public function process()
+    {
         list($success, $form) = $this->process_form(array('nux_service', 'nux_email'));
         if ($success) {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
@@ -249,8 +258,10 @@ class Hm_Handler_process_nux_service extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_get_nux_service_details extends Hm_Handler_Module {
-    public function process() {
+class Hm_Handler_get_nux_service_details extends Hm_Handler_Module
+{
+    public function process()
+    {
         list($success, $form) = $this->process_form(array('nux_service'));
         if ($success) {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
@@ -264,31 +275,133 @@ class Hm_Handler_get_nux_service_details extends Hm_Handler_Module {
 }
 
 /**
+ * @subpackage nux/handler
+ */
+class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
+{
+    public function process()
+    {
+        list($success, $form) = $this->process_form(array('accounts_source'));
+
+        if ($success) {
+            // if($form['accounts_source'] == 'yaml') {
+            // $file = $this->request->files['accounts_csv'];
+            $file = WEB_ROOT . 'modules/nux/assets/data/server_accounts_sample.yaml';
+            // 
+            // if(!is_null($file) && $file['type'] == 'text/yaml') {
+            try {
+                $servers = Yaml::parseFile($file); //$file['tmp_name']
+
+                foreach ($servers as $key => $value) {
+                    if (empty($value['user']['username']) or empty($value['user']['password'])) {
+                        Hm_Msgs::add('ERRUsername and password are required for: ' . $key . ' server');
+                        return;
+                    }
+                    if ($value['jmap'] && !empty($value['jmap']['jmap_server'])) {
+                        if (!$this->module_is_supported('jmap')) {
+                            Hm_Msgs::add("ERRJMAP module is not enabled");
+                            return;
+                        }
+                        connect_to_imap_server(
+                            $value['imap']['imap_server'],
+                            $key,
+                            null,
+                            $value['user']['username'],
+                            $value['user']['password'],
+                            false,
+                            null,
+                            false,
+                            'jmap',
+                            $this,
+                            false
+                        );
+                        Hm_Msgs::add("JMAP Server " . $key . " saved");
+                    }
+                    if ($value['smtp'] && !empty($value['smtp']['smtp_server'])) {
+                        // Check if module is supported
+                        if (!$this->module_is_supported('smtp')) {
+                            Hm_Msgs::add("ERRSMTP module is not enabled");
+                        } else {
+                            //TO DO: check first if the smtp_server server is already configured before connecting. can use the in_server_list function or create a new one specifically for my case
+                            $smtp_server_id = connect_to_smtp_server(
+                                $value['smtp']['smtp_server'],
+                                $key,
+                                $value['smtp']['smtp_port'],
+                                $value['user']['username'],
+                                $value['user']['password'],
+                                $value['smtp']['smtp_tls'],
+                                $this
+                            );
+                            var_dump('smtp_server_id', $smtp_server_id);
+                            die();
+                            Hm_Msgs::add("SMTP Server " . $key . " saved");
+                        }
+                    }
+
+                    if ($value['imap'] && !empty($value['imap']['imap_server'])) {
+                        // Check if module is supported
+                        if (!$this->module_is_supported('imap')) {
+                            Hm_Msgs::add("ERRIMAP module is not enabled");
+                            return;
+                        }
+                        //TO DO: check first if the imap_server server is already configured before connecting can use the in_server_list function or create a new one specifically for my case
+                        connect_to_imap_server(
+                            $value['imap']['imap_server'],
+                            $key,
+                            $value['imap']['port'],
+                            $value['user']['username'],
+                            $value['user']['password'],
+                            $value['imap']['tls'],
+                            $value['sieve']['sieve_host'],
+                            $value['sieve']['sieve_port'],
+                            'imap',
+                            $this
+                        );
+                        Hm_Msgs::add("Server " . $key . "  saved");
+                    }
+                }
+            } catch (\Throwable $th) {
+                Hm_Msgs::add('ERR' . $th->getMessage());
+                exit(var_dump($th->getMessage()));
+                Hm_Dispatch::page_redirect('?page=servers');
+            }
+            // }
+            // }
+        } else {
+            // TODO: Add error message and redirect back
+        }
+    }
+}
+
+
+/**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_dialog extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_quick_add_dialog extends Hm_Output_Module
+{
+    protected function output()
+    {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        return '<div class="quick_add_section">'.
-            '<div class="nux_step_one px-4 pt-">'.
-            '<p class="py-3">'.$this->trans('Quickly add an account from popular E-mail providers. To manually configure an account, use the IMAP/SMTP sections below.').'</p>'.
-            '<div class="row"><div class="col col-xl-7"><div class="form-floating mb-3">'.
-            ' <select id="service_select" name="service_select" class="form-select">'.
-            '<option value="">'.$this->trans('Select an E-mail provider').'</option>'.
-            Nux_Quick_Services::option_list(false, $this).'</select>'.
-            '<label for="service_select">'.$this->trans('Select an E-mail provider').'</label></div>'.
+        return '<div class="quick_add_section">' .
+            '<div class="nux_step_one px-4 pt-">' .
+            '<p class="py-3">' . $this->trans('Quickly add an account from popular E-mail providers. To manually configure an account, use the IMAP/SMTP sections below.') . '</p>' .
+            '<div class="row"><div class="col col-lg-4"><div class="form-floating mb-3">' .
+            ' <select id="service_select" name="service_select" class="form-select">' .
+            '<option value="">' . $this->trans('Select an E-mail provider') . '</option>' .
+            Nux_Quick_Services::option_list(false, $this) . '</select>' .
+            '<label for="service_select">' . $this->trans('Select an E-mail provider') . '</label></div>' .
 
-            '<div class="form-floating mb-3">'.
-            '<input type="email" id="nux_username" class="form-control nux_username" placeholder="'.$this->trans('Your E-mail address').'">'.
-            '<label for="nux_username">'.$this->trans('Username').'</label></div>'.
+            '<div class="form-floating mb-3">' .
+            '<input type="email" id="nux_username" class="form-control nux_username" placeholder="' . $this->trans('Your E-mail address') . '">' .
+            '<label for="nux_username">' . $this->trans('Username') . '</label></div>' .
 
-            '<div class="form-floating mb-3">'.
-            '<input type="text" id="nux_account_name" class="form-control nux_account_name" placeholder="'.$this->trans('Account Name [optional]').'">'.
-            '<label for="nux_account_name">'.$this->trans('Account name').'</label></div>'.
+            '<div class="form-floating mb-3">' .
+            '<input type="text" id="nux_account_name" class="form-control nux_account_name" placeholder="' . $this->trans('Account Name [optional]') . '">' .
+            '<label for="nux_account_name">' . $this->trans('Account name') . '</label></div>' .
 
-            '<input type="button" class="nux_next_button btn btn-primary btn-md px-5" value="'.$this->trans('Next').'">'.
+            '<input type="button" class="nux_next_button btn btn-primary btn-md px-5" value="' . $this->trans('Next') . '">' .
             '</div></div></div><div class="nux_step_two px-4 pt-3"></div></div>';
     }
 }
@@ -296,14 +409,44 @@ class Hm_Output_quick_add_dialog extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_filter_service_select extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_quick_add_multiple_dialog extends Hm_Output_Module
+{
+    protected function output()
+    {
+        if ($this->get('single_server_mode')) {
+            return '';
+        }
+        $title = $this->trans('Import from CSV file');
+        $notice = 'Please ensure your CSV header file follows the format: server_name, username, password, imap_server, imap_port, imap_tls, smtp_server, smtp_port, smtp_tls, sieve_host, sieve_port.';
+        $csv_sample_path = WEB_ROOT . 'modules/nux/assets/data/server_accounts_sample.csv';
+
+        return '<div class="quick_add_multiple_section">' .
+            '<div class="row"><div class="col col-lg-4"><div class="form-floating mb-3">' .
+            '<form class="quick_add_multiple_server_form" action="?page=add_multiple_servers" method="POST" enctype="multipart/form-data">' .
+            '<button class="browser_acc_csv mt-2 btn btn-light" title="' . $notice . '"><i class="bi bi-filetype-csv me-2"></i>' . $title . '</button>' .
+            '<div class="server_form">' .
+            '<div><a href="' . $csv_sample_path . '">' . $this->trans('download a sample csv file') . '</a></div><br />' .
+            '<input type="hidden" name="hm_page_key" value="' . $this->html_safe(Hm_Request_Key::generate()) . '" />' .
+            '<input type="hidden" name="accounts_source" value="yaml" />' .
+            '<label class="screen_reader" for="accounts_csv">' . $this->trans('Csv File') . '</label>' .
+            '<input class="form-control" id="accounts_csv" type="file" name="accounts_csv" accept=".csv,.yaml"/> <br />' .
+            '<input class="btn btn-primary add_multiple_server_submit" type="submit" name="import_contact" id="import_contact" value="' . $this->trans('Add') . '" /> <input type="button" class="btn btn-secondary reset_add_multiple_server" value="' .
+            $this->trans('Cancel') . '" /></div></form></div></div></div></div></div>';
+    }
+}
+
+/**
+ * @subpackage nux/output
+ */
+class Hm_Output_filter_service_select extends Hm_Output_Module
+{
+    protected function output()
+    {
         $details = $this->get('nux_add_service_details', array());
         if (!empty($details)) {
             if (array_key_exists('auth', $details) && $details['auth'] == 'oauth2') {
                 $this->out('nux_service_step_two',  oauth2_form($details, $this));
-            }
-            else {
+            } else {
                 $this->out('nux_service_step_two',  credentials_form($details, $this));
             }
         }
@@ -313,8 +456,10 @@ class Hm_Output_filter_service_select extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_service_details extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_service_details extends Hm_Output_Module
+{
+    protected function output()
+    {
         $details = $this->get('nux_add_service_details', array());
         $this->out('service_details',  json_encode($details));
     }
@@ -330,8 +475,9 @@ class Hm_Output_nux_dev_news extends Hm_Output_Module {
         }
         $res = '<div class="nux_dev_news mt-3 col-12"><div class="card"><div class="card-body"><div class="card_title"><h4>'.$this->trans('Development Updates').'</h4></div><table>';
         foreach ($this->get('nux_dev_news', array()) as $vals) {
-            $res .= sprintf('<tr><td><a href="https://github.com/cypht-org/cypht/commit/%s" target="_blank" rel="noopener">%s</a>'.
-                '</td><td class="msg_date">%s</td><td>%s</td><td>%s</td></tr>',
+            $res .= sprintf(
+                '<tr><td><a href="https://github.com/cypht-org/cypht/commit/%s" target="_blank" rel="noopener">%s</a>' .
+                    '</td><td class="msg_date">%s</td><td>%s</td><td>%s</td></tr>',
                 $this->html_safe($vals['hash']),
                 $this->html_safe($vals['shash']),
                 $this->html_safe($vals['name']),
@@ -358,8 +504,10 @@ class Hm_Output_nux_help extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_welcome_dialog extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_welcome_dialog extends Hm_Output_Module
+{
+    protected function output()
+    {
         if ($this->get('single_server_mode')) {
             return '';
         }
@@ -367,9 +515,9 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module {
         $tz = $this->get('tzone');
         $protos = array('imap', 'smtp', 'feeds', 'profiles');
 
-        $res = '<div class="nux_welcome mt-3 col-lg-6 col-md-5 col-sm-12"><div class="card"><div class="card-body"><div class="card-title"><h4>'.$this->trans('Welcome to Cypht').'</h4></div>';
-        $res .= '<div class="mb-3"><p>'.$this->trans('Add a popular E-mail source quickly and easily').'</p>';
-        $res .= '<a class="mt-3 btn btn-light" href="?page=servers#quick_add_section"><i class="bi bi-person-plus me-3"></i>'.$this->trans('Add an E-mail Account').'</a>';
+        $res = '<div class="nux_welcome mt-3 col-lg-6 col-md-5 col-sm-12"><div class="card"><div class="card-body"><div class="card-title"><h4>' . $this->trans('Welcome to Cypht') . '</h4></div>';
+        $res .= '<div class="mb-3"><p>' . $this->trans('Add a popular E-mail source quickly and easily') . '</p>';
+        $res .= '<a class="mt-3 btn btn-light" href="?page=servers#quick_add_section"><i class="bi bi-person-plus me-3"></i>' . $this->trans('Add an E-mail Account') . '</a>';
         $res .= '</div><ul class="mt-4">';
 
         foreach ($protos as $proto) {
@@ -377,7 +525,7 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module {
             if ($proto == 'feeds') {
                 $proto_dsp = 'RSS/ATOM';
             }
-            $res .= '<li class="nux_'.$proto.' mt-3">';
+            $res .= '<li class="nux_' . $proto . ' mt-3">';
 
             // Check if user have profiles configured
             if ($proto == 'profiles') {
@@ -399,8 +547,7 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module {
             elseif ($server_data[$proto] === 0) {
                 $res .= sprintf($this->trans('You don\'t have any %s sources'), mb_strtoupper($proto_dsp));
                 $res .= sprintf(' <a href="?page=servers#%s_section">%s</a>', $proto, $this->trans('Add'));
-            }
-            else {
+            } else {
                 if ($server_data[$proto] > 1) {
                     $res .= sprintf($this->trans('You have %d %s sources'), $server_data[$proto], mb_strtoupper($proto_dsp));
                 }
@@ -415,11 +562,10 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module {
         $res .= '<div class="nux_tz">';
         if (!$tz) {
             $res .= $this->trans('Your timezone is NOT set');
-        }
-        else {
+        } else {
             $res .= sprintf($this->trans('Your timezone is set to %s'), $this->html_safe($tz));
         }
-        $res .= ' <a href="?page=settings#general_setting">'.$this->trans('Update').'</a></div></div></div></div>';
+        $res .= ' <a href="?page=settings#general_setting">' . $this->trans('Update') . '</a></div></div></div></div>';
         return $res;
     }
 }
@@ -427,11 +573,13 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_nux_message_list_notice extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_nux_message_list_notice extends Hm_Output_Module
+{
+    protected function output()
+    {
         $msg = '<div class="nux_empty_combined_view">';
         $msg .= $this->trans('You don\'t have any data sources assigned to this page.');
-        $msg .= '<br /><a href="?page=servers">'.$this->trans('Add some').'</a>';
+        $msg .= '<br /><a href="?page=servers">' . $this->trans('Add some') . '</a>';
         $msg .= '</div>';
         return $msg;
     }
@@ -440,14 +588,31 @@ class Hm_Output_nux_message_list_notice extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_section extends Hm_Output_Module {
-    protected function output() {
+class Hm_Output_quick_add_section extends Hm_Output_Module
+{
+    protected function output()
+    {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        return '<div class="nux_add_account"><div data-target=".quick_add_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">'.
-            '<i class="bi bi-check-circle-fill me-3"></i>'.
-            '<b>'.$this->trans('Add an E-mail Account').'</b></a></div>';
+        return '<div class="nux_add_account"><div data-target=".quick_add_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">' .
+            '<i class="bi bi-check-circle-fill me-3"></i>' .
+            '<b>' . $this->trans('Add an E-mail Account') . '</b></a></div>';
+    }
+}
+/**
+ * @subpackage nux/output
+ */
+class Hm_Output_quick_add_multiple_section extends Hm_Output_Module
+{
+    protected function output()
+    {
+        if ($this->get('single_server_mode')) {
+            return '';
+        }
+        return '<div class="nux_add_multiple_account"><div data-target=".quick_add_multiple_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">' .
+            '<i class="bi bi-filetype-csv me-3"></i>' .
+            '<b>' . $this->trans('Bulk-import accounts using csv template') . '</b></a></div>';
     }
 }
 
@@ -455,26 +620,29 @@ class Hm_Output_quick_add_section extends Hm_Output_Module {
  * @subpackage nux/functions
  */
 if (!hm_exists('oauth2_form')) {
-function oauth2_form($details, $mod) {
-    $oauth2 = new Hm_Oauth2($details['client_id'], $details['client_secret'], $details['redirect_uri']);
-    $url = $oauth2->request_authorization_url($details['auth_uri'], $details['scope'], 'nux_authorization', $details['email']);
-    $res = '<input type="hidden" name="nux_service" value="'.$mod->html_safe($details['id']).'" />';
-    $res .= '<div class="nux_step_two_title fw-bold">'.$mod->html_safe($details['name']).'</div><div class="mb-3">';
-    $res .= $mod->trans('This provider supports Oauth2 access to your account.');
-    $res .= $mod->trans(' This is the most secure way to access your E-mail. Click "Enable" to be redirected to the provider site to allow access.');
-    $res .= '</div><div class="mb-3"><a class="enable_auth2 btn btn-sm btn-success me-2" href="'.$url.'">'.$mod->trans('Enable').'</a>';
-    $res .= '<a href="" class="reset_nux_form btn btn-sm btn-secondary">Reset</a></div>';
-    return $res;
-}}
+    function oauth2_form($details, $mod)
+    {
+        $oauth2 = new Hm_Oauth2($details['client_id'], $details['client_secret'], $details['redirect_uri']);
+        $url = $oauth2->request_authorization_url($details['auth_uri'], $details['scope'], 'nux_authorization', $details['email']);
+        $res = '<input type="hidden" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
+        $res .= '<div class="nux_step_two_title fw-bold">' . $mod->html_safe($details['name']) . '</div><div class="mb-3">';
+        $res .= $mod->trans('This provider supports Oauth2 access to your account.');
+        $res .= $mod->trans(' This is the most secure way to access your E-mail. Click "Enable" to be redirected to the provider site to allow access.');
+        $res .= '</div><div class="mb-3"><a class="enable_auth2 btn btn-sm btn-success me-2" href="' . $url . '">' . $mod->trans('Enable') . '</a>';
+        $res .= '<a href="" class="reset_nux_form btn btn-sm btn-secondary">Reset</a></div>';
+        return $res;
+    }
+}
 
 /**
  * @subpackage nux/functions
  */
 if (!hm_exists('credentials_form')) {
-    function credentials_form($details, $mod) {
-        $res = '<input type="hidden" id="nux_service" name="nux_service" value="'.$mod->html_safe($details['id']).'" />';
-        $res .= '<input type="hidden" name="nux_name" class="nux_name" value="'.$mod->html_safe($details['name']).'" />';
-        $res .= '<div class="nux_step_two_title"><b>'.$mod->html_safe($details['name']).'</b></div>';
+    function credentials_form($details, $mod)
+    {
+        $res = '<input type="hidden" id="nux_service" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
+        $res .= '<input type="hidden" name="nux_name" class="nux_name" value="' . $mod->html_safe($details['name']) . '" />';
+        $res .= '<div class="nux_step_two_title"><b>' . $mod->html_safe($details['name']) . '</b></div>';
         $res .= $mod->trans('Enter your password for this E-mail provider to complete the connection process');
 
         $res .= '<div class="row"><div class="col col-lg-4">';
@@ -489,7 +657,7 @@ if (!hm_exists('credentials_form')) {
         $res .= '<label for="nux_password">'.$mod->trans('E-mail Password').'</label></div>';
 
         // Connect Button
-        $res .= '<input type="button" class="nux_submit px-5 btn btn-primary me-3" value="'.$mod->trans('Connect').'">';
+        $res .= '<input type="button" class="nux_submit px-5 btn btn-primary me-3" value="' . $mod->trans('Connect') . '">';
 
         // Reset Link
         $res .= '<a href="" class="reset_nux_form px-5 btn btn-secondary">Reset</a>';
@@ -503,26 +671,45 @@ if (!hm_exists('credentials_form')) {
 /**
  * @subpackage nux/functions
  */
-if (!hm_exists('data_source_available')) {
-function data_source_available($mods, $types) {
-    if (!is_array($types)) {
-        $types = array($types);
+if (!hm_exists('parse_yaml_file')) {
+    function parse_yaml_file($filePath)
+    {
+        $yamlContent = file_get_contents($filePath);
+
+        $data = yaml_parse_file($filePath);
+
+        return $data;
     }
-    return count( array_intersect($types, $mods) ) == count( $types );
-}}
+}
+
+/**
+ * @subpackage nux/functions
+ */
+if (!hm_exists('data_source_available')) {
+    function data_source_available($mods, $types)
+    {
+        if (!is_array($types)) {
+            $types = array($types);
+        }
+        return count(array_intersect($types, $mods)) == count($types);
+    }
+}
 
 /**
  * @subpackage nux/lib
  */
-class Nux_Quick_Services {
+class Nux_Quick_Services
+{
 
     static private $services = array();
     static private $oauth2 = array();
 
-    static public function add($id, $details) {
+    static public function add($id, $details)
+    {
         self::$services[$id] = $details;
     }
-    static public function oauth2_setup($config) {
+    static public function oauth2_setup($config)
+    {
         $services = array_keys(config('oauth2'));
         foreach ($services as $service) {
             $vals = $config->get($service, []);
@@ -539,25 +726,30 @@ class Nux_Quick_Services {
         self::$oauth2 = config('oauth2');
     }
 
-    static public function option_list($current, $mod) {
+    static public function option_list($current, $mod)
+    {
         $res = '';
-        uasort(self::$services, function($a, $b) { return strcasecmp($a['name'], $b['name']); });
-        foreach(self::$services as $id => $details) {
-            $res .= '<option value="'.$mod->html_safe($id).'"';
+        uasort(self::$services, function ($a, $b) {
+            return strcasecmp($a['name'], $b['name']);
+        });
+        foreach (self::$services as $id => $details) {
+            $res .= '<option value="' . $mod->html_safe($id) . '"';
             if ($id == $current) {
                 $res .= ' selected="selected"';
             }
-            $res .= '>'.$mod->trans($details['name']);
+            $res .= '>' . $mod->trans($details['name']);
             $res .= '</option>';
         }
         return $res;
     }
 
-    static public function exists($id) {
+    static public function exists($id)
+    {
         return array_key_exists($id, self::$services);
     }
 
-    static public function details($id) {
+    static public function details($id)
+    {
         if (array_key_exists($id, self::$services)) {
             return self::$services[$id];
         }

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -1,6 +1,4 @@
 <?php
-
-use SplFileObject;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -10,10 +8,9 @@ use Symfony\Component\Yaml\Yaml;
  * @todo filter/disable features depending on imap module sets
  */
 
-if (!defined('DEBUG_MODE')) {
-    die();
-}
+if (!defined('DEBUG_MODE')) { die(); }
 
+require_once APP_PATH.'modules/nux/functions.php';
 require_once APP_PATH . 'modules/nux/services.php';
 require_once APP_PATH . 'modules/profiles/hm-profiles.php';
 
@@ -43,7 +40,7 @@ class Hm_Handler_nux_dev_news extends Hm_Handler_Module {
                     return;
                 }
                 $json_commits = json_decode($curl_result);
-                foreach ($json_commits as $c) {
+                foreach($json_commits as $c) {
                     $msg = trim($c->commit->message);
                     $res[] = array(
                     'hash' => $c->sha,
@@ -63,10 +60,8 @@ class Hm_Handler_nux_dev_news extends Hm_Handler_Module {
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_nux_homepage_data extends Hm_Handler_Module
-{
-    public function process()
-    {
+class Hm_Handler_nux_homepage_data extends Hm_Handler_Module {
+    public function process() {
 
         $imap_servers = NULL;
         $smtp_servers = NULL;
@@ -101,10 +96,8 @@ class Hm_Handler_nux_homepage_data extends Hm_Handler_Module
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module
-{
-    public function process()
-    {
+class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
+    public function process() {
         if (array_key_exists('state', $this->request->get) && $this->request->get['state'] == 'nux_authorization') {
             if (array_key_exists('code', $this->request->get)) {
                 $details = $this->session->get('nux_add_service_details');
@@ -142,15 +135,19 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module
                     $this->session->record_unsaved('IMAP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     $this->session->close_early();
-                } else {
+                }
+                else {
                     Hm_Msgs::add('ERRAn Error Occurred');
                 }
-            } elseif (array_key_exists('error', $this->request->get)) {
-                Hm_Msgs::add('ERR' . ucwords(str_replace('_', ' ', $this->request->get['error'])));
-            } else {
+            }
+            elseif (array_key_exists('error', $this->request->get)) {
+                Hm_Msgs::add('ERR'.ucwords(str_replace('_', ' ', $this->request->get['error'])));
+            }
+            else {
                 Hm_Msgs::add('ERRAn Error Occurred');
             }
             $this->save_hm_msgs();
+            Hm_Dispatch::page_redirect('?page=servers');
         }
     }
 }
@@ -158,18 +155,16 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_nux_add_service extends Hm_Handler_Module
-{
-    public function process()
-    {
+class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
+    public function process() {
         list($success, $form) = $this->process_form(array('nux_pass', 'nux_service', 'nux_email', 'nux_name'));
         if ($success) {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
                 $details = Nux_Quick_Services::details($form['nux_service']);
                 $details['name'] = $form['nux_name'];
                 if ($form['nux_service'] == 'all-inkl') {
-                    $details['server'] = $this->request->post['nux_all_inkl_login'] . $details['server'];
-                    $details['smtp']['server'] = $this->request->post['nux_all_inkl_login'] . $details['smtp']['server'];
+                    $details['server'] = $this->request->post['nux_all_inkl_login'].$details['server'];
+                    $details['smtp']['server'] = $this->request->post['nux_all_inkl_login'].$details['smtp']['server'] ;
                 }
                 $imap_list = array(
                     'name' => $details['name'],
@@ -209,9 +204,12 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module
                     $this->save_hm_msgs();
                     $this->session->close_early();
                     $this->out('nux_account_added', true);
-                    $this->out('nux_server_id', $new_id);
-                    $this->out('nux_service_name', $form['nux_service']);
-                } else {
+                    if ($this->module_is_supported('imap_folders')) {
+                        $this->out('nux_server_id', $new_id);
+                        $this->out('nux_service_name', $form['nux_service']);
+                    }
+                }
+                else {
                     Hm_IMAP_List::del($new_id);
                     Hm_Msgs::add('ERRAuthentication failed');
                 }
@@ -223,10 +221,8 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_setup_nux extends Hm_Handler_Module
-{
-    public function process()
-    {
+class Hm_Handler_setup_nux extends Hm_Handler_Module {
+    public function process() {
         Nux_Quick_Services::oauth2_setup($this->config);
     }
 }
@@ -234,10 +230,8 @@ class Hm_Handler_setup_nux extends Hm_Handler_Module
 /**
  * @subpackage nux/handler
  */
-class Hm_Handler_process_nux_service extends Hm_Handler_Module
-{
-    public function process()
-    {
+class Hm_Handler_process_nux_service extends Hm_Handler_Module {
+    public function process() {
         list($success, $form) = $this->process_form(array('nux_service', 'nux_email'));
         if ($success) {
             if (Nux_Quick_Services::exists($form['nux_service'])) {
@@ -281,166 +275,182 @@ class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
         list($success, $form) = $this->process_form(array('accounts_source'));
 
         if ($success) {
-            $file = $this->request->files['accounts_sample'];
-            if (!is_null($file) && $file['type'] == 'application/x-yaml') {
+            if (!is_array($this->request->files) || !array_key_exists('accounts_sample', $this->request->files)) {
+                return;
+            }
+            if (!is_array($this->request->files['accounts_sample']) || !array_key_exists('tmp_name', $this->request->files['accounts_sample'])) {
+                return;
+            }
+
+            if ($this->request->files['accounts_sample']['type'] == 'application/x-yaml') {
                 try {
-                    $servers = Yaml::parseFile($file['tmp_name']);
-                } catch (\Throwable $th) {
-                    Hm_Msgs::add('ERR' . $th->getMessage());
-                    $this->save_hm_msgs();
-                    Hm_Dispatch::page_redirect('?page=servers');
-                }
-                foreach ($servers as $key => $value) {
-                    if (empty($value['user']['username']) or empty($value['user']['password'])) {
-                        Hm_Msgs::add('ERRUsername and password are required for: ' . $key . ' server');
-                        return;
-                    }
-                    if ($value['jmap'] && !empty($value['jmap']['jmap_server'])) {
-                        if (!$this->module_is_supported('jmap')) {
-                            Hm_Msgs::add("ERRJMAP module is not enabled");
+                    $servers = Yaml::parseFile($this->request->files['accounts_sample']['tmp_name']);
+                    foreach ($servers as $key => $value) {
+                        if (empty($value['user']['username']) or empty($value['user']['password'])) {
+                            Hm_Msgs::add('ERRUsername and password are required for: ' . $key . ' server');
                             return;
                         }
-                        connect_to_imap_server(
-                            $value['jmap']['jmap_server'],
-                            $key,
-                            null,
-                            $value['user']['username'],
-                            $value['user']['password'],
-                            false,
-                            null,
-                            false,
-                            'jmap',
-                            $this,
-                            false
-                        );
-                        Hm_Msgs::add("JMAP Server " . $key . " saved");
-                    }
-                    if ($value['smtp'] && !empty($value['smtp']['smtp_server'])) {
-                        // Check if module is supported
-                        if (!$this->module_is_supported('smtp')) {
-                            Hm_Msgs::add("ERRSMTP module is not enabled");
-                        } else {
-                            //TO DO: check first if the smtp_server server is already configured before connecting. can use the in_server_list function or create a new one specifically for my case
-                            $smtp_server_id = connect_to_smtp_server(
-                                $value['smtp']['smtp_server'],
-                                $key,
-                                $value['smtp']['smtp_port'],
-                                $value['user']['username'],
-                                $value['user']['password'],
-                                $value['smtp']['smtp_tls'],
-                                false
-                            );
-                            Hm_Msgs::add("SMTP Server " . $key . " saved");
-                        }
-                    }
-
-                    if ($value['imap'] && !empty($value['imap']['imap_server'])) {
-                        // Check if module is supported
-                        if (!$this->module_is_supported('imap')) {
-                            Hm_Msgs::add("ERRIMAP module is not enabled");
-                            return;
-                        }
-                        //TO DO: check first if the imap_server server is already configured before connecting can use the in_server_list function or create a new one specifically for my case
-                        $imap_server_id = connect_to_imap_server(
-                            $value['imap']['imap_server'],
-                            $key,
-                            $value['imap']['port'],
-                            $value['user']['username'],
-                            $value['user']['password'],
-                            $value['imap']['tls'],
-                            $value['sieve']['sieve_host'],
-                            $value['sieve']['sieve_port'],
-                            'imap',
-                            $this
-                        );
-                        Hm_Msgs::add("Server " . $key . "  saved");
-                    }
-                }
-
-                $this->save_hm_msgs();
-            }elseif(!is_null($file) && $file['type'] == 'text/csv'){
-                try {
-                    $file = new SplFileObject($file['tmp_name']);
-                    // Set the file to read as CSV
-                    $file->setFlags(SplFileObject::READ_CSV);
-                    $is_first_line = true;
-                    // Loop through each line in the CSV file
-                    while (!$file->eof()) {
-                        $line = $file->fgetcsv();
-                        // Skip processing if it's the first line
-                        if ($is_first_line) {
-                            $is_first_line = false;
-                            continue;
-                        }
-                        // Check if line is not empty to avoid processing false empty line
-                        if ($line && !empty(array_filter($line))) {
-                            // Process the CSV line here
-                            $server_data = explode(';', $line[0]);
-                            //check jmap support and jmap host address data
-                            if ($server_data[1] && !empty($server_data[2])) {
-                                if (!$this->module_is_supported('jmap')) {
-                                    Hm_Msgs::add("ERRJMAP module is not enabled");
-                                }else {
-                                connect_to_imap_server(
-                                    $server_data[2],
-                                    $server_data[0],
+                        if ($value['jmap'] && !empty($value['jmap']['server'])) {
+                            if (!$this->module_is_supported('jmap')) {
+                                Hm_Msgs::add("ERRJMAP module is not enabled");
+                            }else {
+                                $jmap_server_id = connect_to_imap_server(
+                                    $value['jmap']['server'],
+                                    $key,
                                     null,
-                                    $server_data[3],
-                                    $server_data[4],
+                                    $value['user']['username'],
+                                    $value['user']['password'],
                                     false,
                                     null,
                                     false,
                                     'jmap',
                                     $this,
-                                    false
+                                    $value['imap']['hide_from_combined_view']
                                 );
-                                Hm_Msgs::add("JMAP Server " . $server_data[0] . " saved");
+                                if ($jmap_server_id !== null) {
+                                    Hm_Msgs::add("JMAP Server " . $key . " saved");
                                 }
                             }
-                            //check stmp support and stmp host address data
-                            if ($server_data[8] && !empty($server_data[9])) {
-                                if (!$this->module_is_supported('smtp')) {
-                                    Hm_Msgs::add("ERRSMTP module is not enabled");
-                                } else {
-                                    $smtp_server_id = connect_to_smtp_server(
-                                        $server_data[9],
-                                        $server_data[0],
-                                        $server_data[10],
-                                        $server_data[3],
-                                        $server_data[4],
-                                        $server_data[11],
-                                        false
-                                    );
-                                    Hm_Msgs::add("SMTP Server " . $server_data[0] . " saved");
-                                }
-                            }
-                            //check imap support and stmp host address data
-                            if ($server_data[6] && !empty($server_data[7])) {
-                                if (!$this->module_is_supported('imap')) {
-                                    Hm_Msgs::add("ERRIMAP module is not enabled");
-                                }else {
+                        }elseif ($value['imap'] && !empty($value['imap']['server'])) {
+                            // Check if module is supported
+                            if (!$this->module_is_supported('imap')) {
+                                Hm_Msgs::add("ERRIMAP module is not enabled");
+                            }else {
+                                //TO DO: check first if the imap_server server is already configured before connecting can use the in_server_list function or create a new one specifically for my case
                                 $imap_server_id = connect_to_imap_server(
-                                    $server_data[7],
-                                    $server_data[0],
-                                    $server_data[5],
-                                    $server_data[3],
-                                    $server_data[4],
-                                    $server_data[6],
-                                    $server_data[12],
-                                    $server_data[13],
+                                    $value['imap']['server'],
+                                    $key,
+                                    $value['imap']['port'],
+                                    $value['user']['username'],
+                                    $value['user']['password'],
+                                    $value['imap']['tls'],
+                                    $value['sieve']['host'].':'.$value['sieve']['port'],
+                                    !empty($value['sieve']['sieve_port']) && !empty($value['sieve']['sieve_host']) ? true : false,
                                     'imap',
-                                    $this
+                                    $this,
+                                    $value['imap']['hide_from_combined_view']
                                 );
-                                Hm_Msgs::add("Server " . $server_data[0] . "  saved");
+                                if ($imap_server_id !== null) {
+                                    Hm_Msgs::add("Server " . $key . "  saved");
                                 }
                             }
                         }
+                        if ($value['smtp'] && !empty($value['smtp']['server'])) {
+                            // Check if module is supported
+                            if (!$this->module_is_supported('smtp')) {
+                                Hm_Msgs::add("ERRSMTP module is not enabled");
+                            } else {
+                                //TO DO: check first if the smtp_server server is already configured before connecting. can use the in_server_list function or create a new one specifically for my case
+                                $smtp_server_id = connect_to_smtp_server(
+                                    $value['smtp']['server'],
+                                    $key,
+                                    $value['smtp']['port'],
+                                    $value['user']['username'],
+                                    $value['user']['password'],
+                                    $value['smtp']['tls'],
+                                    false
+                                );
+                                if ($smtp_server_id !== null) {
+                                    Hm_Msgs::add("SMTP Server " . $key . " saved");
+                                }
+                            }
+                        }
+                        // Verify connection requirements
+                        if (($jmap_server_id === null && $imap_server_id === null) || $smtp_server_id === null) {
+                            if ($jmap_server_id !== null) {
+                                Hm_IMAP_List::del($jmap_server_id);
+                            }
+                            if ($imap_server_id !== null) {
+                                Hm_IMAP_List::del($imap_server_id);
+                            }
+                            if ($smtp_server_id !== null) {
+                                Hm_SMTP_List::del($smtp_server_id);
+                            }
+                        }
                     }
-                    $this->save_hm_msgs();
-
+                } catch (\Throwable $th) {
+                    Hm_Msgs::add('ERR' . $th->getMessage());
+                }
+            }elseif($this->request->files['accounts_sample']['type'] == 'text/csv'){
+                try {
+                    $server_data = parse_csv_with_headers($this->request->files['accounts_sample']['tmp_name']);
+                    foreach ($server_data as $server) {
+                        if ($server['jmap_server'] && !empty($server['jmap_server'])) {
+                            if (!$this->module_is_supported('jmap')) {
+                                Hm_Msgs::add("ERRJMAP module is not enabled");
+                            }else {
+                                $jmap_server_id = connect_to_imap_server(
+                                    $server['jmap_server'],
+                                    $server['server_name'],
+                                    null,
+                                    $server['username'],
+                                    $server['password'],
+                                    false,
+                                    null,
+                                    false,
+                                    'jmap',
+                                    $this,
+                                    $server['hide_from_combined_view'] === "TRUE"
+                                );
+                                if ($jmap_server_id !== null) {
+                                    Hm_Msgs::add("JMAP Server " . $server['server_name'] . " saved");
+                                }
+                            }
+                        }elseif($server['imap_server'] && !empty($server['imap_server'])) {
+                            if (!$this->module_is_supported('imap')) {
+                                Hm_Msgs::add("ERRIMAP module is not enabled");
+                            }else {
+                                $imap_server_id = connect_to_imap_server(
+                                    $server['imap_server'],
+                                    $server['server_name'],
+                                    $server['imap_port'],
+                                    $server['username'],
+                                    $server['password'],
+                                    $server['imap_tls'] === "TRUE",
+                                    $server['sieve_host'].':'.$server['sieve_port'],
+                                    !empty($server['sieve_port']) &&  !empty($server['sieve_host']) ? true : false,
+                                    'imap',
+                                    $this,
+                                    $server['imap_hide_from_combined_view'] === "TRUE"
+                                );
+                                if ($imap_server_id !== null) {
+                                    Hm_Msgs::add("Server " . $server['server_name'] . "  saved");
+                                }
+                            }
+                        }
+                        if ($server['smtp_server'] && !empty($server['smtp_server'])) {
+                            if (!$this->module_is_supported('smtp')) {
+                                Hm_Msgs::add("ERRSMTP module is not enabled");
+                            } else {
+                                $smtp_server_id = connect_to_smtp_server(
+                                    $server['smtp_server'],
+                                    $server['server_name'],
+                                    $server['smtp_port'],
+                                    $server['username'],
+                                    $server['password'],
+                                    $server['smtp_tls'] === "TRUE",
+                                    false
+                                );
+                                if ($smtp_server_id !== null) {
+                                    Hm_Msgs::add("SMTP Server " . $server['server_name'] . " saved");
+                                }
+                            }
+                        }
+                        // Verify connection requirements
+                        if (($jmap_server_id === null && $imap_server_id === null) || $smtp_server_id === null) {
+                            if ($jmap_server_id !== null) {
+                                Hm_IMAP_List::del($jmap_server_id);
+                            }
+                            if ($imap_server_id !== null) {
+                                Hm_IMAP_List::del($imap_server_id);
+                            }
+                            if ($smtp_server_id !== null) {
+                                Hm_SMTP_List::del($smtp_server_id);
+                            }
+                        } 
+                    }
                 } catch (\Exception $ex) {
                     Hm_Msgs::add('ERR' . $ex->getMessage());
-                    $this->save_hm_msgs();
                 }
             }
         }
@@ -451,31 +461,29 @@ class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_dialog extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_quick_add_dialog extends Hm_Output_Module {
+    protected function output() {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        return '<div class="quick_add_section">' .
-            '<div class="nux_step_one px-4 pt-">' .
-            '<p class="py-3">' . $this->trans('Quickly add an account from popular E-mail providers. To manually configure an account, use the IMAP/SMTP sections below.') . '</p>' .
-            '<div class="row"><div class="col col-lg-4"><div class="form-floating mb-3">' .
-            ' <select id="service_select" name="service_select" class="form-select">' .
-            '<option value="">' . $this->trans('Select an E-mail provider') . '</option>' .
-            Nux_Quick_Services::option_list(false, $this) . '</select>' .
-            '<label for="service_select">' . $this->trans('Select an E-mail provider') . '</label></div>' .
+        return '<div class="quick_add_section">'.
+            '<div class="nux_step_one px-4 pt-">'.
+            '<p class="py-3">'.$this->trans('Quickly add an account from popular E-mail providers. To manually configure an account, use the IMAP/SMTP sections below.').'</p>'.
+            '<div class="row"><div class="col col-lg-4"><div class="form-floating mb-3">'.
+            ' <select id="service_select" name="service_select" class="form-select">'.
+            '<option value="">'.$this->trans('Select an E-mail provider').'</option>'.
+            Nux_Quick_Services::option_list(false, $this).'</select>'.
+            '<label for="service_select">'.$this->trans('Select an E-mail provider').'</label></div>'.
 
-            '<div class="form-floating mb-3">' .
-            '<input type="email" id="nux_username" class="form-control nux_username" placeholder="' . $this->trans('Your E-mail address') . '">' .
-            '<label for="nux_username">' . $this->trans('Username') . '</label></div>' .
+            '<div class="form-floating mb-3">'.
+            '<input type="email" id="nux_username" class="form-control nux_username" placeholder="'.$this->trans('Your E-mail address').'">'.
+            '<label for="nux_username">'.$this->trans('Username').'</label></div>'.
 
-            '<div class="form-floating mb-3">' .
-            '<input type="text" id="nux_account_name" class="form-control nux_account_name" placeholder="' . $this->trans('Account Name [optional]') . '">' .
-            '<label for="nux_account_name">' . $this->trans('Account name') . '</label></div>' .
+            '<div class="form-floating mb-3">'.
+            '<input type="text" id="nux_account_name" class="form-control nux_account_name" placeholder="'.$this->trans('Account Name [optional]').'">'.
+            '<label for="nux_account_name">'.$this->trans('Account name').'</label></div>'.
 
-            '<input type="button" class="nux_next_button btn btn-primary btn-md px-5" value="' . $this->trans('Next') . '">' .
+            '<input type="button" class="nux_next_button btn btn-primary btn-md px-5" value="'.$this->trans('Next').'">'.
             '</div></div></div><div class="nux_step_two px-4 pt-3"></div></div>';
     }
 }
@@ -483,22 +491,19 @@ class Hm_Output_quick_add_dialog extends Hm_Output_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_multiple_dialog extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_quick_add_multiple_dialog extends Hm_Output_Module {
+    protected function output() {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        $title = $this->trans('Import from YAML or CSV file');
-        $notice = 'Please ensure your YAML or CSV  file follows the correct format';
+        $notice = $this->trans('Please ensure your YAML or CSV  file follows the correct format');
         $yaml_file_sample_path = WEB_ROOT . 'modules/nux/assets/data/server_accounts_sample.yaml';
         $csv_file_sample_path = WEB_ROOT . 'modules/nux/assets/data/server_accounts_sample.csv';
 
         return '<div class="quick_add_multiple_section">' .
             '<div class="row"><div class="col col-lg-6"><div class="form-floating mb-3">' .
             '<form class="quick_add_multiple_server_form" action="?page=servers" method="POST" enctype="multipart/form-data">' .
-            '<button class="browser_acc_file mt-2 btn btn-light" title="' . $notice . '"><i class="bi bi-filetype-yml me-2"></i>' . $title . '</button>' .
+            '<p class="mt-2">' . $notice . '</p>' .
             '<div class="server_form"><br />' .
             '<div class="row">' .
             '<div class="col-md-6">' .
@@ -520,15 +525,14 @@ class Hm_Output_quick_add_multiple_dialog extends Hm_Output_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_filter_service_select extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_filter_service_select extends Hm_Output_Module {
+    protected function output() {
         $details = $this->get('nux_add_service_details', array());
         if (!empty($details)) {
             if (array_key_exists('auth', $details) && $details['auth'] == 'oauth2') {
                 $this->out('nux_service_step_two',  oauth2_form($details, $this));
-            } else {
+            }
+            else {
                 $this->out('nux_service_step_two',  credentials_form($details, $this));
             }
         }
@@ -538,10 +542,8 @@ class Hm_Output_filter_service_select extends Hm_Output_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_service_details extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_service_details extends Hm_Output_Module {
+    protected function output() {
         $details = $this->get('nux_add_service_details', array());
         $this->out('service_details',  json_encode($details));
     }
@@ -557,9 +559,8 @@ class Hm_Output_nux_dev_news extends Hm_Output_Module {
         }
         $res = '<div class="nux_dev_news mt-3 col-12"><div class="card"><div class="card-body"><div class="card_title"><h4>'.$this->trans('Development Updates').'</h4></div><table>';
         foreach ($this->get('nux_dev_news', array()) as $vals) {
-            $res .= sprintf(
-                '<tr><td><a href="https://github.com/cypht-org/cypht/commit/%s" target="_blank" rel="noopener">%s</a>' .
-                    '</td><td class="msg_date">%s</td><td>%s</td><td>%s</td></tr>',
+            $res .= sprintf('<tr><td><a href="https://github.com/cypht-org/cypht/commit/%s" target="_blank" rel="noopener">%s</a>'.
+                '</td><td class="msg_date">%s</td><td>%s</td><td>%s</td></tr>',
                 $this->html_safe($vals['hash']),
                 $this->html_safe($vals['shash']),
                 $this->html_safe($vals['name']),
@@ -575,23 +576,19 @@ class Hm_Output_nux_dev_news extends Hm_Output_Module {
 /**
  * @subpackage nux/output
  */
-class Hm_Output_nux_help extends Hm_Output_Module
-{
-    protected function output()
-    {
-        return '<div class="nux_help mt-3 col-lg-6 col-md-12 col-sm-12"><div class="card"><div class="card-body"><div class="card_title"><h4>' . $this->trans('Help') . '</h4></div>' .
-            $this->trans('Cypht is a webmail program. You can use it to access your E-mail accounts from any service that offers IMAP, or SMTP access - which most do.') . ' ' .
-            '</div></div></div>';
+class Hm_Output_nux_help extends Hm_Output_Module {
+    protected function output() {
+        return '<div class="nux_help mt-3 col-lg-6 col-md-12 col-sm-12"><div class="card"><div class="card-body"><div class="card_title"><h4>'.$this->trans('Help').'</h4></div>'.
+            $this->trans('Cypht is a webmail program. You can use it to access your E-mail accounts from any service that offers IMAP, or SMTP access - which most do.').' '.
+        '</div></div></div>';
     }
 }
 
 /**
  * @subpackage nux/output
  */
-class Hm_Output_welcome_dialog extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_welcome_dialog extends Hm_Output_Module {
+    protected function output() {
         if ($this->get('single_server_mode')) {
             return '';
         }
@@ -599,9 +596,9 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module
         $tz = $this->get('tzone');
         $protos = array('imap', 'smtp', 'feeds', 'profiles');
 
-        $res = '<div class="nux_welcome mt-3 col-lg-6 col-md-5 col-sm-12"><div class="card"><div class="card-body"><div class="card-title"><h4>' . $this->trans('Welcome to Cypht') . '</h4></div>';
-        $res .= '<div class="mb-3"><p>' . $this->trans('Add a popular E-mail source quickly and easily') . '</p>';
-        $res .= '<a class="mt-3 btn btn-light" href="?page=servers#quick_add_section"><i class="bi bi-person-plus me-3"></i>' . $this->trans('Add an E-mail Account') . '</a>';
+        $res = '<div class="nux_welcome mt-3 col-lg-6 col-md-5 col-sm-12"><div class="card"><div class="card-body"><div class="card-title"><h4>'.$this->trans('Welcome to Cypht').'</h4></div>';
+        $res .= '<div class="mb-3"><p>'.$this->trans('Add a popular E-mail source quickly and easily').'</p>';
+        $res .= '<a class="mt-3 btn btn-light" href="?page=servers#quick_add_section"><i class="bi bi-person-plus me-3"></i>'.$this->trans('Add an E-mail Account').'</a>';
         $res .= '</div><ul class="mt-4">';
 
         foreach ($protos as $proto) {
@@ -609,7 +606,7 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module
             if ($proto == 'feeds') {
                 $proto_dsp = 'RSS/ATOM';
             }
-            $res .= '<li class="nux_' . $proto . ' mt-3">';
+            $res .= '<li class="nux_'.$proto.' mt-3">';
 
             // Check if user have profiles configured
             if ($proto == 'profiles') {
@@ -631,7 +628,8 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module
             elseif ($server_data[$proto] === 0) {
                 $res .= sprintf($this->trans('You don\'t have any %s sources'), mb_strtoupper($proto_dsp));
                 $res .= sprintf(' <a href="?page=servers#%s_section">%s</a>', $proto, $this->trans('Add'));
-            } else {
+            }
+            else {
                 if ($server_data[$proto] > 1) {
                     $res .= sprintf($this->trans('You have %d %s sources'), $server_data[$proto], mb_strtoupper($proto_dsp));
                 }
@@ -646,10 +644,11 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module
         $res .= '<div class="nux_tz">';
         if (!$tz) {
             $res .= $this->trans('Your timezone is NOT set');
-        } else {
+        }
+        else {
             $res .= sprintf($this->trans('Your timezone is set to %s'), $this->html_safe($tz));
         }
-        $res .= ' <a href="?page=settings#general_setting">' . $this->trans('Update') . '</a></div></div></div></div>';
+        $res .= ' <a href="?page=settings#general_setting">'.$this->trans('Update').'</a></div></div></div></div>';
         return $res;
     }
 }
@@ -657,13 +656,11 @@ class Hm_Output_welcome_dialog extends Hm_Output_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_nux_message_list_notice extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_nux_message_list_notice extends Hm_Output_Module {
+    protected function output() {
         $msg = '<div class="nux_empty_combined_view">';
         $msg .= $this->trans('You don\'t have any data sources assigned to this page.');
-        $msg .= '<br /><a href="?page=servers">' . $this->trans('Add some') . '</a>';
+        $msg .= '<br /><a href="?page=servers">'.$this->trans('Add some').'</a>';
         $msg .= '</div>';
         return $msg;
     }
@@ -672,128 +669,42 @@ class Hm_Output_nux_message_list_notice extends Hm_Output_Module
 /**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_section extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_quick_add_section extends Hm_Output_Module {
+    protected function output() {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        return '<div class="nux_add_account"><div data-target=".quick_add_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">' .
-            '<i class="bi bi-check-circle-fill me-3"></i>' .
-            '<b>' . $this->trans('Add an E-mail Account') . '</b></a></div>';
+        return '<div class="nux_add_account"><div data-target=".quick_add_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">'.
+            '<i class="bi bi-check-circle-fill me-3"></i>'.
+            '<b>'.$this->trans('Add an E-mail Account').'</b></a></div>';
     }
 }
 /**
  * @subpackage nux/output
  */
-class Hm_Output_quick_add_multiple_section extends Hm_Output_Module
-{
-    protected function output()
-    {
+class Hm_Output_quick_add_multiple_section extends Hm_Output_Module {
+    protected function output() {
         if ($this->get('single_server_mode')) {
             return '';
         }
-        return '<div class="nux_add_multiple_account"><div data-target=".quick_add_multiple_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">' .
+        return '<div data-target=".quick_add_multiple_section" class="server_section border-bottom cursor-pointer px-1 py-3 pe-auto"><a href="#" class="pe-auto">' .
             '<i class="bi bi-filetype-yml me-3"></i>' .
             '<b>' . $this->trans('Bulk-import accounts using yaml or csv template') . '</b></a></div>';
     }
 }
 
 /**
- * @subpackage nux/functions
- */
-if (!hm_exists('oauth2_form')) {
-    function oauth2_form($details, $mod)
-    {
-        $oauth2 = new Hm_Oauth2($details['client_id'], $details['client_secret'], $details['redirect_uri']);
-        $url = $oauth2->request_authorization_url($details['auth_uri'], $details['scope'], 'nux_authorization', $details['email']);
-        $res = '<input type="hidden" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
-        $res .= '<div class="nux_step_two_title fw-bold">' . $mod->html_safe($details['name']) . '</div><div class="mb-3">';
-        $res .= $mod->trans('This provider supports Oauth2 access to your account.');
-        $res .= $mod->trans(' This is the most secure way to access your E-mail. Click "Enable" to be redirected to the provider site to allow access.');
-        $res .= '</div><div class="mb-3"><a class="enable_auth2 btn btn-sm btn-success me-2" href="' . $url . '">' . $mod->trans('Enable') . '</a>';
-        $res .= '<a href="" class="reset_nux_form btn btn-sm btn-secondary">Reset</a></div>';
-        return $res;
-    }
-}
-
-/**
- * @subpackage nux/functions
- */
-if (!hm_exists('credentials_form')) {
-    function credentials_form($details, $mod)
-    {
-        $res = '<input type="hidden" id="nux_service" name="nux_service" value="' . $mod->html_safe($details['id']) . '" />';
-        $res .= '<input type="hidden" name="nux_name" class="nux_name" value="' . $mod->html_safe($details['name']) . '" />';
-        $res .= '<div class="nux_step_two_title"><b>' . $mod->html_safe($details['name']) . '</b></div>';
-        $res .= $mod->trans('Enter your password for this E-mail provider to complete the connection process');
-
-        $res .= '<div class="row"><div class="col col-lg-4">';
-        // E-mail Address Field
-        $res .= '<div class="form-floating mb-3 mt-3">';
-        $res .= '<input type="email" class="form-control warn_on_paste" id="nux_email" name="nux_email" placeholder="'.$mod->trans('E-mail Address').'" value="'.$mod->html_safe($details['email']).'">';
-        $res .= '<label for="nux_email">'.$mod->trans('E-mail Address').'</label></div>';
-
-        // E-mail Password Field
-        $res .= '<div class="form-floating mb-3">';
-        $res .= '<input type="password" class="form-control nux_password warn_on_paste" id="nux_password" name="nux_password" placeholder="'.$mod->trans('E-Mail Password').'">';
-        $res .= '<label for="nux_password">'.$mod->trans('E-mail Password').'</label></div>';
-
-        // Connect Button
-        $res .= '<input type="button" class="nux_submit px-5 btn btn-primary me-3" value="' . $mod->trans('Connect') . '">';
-
-        // Reset Link
-        $res .= '<a href="" class="reset_nux_form px-5 btn btn-secondary">Reset</a>';
-
-        $res .= '</div></div>';
-
-        return $res;
-    }
-}
-
-/**
- * @subpackage nux/functions
- */
-if (!hm_exists('parse_yaml_file')) {
-    function parse_yaml_file($filePath)
-    {
-        $yamlContent = file_get_contents($filePath);
-
-        $data = yaml_parse_file($filePath);
-
-        return $data;
-    }
-}
-
-/**
- * @subpackage nux/functions
- */
-if (!hm_exists('data_source_available')) {
-    function data_source_available($mods, $types)
-    {
-        if (!is_array($types)) {
-            $types = array($types);
-        }
-        return count(array_intersect($types, $mods)) == count($types);
-    }
-}
-
-/**
  * @subpackage nux/lib
  */
-class Nux_Quick_Services
-{
+class Nux_Quick_Services {
 
     static private $services = array();
     static private $oauth2 = array();
 
-    static public function add($id, $details)
-    {
+    static public function add($id, $details) {
         self::$services[$id] = $details;
     }
-    static public function oauth2_setup($config)
-    {
+    static public function oauth2_setup($config) {
         $services = array_keys(config('oauth2'));
         foreach ($services as $service) {
             $vals = $config->get($service, []);
@@ -810,30 +721,25 @@ class Nux_Quick_Services
         self::$oauth2 = config('oauth2');
     }
 
-    static public function option_list($current, $mod)
-    {
+    static public function option_list($current, $mod) {
         $res = '';
-        uasort(self::$services, function ($a, $b) {
-            return strcasecmp($a['name'], $b['name']);
-        });
-        foreach (self::$services as $id => $details) {
-            $res .= '<option value="' . $mod->html_safe($id) . '"';
+        uasort(self::$services, function($a, $b) { return strcasecmp($a['name'], $b['name']); });
+        foreach(self::$services as $id => $details) {
+            $res .= '<option value="'.$mod->html_safe($id).'"';
             if ($id == $current) {
                 $res .= ' selected="selected"';
             }
-            $res .= '>' . $mod->trans($details['name']);
+            $res .= '>'.$mod->trans($details['name']);
             $res .= '</option>';
         }
         return $res;
     }
 
-    static public function exists($id)
-    {
+    static public function exists($id) {
         return array_key_exists($id, self::$services);
     }
 
-    static public function details($id)
-    {
+    static public function details($id) {
         if (array_key_exists($id, self::$services)) {
             return self::$services[$id];
         }

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -50,8 +50,7 @@ add_output('home', 'nux_dev_news', true, 'nux', 'nux_help', 'after');
 
 add_output('message_list', 'nux_message_list_notice', true, 'nux', 'message_list_start', 'before');
 
-setup_base_page('add_multiple_servers', 'core');
-add_handler('add_multiple_servers', 'process_import_accouts_servers', true, 'nux','load_user_data', 'after');
+add_handler('servers', 'process_import_accouts_servers', true, 'nux','load_smtp_servers_from_config', 'after');
 add_output('servers', 'quick_add_multiple_section', true, 'nux', 'server_config_stepper_accordion_end_part', 'after');
 add_output('servers', 'quick_add_multiple_dialog', true, 'nux', 'quick_add_multiple_section', 'after');
 
@@ -60,7 +59,6 @@ return array(
         'ajax_nux_service_select',
         'ajax_get_nux_service_details',
         'ajax_nux_add_service',
-        'add_multiple_servers',
     ),
     'allowed_get' => array(
         'code' => FILTER_DEFAULT,

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -81,7 +81,6 @@ return array(
         'nux_account_name' => FILTER_DEFAULT,
         'nux_all_inkl_login' => FILTER_DEFAULT,
         'accounts_source' => FILTER_DEFAULT,
-        'accounts_source' => FILTER_DEFAULT,
-        'accounts_csv' => FILTER_DEFAULT,
+        'accounts_sample' => FILTER_DEFAULT,
     )
 );

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -50,11 +50,17 @@ add_output('home', 'nux_dev_news', true, 'nux', 'nux_help', 'after');
 
 add_output('message_list', 'nux_message_list_notice', true, 'nux', 'message_list_start', 'before');
 
+setup_base_page('add_multiple_servers', 'core');
+add_handler('add_multiple_servers', 'process_import_accouts_servers', true, 'nux','load_user_data', 'after');
+add_output('servers', 'quick_add_multiple_section', true, 'nux', 'server_config_stepper_accordion_end_part', 'after');
+add_output('servers', 'quick_add_multiple_dialog', true, 'nux', 'quick_add_multiple_section', 'after');
+
 return array(
     'allowed_pages' => array(
         'ajax_nux_service_select',
         'ajax_get_nux_service_details',
-        'ajax_nux_add_service'
+        'ajax_nux_add_service',
+        'add_multiple_servers',
     ),
     'allowed_get' => array(
         'code' => FILTER_DEFAULT,
@@ -75,6 +81,9 @@ return array(
         'nux_name' => FILTER_DEFAULT,
         'nux_pass' => FILTER_UNSAFE_RAW,
         'nux_account_name' => FILTER_DEFAULT,
-        'nux_all_inkl_login' => FILTER_DEFAULT
+        'nux_all_inkl_login' => FILTER_DEFAULT,
+        'accounts_source' => FILTER_DEFAULT,
+        'accounts_source' => FILTER_DEFAULT,
+        'accounts_csv' => FILTER_DEFAULT,
     )
 );

--- a/modules/nux/site.css
+++ b/modules/nux/site.css
@@ -1,6 +1,6 @@
 /* .nux_add_account { table-layout: fixed; width: 100%; display: table; background-color: #fff; } */
 /* .nux_subtitle { font-size: 80%; margin-left: 40px; display: inline; } */
-.quick_add_section { display: none; }
+.quick_add_section, .quick_add_multiple_section { display: none; }
 /* .nux_step_two_title { padding-top: 20px; font-size: 110%; padding-bottom: 10px; } */
 /* .nux_step_one, .nux_step_two { padding-left: 40px; max-width: 600px; } */
 /* .enable_auth2 { float: left; padding: 20px; padding-left: 0px; padding-bottom: 40px; font-size: 110%; } */
@@ -20,8 +20,10 @@
 /* .nux_try_out { display: block; text-align: center; margin: auto; margin-top: 10px; } */
 .nux_tz {  margin-top: 30px; }
 .nux_empty_combined_view { display: none; text-align: center; padding-top: 100px; color: #666; }
-
-.mobile .quick_add_section { padding-left: 0px; }
+.quick_add_multiple_server_form input { margin: 5px; margin-left: 0px; }
+.quick_add_multiple_server_form { padding-top: 10px; display: block; }
+/* .quick_add_multiple_server_form .server_form { display: none; } */
+.mobile .quick_add_section, .mobile .quick_add_multiple_section { padding-left: 0px; }
 .mobile .nux_dev_news, .mobile .nux_help, .mobile .nux_welcome { max-width: 90%; width: 90%; margin: 10px  auto; padding-left: 10px; padding-right: 5px; float: none; min-height: 200px; }
 .mobile .nux_dev_news { width: 90%; overflow: hidden; }
 .mobile .nux_welcome ul { padding-left: 10px; }

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -132,6 +132,13 @@ $(function() {
                 $('.nux_extra_fields').remove();
             }
         });
+        $('.browser_acc_csv').on("click", function(e) {
+            e.preventDefault();
+            $(this).next().toggle();
+        });
+        $('.reset_add_multiple_server').on("click", function() {
+            Hm_Utils.redirect('?page=servers');
+        });
     }
     else if (hm_page_name() === 'message_list') {
         var list_path = hm_list_path();

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -132,10 +132,6 @@ $(function() {
                 $('.nux_extra_fields').remove();
             }
         });
-        $('.browser_acc_file').on("click", function(e) {
-            e.preventDefault();
-            $(this).next().toggle();
-        });
         $('.reset_add_multiple_server').on("click", function() {
             Hm_Utils.redirect('?page=servers');
         });

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -132,9 +132,6 @@ $(function() {
                 $('.nux_extra_fields').remove();
             }
         });
-        $('.reset_add_multiple_server').on("click", function() {
-            Hm_Utils.redirect('?page=servers');
-        });
     }
     else if (hm_page_name() === 'message_list') {
         var list_path = hm_list_path();

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -132,7 +132,7 @@ $(function() {
                 $('.nux_extra_fields').remove();
             }
         });
-        $('.browser_acc_csv').on("click", function(e) {
+        $('.browser_acc_file').on("click", function(e) {
             e.preventDefault();
             $(this).next().toggle();
         });

--- a/modules/pgp/modules.php
+++ b/modules/pgp/modules.php
@@ -48,10 +48,7 @@ class Hm_Handler_pgp_import_public_key extends Hm_Handler_Module {
         if (!$success) {
             return;
         }
-        if (!is_array($this->request->files) || !array_key_exists('public_key', $this->request->files)) {
-            return;
-        }
-        if (!is_array($this->request->files['public_key']) || !array_key_exists('tmp_name', $this->request->files['public_key'])) {
+        if (! check_file_upload($this->request, 'public_key')) {
             return;
         }
         $fingerprint = validate_public_key($this->request->files['public_key']['tmp_name']);

--- a/modules/profiles/setup.php
+++ b/modules/profiles/setup.php
@@ -21,6 +21,7 @@ add_handler('compose', 'compose_profile_data', true, 'profiles', 'load_smtp_serv
 
 add_handler('ajax_smtp_save_draft', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
 add_handler('ajax_smtp_attach_file', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
+add_handler('servers', 'compose_profile_data', true, 'profiles', 'load_smtp_servers_from_config', 'after');
 
 return array(
     'allowed_pages' => array(


### PR DESCRIPTION
## Email Account Configuration for Cypht

This repository contains the account configuration settings for the Cypht. Unlike an approach based on directly storing configuration settings in the code (ex: config/account.php), we have opted to use a CSV file for configuring accounts.

Related Issue: [https://github.com/cypht-org/cypht/issues/974](https://github.com/cypht-org/cypht/issues/974)

### Data Isolation

By storing configuration settings in a CSV file, each user can have their own distinct configuration file. This allows for data isolation, ensuring that each user only has access to their own configured accounts and cannot access accounts configured by other users.

### Example CSV File Structure:
<img width="1119" alt="Screenshot 2024-04-25 at 20 59 10" src="https://github.com/cypht-org/cypht/assets/28566468/d76f053a-c186-49ad-9bb9-954306fdde91">

### This is the display
<img width="1221" alt="Screenshot 2024-04-25 at 21 05 32" src="https://github.com/cypht-org/cypht/assets/28566468/bbcbc88c-3bc7-4afc-84e9-a2c632f503d3">

