### PR TITLE
[ENH]: add profiles and imap_folders to default enabled modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,7 +191,7 @@ WORDPRESS_CLIENT_URI=
 RECAPTCHA_SECRET=
 RECAPTCHA_SITE_KEY=
 
-CYPHT_MODULES="core,contacts,local_contacts,ldap_contacts,gmail_contacts,feeds,jmap,imap,smtp,account,idle_timer,desktop_notifications,calendar,themes,nux,developer"
+CYPHT_MODULES="core,contacts,local_contacts,ldap_contacts,gmail_contacts,feeds,jmap,imap,smtp,account,idle_timer,desktop_notifications,calendar,themes,nux,developer,profiles,imap_folders"
 
 #LoginPage
 FANCY_LOGIN=false


### PR DESCRIPTION
This PR adds **profiles** and **imap_folders** to default enabled modules within `.env.example`
### Issue
Some users creating a `.env` file from .env.example are encountering the error message **_Please create a profile for saving sent messages option_**. Some of them may not know how to do so, as the related menus (profiles or folders) are not visible by default. The same issue occurs for users starting Cypht from the Docker image [https://github.com/cypht-org/cypht/pull/1001](https://github.com/cypht-org/cypht/pull/1001)