### PR TITLE
POC: Docker files in local directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,23 @@
 APP_NAME=Cypht
 
+# DB_CONNECTION_TYPE=host
+# DB_DRIVER=mysql
+# DB_PORT=
+# DB_HOST=localhost
+# DB_NAME=test
+# DB_USER=test
+# DB_PASS=123456
+# DB_SOCKET=/var/lib/mysqld/mysqld.sock
+
+# AUTH_USERNAME=admin
+# AUTH_PASSWORD=admin_password
 DB_CONNECTION_TYPE=host
+DB_HOST=db
+DB_NAME=cypht
+DB_USER=cypht
+DB_PASS=cypht_password
+SESSION_TYPE=db
 DB_DRIVER=mysql
-DB_PORT=
-DB_HOST=localhost
-DB_NAME=test
-DB_USER=test
-DB_PASS=123456
-DB_SOCKET=/var/lib/mysqld/mysqld.sock
 
 SESSION_TYPE=PHP
 AUTH_TYPE=DB

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       dockerfile: ./docker/Dockerfile
     volumes:
       - ./cypht/users:/var/lib/hm3/users
+    # TODO: add health check here
     ports:
       - "80:80"
     environment:
@@ -29,3 +30,5 @@ services:
       - CYPHT_DB_USER=cypht
       - CYPHT_DB_PASS=cypht_password
       - CYPHT_SESSION_TYPE=db
+
+  # TODO: add memcache and redis to this sample

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  db:
+    image: mariadb:10
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./db:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root_password
+      - MYSQL_DATABASE=cypht
+      - MYSQL_USER=cypht
+      - MYSQL_PASSWORD=cypht_password
+  cypht:
+    # image: sailfrog/cypht-docker:latest
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    volumes:
+      - ./cypht/users:/var/lib/hm3/users
+    ports:
+      - "80:80"
+    environment:
+      - CYPHT_AUTH_USERNAME=admin
+      - CYPHT_AUTH_PASSWORD=admin_password
+      - CYPHT_DB_CONNECTION_TYPE=host
+      - CYPHT_DB_HOST=db
+      - CYPHT_DB_NAME=cypht
+      - CYPHT_DB_USER=cypht
+      - CYPHT_DB_PASS=cypht_password
+      - CYPHT_SESSION_TYPE=db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM php:7.4.33-fpm-alpine
 
 # WORKDIR "/var/www"
 
+# TODO: change this to /app for simplification
 WORKDIR "/usr/local/share/cypht"
 
 RUN set -e \
@@ -45,23 +46,22 @@ RUN set -e \
 
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/supervisord.conf /etc/supervisord.conf
-COPY docker/docker-entrypoint.sh /usr/local/bin/
-COPY docker/cypht_setup_database.php /tmp/cypht_setup_database.php
+# COPY docker/docker-entrypoint.sh /usr/local/bin/
+# COPY docker/cypht_setup_database.php /tmp/cypht_setup_database.php
 
 RUN set -ex \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && chmod 700 /tmp/cypht_setup_database.php \
-    && chmod +x /usr/local/bin/docker-entrypoint.sh
+    && ln -sf /dev/stderr /var/log/nginx/error.log 
+# && chmod 700 docker/cypht_setup_database.php 
+#    && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 COPY composer.* .
 
-RUN composer update \
-    && composer install
+RUN composer update && composer install
 
 COPY . .
 COPY .env.example .env
 
 EXPOSE 80 443
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,67 @@
+FROM php:7.4.33-fpm-alpine
+
+# ENV CYPHT_DEST "/usr/local/share/cypht"
+
+# WORKDIR "/var/www"
+
+WORKDIR "/usr/local/share/cypht"
+
+RUN set -e \
+    && apk add --no-cache \
+    supervisor \
+    nginx \
+    composer \
+    # GD
+    freetype libpng libjpeg-turbo \
+    php-session php-fileinfo php-dom php-xml libxml2-dev php-xmlwriter php-tokenizer \
+    && apk add --no-cache --virtual .build-deps \
+    ca-certificates \
+    # wget \
+    # unzip \
+    # For GD (2fa module)
+    libpng-dev libjpeg-turbo-dev freetype-dev \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-install gd pdo pdo_mysql \
+    # && mkdir ${CYPHT_DEST} \
+    # && cd ${CYPHT_DEST} \
+    # && mkdir /tmp/cypht-temp \
+    # && cd /tmp/cypht-temp \
+    # && wget https://github.com/cypht-org/cypht/archive/master.zip \
+    # && unzip master.zip \
+    # && cp cypht-master/hm3.sample.ini cypht-master/hm3.ini \
+    # && find . -type d -print | xargs chmod 755 \
+    # && find . -type f -print | xargs chmod 644 \
+    # && chown -R root:root cypht-master \
+    # && mv cypht-master/* ${CYPHT_DEST} \
+    # && cd /tmp \
+    # && rm -rf cypht-temp \
+    # && apk del .build-deps \
+    # && cd ${CYPHT_DEST} \
+    # && composer update \
+    # && composer self-update --2 \
+    # && composer install \
+    && echo "post_max_size = 60M" >> /usr/local/etc/php/php.ini \
+    && echo "upload_max_filesize = 50M" >> /usr/local/etc/php/php.ini
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/supervisord.conf /etc/supervisord.conf
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+COPY docker/cypht_setup_database.php /tmp/cypht_setup_database.php
+
+RUN set -ex \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && chmod 700 /tmp/cypht_setup_database.php \
+    && chmod +x /usr/local/bin/docker-entrypoint.sh
+
+COPY composer.* .
+
+RUN composer update \
+    && composer install
+
+COPY . .
+COPY .env.example .env
+
+EXPOSE 80 443
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker/cypht_setup_database.php
+++ b/docker/cypht_setup_database.php
@@ -1,0 +1,45 @@
+<?php
+$connected = false;
+$session_type = CYPHT_SESSION_TYPE;
+$auth_type = CYPHT_AUTH_TYPE;
+$user_config_type = CYPHT_USER_CONFIG_TYPE;
+$db_driver = CYPHT_DB_DRIVER;
+
+while(!$connected) {
+    try{
+    $conn = new pdo('CYPHT_DB_DRIVER:host=CYPHT_DB_HOST;dbname=CYPHT_DB_NAME', 'CYPHT_DB_USER', 'CYPHT_DB_PASS');
+        $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    printf("Database connection successful ...\n");
+        $connected = true;
+    } catch(PDOException $e){
+        error_log('Waiting for database connection ... (' . $e->getMessage() . ')');
+        sleep(1);
+    }
+}
+if ($session_type == 'DB')  {
+    if ($db_driver == 'mysql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(250), data longblob, date timestamp, primary key (hm_id));";
+    } elseif ($db_driver == 'pgsql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(250) primary key not null, data text, date timestamp);";
+    }
+    printf("Creating database table hm_user_session ...\n");
+    $conn->exec($stmt);
+}
+if ($auth_type == 'DB')  {
+    if ($db_driver == 'mysql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user (username varchar(250), hash varchar(250), primary key (username));";
+    } elseif ($db_driver == 'pgsql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user (username varchar(255) primary key not null, hash varchar(255));";
+    }
+    printf("Creating database table hm_user ...\n");
+    $conn->exec($stmt);
+}
+if ($user_config_type == 'DB')  {
+    if ($db_driver == 'mysql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user_settings(username varchar(250), settings longblob, primary key (username));";
+    } elseif ($db_driver == 'pgsql') {
+        $stmt = "CREATE TABLE IF NOT EXISTS hm_user_settings (username varchar(250) primary key not null, settings text);";
+    }
+    printf("Creating database table hm_user_settings ...\n");
+    $conn->exec($stmt);
+}

--- a/docker/cypht_setup_database.php
+++ b/docker/cypht_setup_database.php
@@ -1,9 +1,14 @@
 <?php
+
+// TODO: this file should probably start with something like #!/usr/bin/env php
+
 $connected = false;
 $session_type = CYPHT_SESSION_TYPE;
 $auth_type = CYPHT_AUTH_TYPE;
 $user_config_type = CYPHT_USER_CONFIG_TYPE;
 $db_driver = CYPHT_DB_DRIVER;
+
+// TODO: move this into the scripts/ dir. its not docker specific
 
 while(!$connected) {
     try{
@@ -22,6 +27,7 @@ if ($session_type == 'DB')  {
     } elseif ($db_driver == 'pgsql') {
         $stmt = "CREATE TABLE IF NOT EXISTS hm_user_session (hm_id varchar(250) primary key not null, data text, date timestamp);";
     }
+    // TODO: sqlite command
     printf("Creating database table hm_user_session ...\n");
     $conn->exec($stmt);
 }
@@ -31,6 +37,7 @@ if ($auth_type == 'DB')  {
     } elseif ($db_driver == 'pgsql') {
         $stmt = "CREATE TABLE IF NOT EXISTS hm_user (username varchar(255) primary key not null, hash varchar(255));";
     }
+    // TODO: sqlite command
     printf("Creating database table hm_user ...\n");
     $conn->exec($stmt);
 }
@@ -40,6 +47,7 @@ if ($user_config_type == 'DB')  {
     } elseif ($db_driver == 'pgsql') {
         $stmt = "CREATE TABLE IF NOT EXISTS hm_user_settings (username varchar(250) primary key not null, settings text);";
     }
+    // TODO: sqlite command
     printf("Creating database table hm_user_settings ...\n");
     $conn->exec($stmt);
 }

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 
 CYPHT_CONFIG_FILE=/usr/local/share/cypht/hm3.ini
 
+# TODO: move to /app/scripts/setup_database.php
+DB_SETUP_SCRIPT=/usr/local/share/cypht/docker/cypht_setup_database.php
+
 #
 # Update ini file based on environment variables (only if the specific environment variable is set)
 #
@@ -162,15 +165,15 @@ db_pass=$(sed -n 's/db_pass=//p' ${CYPHT_CONFIG_FILE})
 db_driver=$(sed -n 's/db_driver=//p' ${CYPHT_CONFIG_FILE})
 if [ "${session_type}" = "DB" ] || [ "${auth_type}" = "DB" ] || [ "${user_config_type}" = "DB" ]
 then
-    sed -i "s/CYPHT_SESSION_TYPE/${session_type}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_AUTH_TYPE/${auth_type}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_USER_CONFIG_TYPE/${user_config_type}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_DB_HOST/${db_host}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_DB_NAME/${db_name}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_DB_USER/${db_user}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_DB_PASS/${db_pass}/" /tmp/cypht_setup_database.php
-    sed -i "s/CYPHT_DB_DRIVER/${db_driver}/" /tmp/cypht_setup_database.php
-    php /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_SESSION_TYPE/${session_type}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_AUTH_TYPE/${auth_type}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_USER_CONFIG_TYPE/${user_config_type}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_DB_HOST/${db_host}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_DB_NAME/${db_name}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_DB_USER/${db_user}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_DB_PASS/${db_pass}/" ${DB_SETUP_SCRIPT}
+    sed -i "s/CYPHT_DB_DRIVER/${db_driver}/" ${DB_SETUP_SCRIPT}
+    php ${DB_SETUP_SCRIPT}
 fi
 
 #

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+
+CYPHT_CONFIG_FILE=/usr/local/share/cypht/hm3.ini
+
+#
+# Update ini file based on environment variables (only if the specific environment variable is set)
+#
+
+# General Settings
+if [ ! -z ${CYPHT_SESSION_TYPE+x} ]; then sed -i "s/session_type=.*/session_type=${CYPHT_SESSION_TYPE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_AUTH_TYPE+x} ]; then sed -i "s/auth_type=.*/auth_type=${CYPHT_AUTH_TYPE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_LDAP_AUTH_SERVER+x} ]; then sed -i "s/ldap_auth_server=.*/ldap_auth_server=${CYPHT_LDAP_AUTH_SERVER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_LDAP_AUTH_PORT+x} ]; then sed -i "s/ldap_auth_port=.*/ldap_auth_port=${CYPHT_LDAP_AUTH_PORT}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_LDAP_AUTH_TLS+x} ]; then sed -i "s/ldap_auth_tls=.*/ldap_auth_tls=${CYPHT_LDAP_AUTH_TLS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_LDAP_AUTH_BASE_DN+x} ]; then sed -i "s/ldap_auth_base_dn=.*/ldap_auth_base_dn=${CYPHT_LDAP_AUTH_BASE_DN}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_IMAP_AUTH_NAME+x} ]; then sed -i "s/imap_auth_name=.*/imap_auth_name=${CYPHT_IMAP_AUTH_NAME}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_IMAP_AUTH_SERVER+x} ]; then sed -i "s/imap_auth_server=.*/imap_auth_server=${CYPHT_IMAP_AUTH_SERVER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_IMAP_AUTH_PORT+x} ]; then sed -i "s/imap_auth_port=.*/imap_auth_port=${CYPHT_IMAP_AUTH_PORT}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_IMAP_AUTH_TLS+x} ]; then sed -i "s/imap_auth_tls=.*/imap_auth_tls=${CYPHT_IMAP_AUTH_TLS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_SMTP_NAME+x} ]; then sed -i "s/default_smtp_name=.*/default_smtp_name=${CYPHT_DEFAULT_SMTP_NAME}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_SMTP_SERVER+x} ]; then sed -i "s/default_smtp_server=.*/default_smtp_server=${CYPHT_DEFAULT_SMTP_SERVER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_SMTP_PORT+x} ]; then sed -i "s/default_smtp_port=.*/default_smtp_port=${CYPHT_DEFAULT_SMTP_PORT}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_SMTP_TLS+x} ]; then sed -i "s/default_smtp_tls=.*/default_smtp_tls=${CYPHT_DEFAULT_SMTP_TLS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_SMTP_NO_AUTH+x} ]; then sed -i "s/default_smtp_no_auth=.*/default_smtp_no_auth=${CYPHT_DEFAULT_SMTP_NO_AUTH}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_USER_CONFIG_TYPE+x} ]; then sed -i "s/user_config_type=.*/user_config_type=${CYPHT_USER_CONFIG_TYPE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_USER_SETTINGS_DIR+x} ]; then sed -i "s!user_settings_dir=.*!user_settings_dir=${CYPHT_USER_SETTINGS_DIR}!" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ATTACHMENT_DIR+x} ]; then sed -i "s/attachment_dir=.*/attachment_dir=${CYPHT_ATTACHMENT_DIR}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_APP_DATA_DIR+x} ]; then sed -i "s/app_data_dir=.*/app_data_dir=${CYPHT_APP_DATA_DIR}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_ORIGIN_CHECK+x} ]; then sed -i "s/disable_origin_check=.*/disable_origin_check=${CYPHT_DISABLE_ORIGIN_CHECK}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ADMIN_USERS+x} ]; then sed -i "s/admin_users=.*/admin_users=${CYPHT_ADMIN_USERS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_COOKIE_DOMAIN+x} ]; then sed -i "s/cookie_domain=.*/cookie_domain=${CYPHT_COOKIE_DOMAIN}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_EMAIL_DOMAIN+x} ]; then sed -i "s/default_email_domain=.*/default_email_domain=${CYPHT_DEFAULT_EMAIL_DOMAIN}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_REDIRECT_AFTER_LOGIN+x} ]; then sed -i "s/redirect_after_login=.*/redirect_after_login=${CYPHT_REDIRECT_AFTER_LOGIN}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_APP_NAME+x} ]; then sed -i "s/app_name=.*/app_name=${CYPHT_APP_NAME}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DEFAULT_LANGUAGE+x} ]; then sed -i "s/default_language=.*/default_language=${CYPHT_DEFAULT_LANGUAGE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_JS_COMPRESS+x} ]; then sed -i "s/js_compress=.*/js_compress=${CYPHT_JS_COMPRESS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_CSS_COMPRESS+x} ]; then sed -i "s/css_compress=.*/css_compress=${CYPHT_CSS_COMPRESS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ENABLE_MEMCACHED+x} ]; then sed -i "s/enable_memcached=.*/enable_memcached=${CYPHT_ENABLE_MEMCACHED}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_MEMCACHED_SERVER+x} ]; then sed -i "s/memcached_server=.*/memcached_server=${CYPHT_MEMCACHED_SERVER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_MEMCACHED_PORT+x} ]; then sed -i "s/memcached_port=.*/memcached_port=${CYPHT_MEMCACHED_PORT}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_MEMCACHED_AUTH+x} ]; then sed -i "s/memcached_auth=.*/memcached_auth=${CYPHT_MEMCACHED_AUTH}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_MEMCACHED_USER+x} ]; then sed -i "s/memcached_user=.*/memcached_user=${CYPHT_MEMCACHED_USER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_MEMCACHED_PASS+x} ]; then sed -i "s/memcached_pass=.*/memcached_pass=${CYPHT_MEMCACHED_PASS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ALLOW_LONG_SESSION+x} ]; then sed -i "s/allow_long_session=.*/allow_long_session=${CYPHT_ALLOW_LONG_SESSION}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_LONG_SESSION_LIFETIME+x} ]; then sed -i "s/long_session_lifetime=.*/long_session_lifetime=${CYPHT_LONG_SESSION_LIFETIME}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ENCRYPT_AJAX_REQUESTS+x} ]; then sed -i "s/encrypt_ajax_requests=.*/encrypt_ajax_requests=${CYPHT_ENCRYPT_AJAX_REQUESTS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ENCRYPT_LOCAL_STORAGE+x} ]; then sed -i "s/encrypt_local_storage=.*/encrypt_local_storage=${CYPHT_ENCRYPT_LOCAL_STORAGE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_IP_CHECK+x} ]; then sed -i "s/disable_ip_check=.*/disable_ip_check=${CYPHT_DISABLE_IP_CHECK}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_ALLOW_EXTERNAL_IMAGE_SOURCES+x} ]; then sed -i "s/allow_external_image_sources=.*/allow_external_image_sources=${CYPHT_ALLOW_EXTERNAL_IMAGE_SOURCES}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_SINGLE_SERVER_MODE+x} ]; then sed -i "s/single_server_mode=.*/single_server_mode=${CYPHT_SINGLE_SERVER_MODE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_EMPTY_SUPERGLOBALS+x} ]; then sed -i "s/disable_empty_superglobals=.*/disable_empty_superglobals=${CYPHT_DISABLE_EMPTY_SUPERGLOBALS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_OPEN_BASEDIR+x} ]; then sed -i "s/disable_open_basedir=.*/disable_open_basedir=${CYPHT_DISABLE_OPEN_BASEDIR}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_INI_SETTINGS+x} ]; then sed -i "s/disable_ini_settings=.*/disable_ini_settings=${CYPHT_DISABLE_INI_SETTINGS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DISABLE_FINGERPRINT+x} ]; then sed -i "s/disable_fingerprint=.*/disable_fingerprint=${CYPHT_DISABLE_FINGERPRINT}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_CONNECTION_TYPE+x} ]; then sed -i "s/db_connection_type=.*/db_connection_type=${CYPHT_DB_CONNECTION_TYPE}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_HOST+x} ]; then sed -i "s/db_host=.*/db_host=${CYPHT_DB_HOST}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_SOCKET+x} ]; then sed -i "s/db_socket=.*/db_socket=${CYPHT_DB_SOCKET}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_NAME+x} ]; then sed -i "s/db_name=.*/db_name=${CYPHT_DB_NAME}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_USER+x} ]; then sed -i "s/db_user=.*/db_user=${CYPHT_DB_USER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_PASS+x} ]; then sed -i "s/db_pass=.*/db_pass=${CYPHT_DB_PASS}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_DB_DRIVER+x} ]; then sed -i "s/db_driver=.*/db_driver=${CYPHT_DB_DRIVER}/" ${CYPHT_CONFIG_FILE}; fi
+if [ ! -z ${CYPHT_API_LOGIN_KEY+x} ]; then sed -i "s/api_login_key=.*/api_login_key=${CYPHT_API_LOGIN_KEY}/" ${CYPHT_CONFIG_FILE}; fi
+
+# Modules
+
+enable_disable_module() {
+    local module=${1}
+    local setting=${2}
+    # For some reason, "(; )?" isn't working but ";\{0,1\} \{0,1\}" does the same thing
+    if [ ${setting} = enable ]
+    then
+        sed -i "s/^;\{0,1\} \{0,1\}modules\[\]=${module}/modules[]=${module}/" ${CYPHT_CONFIG_FILE}
+        if [ ${module} = api_login ]; then sed -i "s/;\{0,1\} \{0,1\}api_login_key=/api_login_key=/" ${CYPHT_CONFIG_FILE}; fi
+    else
+        sed -i "s/^;\{0,1\} \{0,1\}modules\[\]=${module}/; modules[]=${module}/" ${CYPHT_CONFIG_FILE}
+        if [ ${module} = api_login ]; then sed -i "s/;\{0,1\} \{0,1\}api_login_key=/; api_login_key=/" ${CYPHT_CONFIG_FILE}; fi
+    fi
+}
+
+if [ ! -z ${CYPHT_MODULE_CORE+x} ]; then enable_disable_module core ${CYPHT_MODULE_CORE}; fi
+if [ ! -z ${CYPHT_MODULE_CONTACTS+x} ]; then enable_disable_module contacts ${CYPHT_MODULE_CONTACTS}; fi
+if [ ! -z ${CYPHT_MODULE_LOCAL_CONTACTS+x} ]; then enable_disable_module local_contacts ${CYPHT_MODULE_LOCAL_CONTACTS}; fi
+if [ ! -z ${CYPHT_MODULE_LDAP_CONTACTS+x} ]; then enable_disable_module ldap_contacts ${CYPHT_MODULE_LDAP_CONTACTS}; fi
+if [ ! -z ${CYPHT_MODULE_GMAIL_CONTACTS+x} ]; then enable_disable_module gmail_contacts ${CYPHT_MODULE_GMAIL_CONTACTS}; fi
+if [ ! -z ${CYPHT_MODULE_FEEDS+x} ]; then enable_disable_module feeds ${CYPHT_MODULE_FEEDS}; fi
+if [ ! -z ${CYPHT_MODULE_IMAP+x} ]; then enable_disable_module imap ${CYPHT_MODULE_IMAP}; fi
+if [ ! -z ${CYPHT_MODULE_2FA+x} ]; then enable_disable_module 2fa ${CYPHT_MODULE_2FA}; fi
+if [ ! -z ${CYPHT_MODULE_SMTP+x} ]; then enable_disable_module smtp ${CYPHT_MODULE_SMTP}; fi
+if [ ! -z ${CYPHT_MODULE_ACCOUNT+x} ]; then enable_disable_module account ${CYPHT_MODULE_ACCOUNT}; fi
+if [ ! -z ${CYPHT_MODULE_IDLE_TIMER+x} ]; then enable_disable_module idle_timer ${CYPHT_MODULE_IDLE_TIMER}; fi
+if [ ! -z ${CYPHT_MODULE_CALENDAR+x} ]; then enable_disable_module calendar ${CYPHT_MODULE_CALENDAR}; fi
+if [ ! -z ${CYPHT_MODULE_THEMES+x} ]; then enable_disable_module themes ${CYPHT_MODULE_THEMES}; fi
+if [ ! -z ${CYPHT_MODULE_NUX+x} ]; then enable_disable_module nux ${CYPHT_MODULE_NUX}; fi
+if [ ! -z ${CYPHT_MODULE_DEVELOPER+x} ]; then enable_disable_module developer ${CYPHT_MODULE_DEVELOPER}; fi
+if [ ! -z ${CYPHT_MODULE_GITHUB+x} ]; then enable_disable_module github ${CYPHT_MODULE_GITHUB}; fi
+if [ ! -z ${CYPHT_MODULE_RECAPTCHA+x} ]; then enable_disable_module recaptcha ${CYPHT_MODULE_RECAPTCHA}; fi
+if [ ! -z ${CYPHT_MODULE_WORDPRESS+x} ]; then enable_disable_module wordpress ${CYPHT_MODULE_WORDPRESS}; fi
+if [ ! -z ${CYPHT_MODULE_HISTORY+x} ]; then enable_disable_module history ${CYPHT_MODULE_HISTORY}; fi
+if [ ! -z ${CYPHT_MODULE_SAVED_SEARCHES+x} ]; then enable_disable_module saved_searches ${CYPHT_MODULE_SAVED_SEARCHES}; fi
+if [ ! -z ${CYPHT_MODULE_NASA+x} ]; then enable_disable_module nasa ${CYPHT_MODULE_NASA}; fi
+if [ ! -z ${CYPHT_MODULE_PROFILES+x} ]; then enable_disable_module profiles ${CYPHT_MODULE_PROFILES}; fi
+if [ ! -z ${CYPHT_MODULE_INLINE_MESSAGE+x} ]; then enable_disable_module inline_message ${CYPHT_MODULE_INLINE_MESSAGE}; fi
+if [ ! -z ${CYPHT_MODULE_IMAP_FOLDERS+x} ]; then enable_disable_module imap_folders ${CYPHT_MODULE_IMAP_FOLDERS}; fi
+if [ ! -z ${CYPHT_MODULE_KEYBOARD_SHORTCUTS+x} ]; then enable_disable_module keyboard_shortcuts ${CYPHT_MODULE_KEYBOARD_SHORTCUTS}; fi
+if [ ! -z ${CYPHT_MODULE_SIEVEFILTERS+x} ]; then enable_disable_module sievefilters ${CYPHT_MODULE_SIEVEFILTERS}; fi
+if [ ! -z ${CYPHT_MODULE_SITE+x} ]; then enable_disable_module site ${CYPHT_MODULE_SITE}; fi
+if [ ! -z ${CYPHT_MODULE_DYNAMIC_LOGIN+x} ]; then enable_disable_module dynamic_login ${CYPHT_MODULE_DYNAMIC_LOGIN}; fi
+if [ ! -z ${CYPHT_MODULE_API_LOGIN+x} ]; then enable_disable_module api_login ${CYPHT_MODULE_API_LOGIN}; fi
+if [ ! -z ${CYPHT_MODULE_RECOVER_SETTINGS+x} ]; then enable_disable_module recover_settings ${CYPHT_MODULE_RECOVER_SETTINGS}; fi
+if [ ! -z ${CYPHT_MODULE_HELLO_WORLD+x} ]; then enable_disable_module hello_world ${CYPHT_MODULE_HELLO_WORLD}; fi
+if [ ! -z ${CYPHT_MODULE_DESKTOP_NOTIFICATIONS+x} ]; then enable_disable_module desktop_notifications ${CYPHT_MODULE_DESKTOP_NOTIFICATIONS}; fi
+
+# Defaults
+if [ ! -z ${CYPHT_DEFAULT_SETTING_NO_PASSWORD_SAVE+x} ]; then sed -i "s/; default_setting_no_password_save=.*/default_setting_no_password_save=${CYPHT_DEFAULT_SETTING_NO_PASSWORD_SAVE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_IMAP_PER_PAGE+x} ]; then sed -i "s/; default_setting_imap_per_page=.*/default_setting_imap_per_page=${CYPHT_DEFAULT_SETTING_IMAP_PER_PAGE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SIMPLE_MSG_PARTS+x} ]; then sed -i "s/; default_setting_simple_msg_parts=.*/default_setting_simple_msg_parts=${CYPHT_DEFAULT_SETTING_SIMPLE_MSG_PARTS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_MSG_PART_ICONS+x} ]; then sed -i "s/; default_setting_msg_part_icons=.*/default_setting_msg_part_icons=${CYPHT_DEFAULT_SETTING_MSG_PART_ICONS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_TEXT_ONLY+x} ]; then sed -i "s/; default_setting_text_only=.*/default_setting_text_only=${CYPHT_DEFAULT_SETTING_TEXT_ONLY}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SENT_PER_SOURCE+x} ]; then sed -i "s/; default_setting_sent_per_source=.*/default_setting_sent_per_source=${CYPHT_DEFAULT_SETTING_SENT_PER_SOURCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SENT_SINCE+x} ]; then sed -i "s/; default_setting_sent_since=.*/default_setting_sent_since=${CYPHT_DEFAULT_SETTING_SENT_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SHOW_LIST_ICONS+x} ]; then sed -i "s/; default_setting_show_list_icons=.*/default_setting_show_list_icons=${CYPHT_DEFAULT_SETTING_SHOW_LIST_ICONS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_START_PAGE+x} ]; then sed -i "s/; default_setting_start_page=.*/default_setting_start_page=${CYPHT_DEFAULT_SETTING_START_PAGE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_DISABLE_DELETE_PROMPT+x} ]; then sed -i "s/; default_setting_disable_delete_prompt=.*/default_setting_disable_delete_prompt=${CYPHT_DEFAULT_SETTING_DISABLE_DELETE_PROMPT}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_NO_FOLDER_ICONS+x} ]; then sed -i "s/; default_setting_no_folder_icons=.*/default_setting_no_folder_icons=${CYPHT_DEFAULT_SETTING_NO_FOLDER_ICONS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ALL_EMAIL_PER_SOURCE+x} ]; then sed -i "s/; default_setting_all_email_per_source=.*/default_setting_all_email_per_source=${CYPHT_DEFAULT_SETTING_ALL_EMAIL_PER_SOURCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ALL_EMAIL_SINCE+x} ]; then sed -i "s/; default_setting_all_email_since=.*/default_setting_all_email_since=${CYPHT_DEFAULT_SETTING_ALL_EMAIL_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ALL_SINCE+x} ]; then sed -i "s/; default_setting_all_since=.*/default_setting_all_since=${CYPHT_DEFAULT_SETTING_ALL_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ALL_PER_SOURCE+x} ]; then sed -i "s/; default_setting_all_per_source=.*/default_setting_all_per_source=${CYPHT_DEFAULT_SETTING_ALL_PER_SOURCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_UNREAD_PER_SOURCE+x} ]; then sed -i "s/; default_setting_unread_per_source=.*/default_setting_unread_per_source=${CYPHT_DEFAULT_SETTING_UNREAD_PER_SOURCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_FLAGGED_PER_SOURCE+x} ]; then sed -i "s/; default_setting_flagged_per_source=.*/default_setting_flagged_per_source=${CYPHT_DEFAULT_SETTING_FLAGGED_PER_SOURCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_FLAGGED_SINCE+x} ]; then sed -i "s/; default_setting_flagged_since=.*/default_setting_flagged_since=${CYPHT_DEFAULT_SETTING_FLAGGED_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_UNREAD_SINCE+x} ]; then sed -i "s/; default_setting_unread_since=.*/default_setting_unread_since=${CYPHT_DEFAULT_SETTING_UNREAD_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_TIMEZONE+x} ]; then sed -i "s/; default_setting_timezone=.*/default_setting_timezone=${CYPHT_DEFAULT_SETTING_TIMEZONE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_LIST_STYLE+x} ]; then sed -i "s/; default_setting_list_style=.*/default_setting_list_style=${CYPHT_DEFAULT_SETTING_LIST_STYLE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_LANGUAGE+x} ]; then sed -i "s/; default_setting_language=.*/default_setting_language=${CYPHT_DEFAULT_SETTING_LANGUAGE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_FEEDS+x} ]; then sed -i "s/; default_setting_unread_exclude_feeds=.*/default_setting_unread_exclude_feeds=${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_FEEDS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_FEED_LIMIT+x} ]; then sed -i "s/; default_setting_feed_limit=.*/default_setting_feed_limit=${CYPHT_DEFAULT_SETTING_FEED_LIMIT}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_FEED_SINCE+x} ]; then sed -i "s/; default_setting_feed_since=.*/default_setting_feed_since=${CYPHT_DEFAULT_SETTING_FEED_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SMTP_COMPOSE_TYPE+x} ]; then sed -i "s/; default_setting_smtp_compose_type=.*/default_setting_smtp_compose_type=${CYPHT_DEFAULT_SETTING_SMTP_COMPOSE_TYPE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_SMTP_AUTO_BCC+x} ]; then sed -i "s/; default_setting_smtp_auto_bcc=.*/default_setting_smtp_auto_bcc=${CYPHT_DEFAULT_SETTING_SMTP_AUTO_BCC}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_THEME+x} ]; then sed -i "s/; default_setting_theme=.*/default_setting_theme=${CYPHT_DEFAULT_SETTING_THEME}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_WORDPRESS+x} ]; then sed -i "s/; default_setting_unread_exclude_wordpress=.*/default_setting_unread_exclude_wordpress=${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_WORDPRESS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_WORDPRESS_SINCE+x} ]; then sed -i "s/; default_setting_wordpress_since=.*/default_setting_wordpress_since=${CYPHT_DEFAULT_SETTING_WORDPRESS_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_GITHUB+x} ]; then sed -i "s/; default_setting_unread_exclude_github=.*/default_setting_unread_exclude_github=${CYPHT_DEFAULT_SETTING_UNREAD_EXCLUDE_GITHUB}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_GITHUB_LIMIT+x} ]; then sed -i "s/; default_setting_github_limit=.*/default_setting_github_limit=${CYPHT_DEFAULT_SETTING_GITHUB_LIMIT}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_GITHUB_SINCE+x} ]; then sed -i "s/; default_setting_github_since=.*/default_setting_github_since=${CYPHT_DEFAULT_SETTING_GITHUB_SINCE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_INLINE_MESSAGE+x} ]; then sed -i "s/; default_setting_inline_message=.*/default_setting_inline_message=${CYPHT_DEFAULT_SETTING_INLINE_MESSAGE}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ENABLE_KEYBOARD_SHORTCUTS+x} ]; then sed -i "s/; default_setting_enable_keyboard_shortcuts=.*/default_setting_enable_keyboard_shortcuts=${CYPHT_DEFAULT_SETTING_ENABLE_KEYBOARD_SHORTCUTS}/" config.ini; fi
+if [ ! -z ${CYPHT_DEFAULT_SETTING_ENABLE_SIEVE_FILTER+x} ]; then sed -i "s/; default_setting_enable_sieve_filter=.*/default_setting_enable_sieve_filter=${CYPHT_DEFAULT_SETTING_ENABLE_SIEVE_FILTER}/" config.ini; fi
+
+
+#
+# Wait for database to be ready then setup tables for sessions, authentication, and settings as needed
+#
+session_type=$(sed -n 's/session_type=//p' ${CYPHT_CONFIG_FILE})
+auth_type=$(sed -n 's/auth_type=//p' ${CYPHT_CONFIG_FILE})
+user_config_type=$(sed -n 's/user_config_type=//p' ${CYPHT_CONFIG_FILE})
+db_host=$(sed -n 's/db_host=//p' ${CYPHT_CONFIG_FILE})
+db_name=$(sed -n 's/db_name=//p' ${CYPHT_CONFIG_FILE})
+db_user=$(sed -n 's/db_user=//p' ${CYPHT_CONFIG_FILE})
+db_pass=$(sed -n 's/db_pass=//p' ${CYPHT_CONFIG_FILE})
+db_driver=$(sed -n 's/db_driver=//p' ${CYPHT_CONFIG_FILE})
+if [ "${session_type}" = "DB" ] || [ "${auth_type}" = "DB" ] || [ "${user_config_type}" = "DB" ]
+then
+    sed -i "s/CYPHT_SESSION_TYPE/${session_type}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_AUTH_TYPE/${auth_type}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_USER_CONFIG_TYPE/${user_config_type}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_DB_HOST/${db_host}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_DB_NAME/${db_name}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_DB_USER/${db_user}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_DB_PASS/${db_pass}/" /tmp/cypht_setup_database.php
+    sed -i "s/CYPHT_DB_DRIVER/${db_driver}/" /tmp/cypht_setup_database.php
+    php /tmp/cypht_setup_database.php
+fi
+
+#
+# Additional tasks based on the newly-configured settings
+#
+
+# Settings Location - create directory if config type is "file"
+user_config_type=$(sed -n 's/user_config_type=//p' ${CYPHT_CONFIG_FILE})
+user_settings_dir=$(sed -n 's/user_settings_dir=//p' ${CYPHT_CONFIG_FILE})
+if [ "${user_config_type}" = "file" ]
+then
+    mkdir -p ${user_settings_dir}
+    chown www-data:www-data ${user_settings_dir}
+fi
+
+# Attachment Location - create directory
+attachment_dir=$(sed -n 's/attachment_dir=//p' ${CYPHT_CONFIG_FILE})
+mkdir -p ${attachment_dir}
+chown www-data:www-data ${attachment_dir}
+
+# Change /var/lib/nginx owner from root to www-data to avoid "permission denied" error.
+chown -R www-data:www-data /var/lib/nginx
+
+# Application Data Location - create directory
+app_data_dir=$(sed -n 's/app_data_dir=//p' ${CYPHT_CONFIG_FILE})
+mkdir -p ${app_data_dir}
+chown www-data:www-data ${app_data_dir}
+
+#
+# Generate the run-time configuration
+#
+cd /usr/local/share/cypht
+php ./scripts/config_gen.php
+
+#
+# Enable the program in the web-server
+#
+rm -r /var/www
+ln -s /usr/local/share/cypht/site /var/www
+
+#
+# Create user account in database (or change password if user already exists)
+#
+php ./scripts/create_account.php ${CYPHT_AUTH_USERNAME} ${CYPHT_AUTH_PASSWORD}
+#OR maybe run the following if the user already exists...
+#php ./scripts/update_password.php ${CYPHT_AUTH_USERNAME} ${CYPHT_AUTH_PASSWORD}
+
+#
+# Close out tasks
+#
+
+# now that we're definitely done writing configuration, let's clear out the relevant environment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+#for e in "${envs[@]}"; do
+#    unset "$e"
+#done
+
+# Start supervisord and services
+/usr/bin/supervisord -c /etc/supervisord.conf
+
+exec "$@"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,40 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+events {
+	worker_connections 768;
+}
+http {
+	sendfile off;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+	gzip on;
+	gzip_disable "msie6";
+	server {
+		listen 80;
+		server_name localhost;
+		index index.php;
+		root /var/www;
+		client_max_body_size 60M;
+		location / {
+			try_files $uri /index.php$is_args$args;
+		}
+		location ~ \.php {
+			try_files $uri =404;
+			fastcgi_split_path_info ^(.+\.php)(/.+)$;
+			include fastcgi_params;
+			fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+			fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+			fastcgi_index index.php;
+			fastcgi_pass 127.0.0.1:9000;
+		}
+	}
+}

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:php-fpm]
+command=php-fpm
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
This is a proof of concept how how to move and use docker into the main repo, as discussed here:
https://github.com/cypht-org/cypht-docker/issues/31#issuecomment-2081175722

It does not fully work since I have not lined up the env vars, but you can get it started and see the home page by running:

`docker compose up --build`

then visit http://localhost/

I have mostly copied over files from here: https://github.com/cypht-org/cypht-docker/tree/master/image
and I left in the commented out lines so you can see some of the changes I introduced.

docker-compose.yaml here gives several benefits:
1. It provides a runtime spec for the inputs required to run the program.
2. You can easily pull down the git repo and use it right away too see how cypht behaves in docker.
3. We can set it up such that this is also usable for a developer - such that they can work on the project without having php (and other dependencies) installed locally on the machine.
4. We can use docker-compose.yaml to build and distribute production images - likely triggered by a github action or something.
