### PR TITLE
Auto detect IMAP special folders when configuring account

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1103,8 +1103,9 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
 
                 Hm_Msgs::add("Server saved");
                 $this->out('just_saved_credentials', true);
-                $this->out('nux_server_id', $this->imap_server_id);
-                $this->out('nux_service_name', $provider);
+                $this->out('imap_server_id', $this->imap_server_id);
+                $this->out('imap_service_name', $provider);
+                $this->out('imap_folders_enabled', $this->module_is_supported('imap_folders'));
             }
         }
     }

--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1103,6 +1103,8 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
 
                 Hm_Msgs::add("Server saved");
                 $this->out('just_saved_credentials', true);
+                $this->out('nux_server_id', $this->imap_server_id);
+                $this->out('nux_service_name', $provider);
             }
         }
     }

--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1101,11 +1101,12 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
                     add_profile($profileName, $profileSignature, $profileReplyTo, $profileIsDefault, $email, $imapAddress, $this->smtp_server_id, $this->imap_server_id, $this);
                 }
 
-                Hm_Msgs::add("Server saved");
+                if ($this->module_is_supported('imap_folders')) {
+                    $this->out('imap_server_id', $this->imap_server_id);
+                    $this->out('imap_service_name', $provider);
+                }
                 $this->out('just_saved_credentials', true);
-                $this->out('imap_server_id', $this->imap_server_id);
-                $this->out('imap_service_name', $provider);
-                $this->out('imap_folders_enabled', $this->module_is_supported('imap_folders'));
+                Hm_Msgs::add("Server saved");
             }
         }
     }

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -217,6 +217,8 @@ return array(
         'msg_parts' => array(FILTER_UNSAFE_RAW, false),
         'page_links' => array(FILTER_UNSAFE_RAW, false),
         'folder_status' => array(FILTER_DEFAULT, FILTER_REQUIRE_ARRAY),
+        'nux_server_id' => array(FILTER_DEFAULT, false),
+        'nux_service_name' => array(FILTER_DEFAULT, false)
     ),
     'allowed_cookie' => array(
         'CYPHTID' => FILTER_DEFAULT,

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -219,7 +219,6 @@ return array(
         'folder_status' => array(FILTER_DEFAULT, FILTER_REQUIRE_ARRAY),
         'imap_server_id' => array(FILTER_DEFAULT, false),
         'imap_service_name' => array(FILTER_DEFAULT, false),
-        'imap_folders_enabled' => array(FILTER_VALIDATE_BOOLEAN, false)
     ),
     'allowed_cookie' => array(
         'CYPHTID' => FILTER_DEFAULT,

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -217,8 +217,9 @@ return array(
         'msg_parts' => array(FILTER_UNSAFE_RAW, false),
         'page_links' => array(FILTER_UNSAFE_RAW, false),
         'folder_status' => array(FILTER_DEFAULT, FILTER_REQUIRE_ARRAY),
-        'nux_server_id' => array(FILTER_DEFAULT, false),
-        'nux_service_name' => array(FILTER_DEFAULT, false)
+        'imap_server_id' => array(FILTER_DEFAULT, false),
+        'imap_service_name' => array(FILTER_DEFAULT, false),
+        'imap_folders_enabled' => array(FILTER_VALIDATE_BOOLEAN, false)
     ),
     'allowed_cookie' => array(
         'CYPHTID' => FILTER_DEFAULT,

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -2188,11 +2188,11 @@ function submitSmtpImapServer() {
         Hm_Notices.show(res.router_user_msgs);
 
         if (res.just_saved_credentials) {
-            if (res.nux_server_id) {
+            if (res.imap_server_id && res.imap_folders_enabled) {
                 Hm_Ajax.request(
                     [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
-                    {'name': 'imap_server_id', value: res.nux_server_id},
-                    {'name': 'imap_service_name', value: res.nux_service_name}],
+                    {'name': 'imap_server_id', value: res.imap_server_id},
+                    {'name': 'imap_service_name', value: res.imap_service_name}],
                     function () {
                         resetQuickSetupForm();
                     }

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -2188,7 +2188,7 @@ function submitSmtpImapServer() {
         Hm_Notices.show(res.router_user_msgs);
 
         if (res.just_saved_credentials) {
-            if (res.imap_server_id && res.imap_folders_enabled) {
+            if (res.imap_server_id) {
                 Hm_Ajax.request(
                     [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
                     {'name': 'imap_server_id', value: res.imap_server_id},

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -2188,32 +2188,47 @@ function submitSmtpImapServer() {
         Hm_Notices.show(res.router_user_msgs);
 
         if (res.just_saved_credentials) {
-            $('#srv_setup_stepper_stepper').find('form').trigger('reset');
-            display_config_step(0);
-
-            //Initialize the form
-            $("#srv_setup_stepper_profile_reply_to").val('');
-            $("#srv_setup_stepper_profile_signature").val('');
-            $("#srv_setup_stepper_profile_name").val('');
-            $("#srv_setup_stepper_email").val('');
-            $("#srv_setup_stepper_password").val('');
-            $("#srv_setup_stepper_profile_is_default").prop('checked', true);
-            $("#srv_setup_stepper_is_sender").prop('checked', true);
-            $("#srv_setup_stepper_is_receiver").prop('checked', true);
-            $("#srv_setup_stepper_enable_sieve").prop('checked', false);
-            $("#srv_setup_stepper_only_jmap").prop('checked', false);
-            $('#step_config-imap_bloc').show();
-            $('#step_config-smtp_bloc').show();
-            $('#srv_setup_stepper_profile_bloc').show();
-
-            Hm_Utils.set_unsaved_changes(1);
-            Hm_Folders.reload_folders(true);
-            location.reload();
+            if (res.nux_server_id) {
+                Hm_Ajax.request(
+                    [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
+                    {'name': 'imap_server_id', value: res.nux_server_id},
+                    {'name': 'imap_service_name', value: res.nux_service_name}],
+                    function () {
+                        resetQuickSetupForm();
+                    }
+                );
+            } else {
+                resetQuickSetupForm();
+            }
         }
     }, null, null, function (res) {
         $('#srv_setup_stepper_form_loader').addClass('hide');
         $('.step_config-actions').removeClass('hide');
     });
+}
+
+function resetQuickSetupForm() {
+    $('#srv_setup_stepper_stepper').find('form').trigger('reset');
+    display_config_step(0);
+
+    //Initialize the form
+    $("#srv_setup_stepper_profile_reply_to").val('');
+    $("#srv_setup_stepper_profile_signature").val('');
+    $("#srv_setup_stepper_profile_name").val('');
+    $("#srv_setup_stepper_email").val('');
+    $("#srv_setup_stepper_password").val('');
+    $("#srv_setup_stepper_profile_is_default").prop('checked', true);
+    $("#srv_setup_stepper_is_sender").prop('checked', true);
+    $("#srv_setup_stepper_is_receiver").prop('checked', true);
+    $("#srv_setup_stepper_enable_sieve").prop('checked', false);
+    $("#srv_setup_stepper_only_jmap").prop('checked', false);
+    $('#step_config-imap_bloc').show();
+    $('#step_config-smtp_bloc').show();
+    $('#srv_setup_stepper_profile_bloc').show();
+
+    Hm_Utils.set_unsaved_changes(1);
+    Hm_Folders.reload_folders(true);
+    location.reload();
 }
 
 function handleCreateProfileCheckboxChange(checkbox) {

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -129,11 +129,6 @@ class Hm_Handler_process_special_folder extends Hm_Handler_Module {
  */
 class Hm_Handler_process_accept_special_folders extends Hm_Handler_Module {
     public function process() {
-        
-        if (!$this->module_is_supported('imap_folders')) {
-            Hm_Msgs('ERRIMAP folders module is not enabled');
-            return;
-        }
 
         list($success, $form) = $this->process_form(array('imap_server_id', 'imap_service_name'));
         if ($success) {

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -129,6 +129,12 @@ class Hm_Handler_process_special_folder extends Hm_Handler_Module {
  */
 class Hm_Handler_process_accept_special_folders extends Hm_Handler_Module {
     public function process() {
+        
+        if (!$this->module_is_supported('imap_folders')) {
+            Hm_Msgs('ERRIMAP folders module is not enabled');
+            return;
+        }
+
         list($success, $form) = $this->process_form(array('imap_server_id', 'imap_service_name'));
         if ($success) {
             $cache = Hm_IMAP_List::get_cache($this->cache, $form['imap_server_id']);

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -209,9 +209,10 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->save_hm_msgs();
                     $this->session->close_early();
                     $this->out('nux_account_added', true);
-                    $this->out('nux_server_id', $new_id);
-                    $this->out('nux_service_name', $form['nux_service']);
-                    $this->out('nux_imap_folders_enabled', $this->module_is_supported('imap_folders'));
+                    if ($this->module_is_supported('imap_folders')) {
+                        $this->out('nux_server_id', $new_id);
+                        $this->out('nux_service_name', $form['nux_service']);
+                    }
                 }
                 else {
                     Hm_IMAP_List::del($new_id);

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -211,6 +211,7 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->out('nux_account_added', true);
                     $this->out('nux_server_id', $new_id);
                     $this->out('nux_service_name', $form['nux_service']);
+                    $this->out('nux_imap_folders_enabled', $this->module_is_supported('imap_folders'));
                 }
                 else {
                     Hm_IMAP_List::del($new_id);

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -66,7 +66,7 @@ return array(
         'nux_service_step_two' => array(FILTER_UNSAFE_RAW, false),
         'service_details' => array(FILTER_UNSAFE_RAW, false),
         'nux_account_added' => array(FILTER_VALIDATE_BOOLEAN, false),
-        'nux_server_id' => array(FILTER_VALIDATE_INT, false),
+        'nux_server_id' => array(FILTER_DEFAULT, false),
         'nux_service_name' => array(FILTER_DEFAULT, false)
     ),
     'allowed_post' => array(

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -68,7 +68,6 @@ return array(
         'nux_account_added' => array(FILTER_VALIDATE_BOOLEAN, false),
         'nux_server_id' => array(FILTER_DEFAULT, false),
         'nux_service_name' => array(FILTER_DEFAULT, false),
-        'nux_imap_folders_enabled' => array(FILTER_VALIDATE_BOOLEAN, false)
     ),
     'allowed_post' => array(
         'nux_service' => FILTER_DEFAULT,

--- a/modules/nux/setup.php
+++ b/modules/nux/setup.php
@@ -67,7 +67,8 @@ return array(
         'service_details' => array(FILTER_UNSAFE_RAW, false),
         'nux_account_added' => array(FILTER_VALIDATE_BOOLEAN, false),
         'nux_server_id' => array(FILTER_DEFAULT, false),
-        'nux_service_name' => array(FILTER_DEFAULT, false)
+        'nux_service_name' => array(FILTER_DEFAULT, false),
+        'nux_imap_folders_enabled' => array(FILTER_VALIDATE_BOOLEAN, false)
     ),
     'allowed_post' => array(
         'nux_service' => FILTER_DEFAULT,

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -47,7 +47,7 @@ var nux_add_account = function() {
 
 var display_final_nux_step = function(res) {
     if (res.nux_account_added) {
-        if (res.nux_server_id && res.nux_imap_folders_enabled) {
+        if (res.nux_server_id) {
             Hm_Ajax.request(
                 [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
                 {'name': 'imap_server_id', value: res.nux_server_id},

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -47,7 +47,7 @@ var nux_add_account = function() {
 
 var display_final_nux_step = function(res) {
     if (res.nux_account_added) {
-        if (confirm('Do you accept special folders?')) {
+        if (res.nux_server_id && res.nux_imap_folders_enabled) {
             Hm_Ajax.request(
                 [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
                 {'name': 'imap_server_id', value: res.nux_server_id},

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -52,11 +52,13 @@ var display_final_nux_step = function(res) {
                 [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_accept_special_folders'},
                 {'name': 'imap_server_id', value: res.nux_server_id},
                 {'name': 'imap_service_name', value: res.nux_service_name}],
-                false
+                function () {
+                    Hm_Utils.redirect();
+                }
             );
+        } else {
+            Hm_Utils.redirect();
         }
-
-        Hm_Utils.redirect();
     }
 };
 


### PR DESCRIPTION
## PR
After [https://github.com/cypht-org/cypht/pull/625](https://github.com/cypht-org/cypht/pull/625), cypht was unable to auto detect IMAP special folders (Trash/Sent/Drafts) even though they exist on the server.
Based on "RFC 6154: IMAP LIST Extension for Special-Use Mailboxes"

### Related issue:
[https://github.com/cypht-org/cypht/issues/817](https://github.com/cypht-org/cypht/issues/817)

