### PR TITLE
[FIX]Error Ocurred when attempting gmail oauth2 setup

### DIFF
--- a/lib/framework.php
+++ b/lib/framework.php
@@ -66,7 +66,7 @@ if (!class_exists('Hm_Functions')) {
          * @param string $value
          * @return boolean
          */
-        public static function setcookie($name, $value, $lifetime = 0, $path = '', $domain = '', $secure = false, $html_only = false) {
+        public static function setcookie($name, $value, $lifetime = 0, $path = '', $domain = '', $secure = false, $html_only = false, $same_site = 'Strict') {
             $prefix = ($lifetime != 0 && $lifetime < time()) ? 'Deleting' : 'Setting';
             Hm_Debug::add(sprintf('%s cookie: name: %s, lifetime: %s, path: %s, domain: %s, secure: %s, html_only %s',$prefix, $name, $lifetime, $path, $domain, $secure, $html_only));
             if (version_compare(PHP_VERSION, '7.3', '>=')) {
@@ -76,7 +76,7 @@ if (!class_exists('Hm_Functions')) {
                         'domain' => $domain,
                         'secure' => $secure,
                         'httponly' => $html_only,
-                        'samesite' => 'Strict'
+                        'samesite' => $same_site
                     ]
                 );
             } else {

--- a/lib/ini_set.php
+++ b/lib/ini_set.php
@@ -24,7 +24,7 @@ ini_set('session.use_strict_mode', 1);
 /* limit session cookie to HTTP only */
 ini_set('session.cookie_httponly', 1);
 if (version_compare(PHP_VERSION, 7.3, '>=')) {
-    ini_set('session.cookie_samesite', 'Strict');
+    ini_set('session.cookie_samesite', 'Lax');
 }
 
 /* HTTPS required for session cookie */

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -272,7 +272,7 @@ abstract class Hm_Session {
      */
     protected function set_key($request) {
         $this->enc_key = Hm_Crypt::unique_id();
-        $this->secure_cookie($request, 'hm_id', $this->enc_key);
+        $this->secure_cookie($request, 'hm_id', $this->enc_key, '', '', 'Lax');
     }
 
     /**
@@ -329,9 +329,9 @@ abstract class Hm_Session {
      * @param string $domain cookie domain
      * @return boolean
      */
-    public function secure_cookie($request, $name, $value, $path='', $domain='') {
+    public function secure_cookie($request, $name, $value, $path='', $domain='', $same_site = 'Strict') {
         list($path, $domain, $html_only) = $this->prep_cookie_params($request, $name, $path, $domain);
-        return Hm_Functions::setcookie($name, $value, $this->lifetime, $path, $domain, $request->tls, $html_only);
+        return Hm_Functions::setcookie($name, $value, $this->lifetime, $path, $domain, $request->tls, $html_only, $same_site);
     }
 
     /**

--- a/modules/api_login/modules.php
+++ b/modules/api_login/modules.php
@@ -20,8 +20,8 @@ class Hm_Handler_api_login_step_two extends Hm_Handler_login {
             return;
         }
         list($secure, $path, $domain) = $this->session->set_session_params($this->request);
-        Hm_Functions::setcookie('hm_id', stripslashes($form['hm_id']), 0, $path, $domain, $secure, true);
-        Hm_Functions::setcookie('hm_session', stripslashes($form['hm_session']), 0, $path, $domain, $secure, true);
+        Hm_Functions::setcookie('hm_id', stripslashes($form['hm_id']), 0, $path, $domain, $secure, true, 'Lax');
+        Hm_Functions::setcookie('hm_session', stripslashes($form['hm_session']), 0, $path, $domain, $secure, true, 'Lax');
         Hm_Dispatch::page_redirect('?page=home');
     }
 }


### PR DESCRIPTION
For [issue !776 ](https://github.com/cypht-org/cypht/issues/776) and [this !978](https://github.com/cypht-org/cypht/issues/978)
We found that the SameSite option for the cookie caused a redirect to cypht after a successful authentication from OAuth2 failed. As a solution, we used Lax instead of Strict value for hm_session and hm_id cookies, which worked perfectly.