### PR TITLE
Fixed add filter issues

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -360,7 +360,7 @@ class Hm_Output_msgs extends Hm_Output_Module {
         if (!$this->get('router_login_state') && !empty($msgs)) {
             $logged_out_class = ' logged_out';
         }
-        $res .= '<div class="d-none z-3 position-fixed top-0 end-0 mt-3 me-3 sys_messages'.$logged_out_class.'">';
+        $res .= '<div class="d-none position-fixed top-0 end-0 mt-3 me-3 sys_messages'.$logged_out_class.'">';
         if (!empty($msgs)) {
             $res .= implode(',', array_map(function($v) {
                 if (preg_match("/ERR/", $v)) {

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -920,6 +920,9 @@ div.unseen,
 .next th {
   white-space: normal !important;
 }
+.sys_messages {
+  z-index: 1100 !important;
+}
 
 /* mobile */
 .mobile {
@@ -1028,9 +1031,6 @@ div.unseen,
   padding-top: 5px;
   top: 1px;
   left: 70px !important;
-}
-.mobile .sys_messages {
-  z-index: 1000 !important;
 }
 @media (orientation: landscape) {
   .mobile .msg_controls {

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -381,7 +381,6 @@ function Hm_Modal(options) {
         }
 
         btn.addEventListener('click', callback);
-        btn.addEventListener('click', this.hide);
 
         this.modalFooter.append(btn);
     };

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -310,8 +310,7 @@ $(function () {
          **************************************************************************************/
         var edit_script_modal = new Hm_Modal({
             size: 'xl',
-            modalId: 'myEditScriptModal',
-            btnSize: 'lg'
+            modalId: 'myEditScript'
         });
 
         // set content
@@ -340,7 +339,7 @@ $(function () {
         edit_filter_modal.addFooterBtn('Save', 'btn-primary ms-auto', async function () {
             let result = save_filter(current_account);
             if (result) {
-                edit_filter_modal.close();
+                edit_filter_modal.hide();
             }
         });
 
@@ -348,7 +347,7 @@ $(function () {
         edit_filter_modal.addFooterBtn('Convert to code', 'btn-warning', async function () {
             let result = save_filter(current_account, true);
             if (result) {
-                edit_filter_modal.close();
+                edit_filter_modal.hide();
             }
         });
 
@@ -908,6 +907,8 @@ $(function () {
             current_account = $(this).attr('imap_account');
             $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
             $('.modal_sieve_filter_priority').val($(this).attr('priority'));
+            $('.sieve_list_conditions_modal').html('');
+            $('.filter_actions_modal_table').html('');
             Hm_Ajax.request(
                 [   {'name': 'hm_ajax_hook', 'value': 'ajax_sieve_edit_filter'},
                     {'name': 'imap_account', 'value': $(this).attr('imap_account')},
@@ -935,6 +936,8 @@ $(function () {
                         $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
                         if ($("[name^=sieve_selected_action_value]").last().is('input')) {
                             $("[name^=sieve_selected_action_value]").last().val(action.value);
+                        } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
+                            $("[name^=sieve_selected_action_value]").last().text(action.value);
                         }
                     });
                 }

--- a/tests/phpunit/modules/core/modules.php
+++ b/tests/phpunit/modules/core/modules.php
@@ -885,7 +885,7 @@ class Hm_Test_Core_Output_Modules extends TestCase {
         $test = new Output_Test('msgs', 'core');
         $test->handler_response = array('router_login_state' => false);
         $res = $test->run();
-        $this->assertEquals(array('<div class="d-none z-3 position-fixed top-0 end-0 mt-3 me-3 sys_messages logged_out"><div class="alert alert-danger alert-dismissible fade show" role="alert"><i class="bi bi-exclamation-triangle me-2"></i><span class="danger">foo</span>,<div class="alert alert-success alert-dismissible fade show" role="alert"><i class="bi bi-check-circle me-2"></i><span class="info">foo</span><button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div></div>'), $res->output_response);
+        $this->assertEquals(array('<div class="d-none position-fixed top-0 end-0 mt-3 me-3 sys_messages logged_out"><div class="alert alert-danger alert-dismissible fade show" role="alert"><i class="bi bi-exclamation-triangle me-2"></i><span class="danger">foo</span>,<div class="alert alert-success alert-dismissible fade show" role="alert"><i class="bi bi-check-circle me-2"></i><span class="info">foo</span><button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div></div>'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
This PR fixes some issue with add filter/add script buttons.
First the save button was calling unexisting close function
Also it raise the z-index of alerts so they won't be hidden by modal
Also when editing a filter, it fixes the default value of action when it is a textarea. The value was not set.
Finally it fixes the conditions/actions which were not cleared after clicking on one. To reproduce this click on edit icon of a filter then close the modal, click edit on another filter you will see that they will be combined.