### PR TITLE
Sieve: fixed multiple actions broken by validation

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1459,7 +1459,7 @@ if (!hm_exists('connect_to_imap_server')) {
 
                 include APP_PATH.'modules/sievefilters/hm-sieve.php';
                 $sieveClientFactory = new Hm_Sieve_Client_Factory();
-                $client = $sieveClientFactory::init(null, $server);
+                $client = $sieveClientFactory->init(null, $server);
 
                 if (!$client) {
                     Hm_Msgs::add("ERRFailed to authenticate to the Sieve host");

--- a/modules/sievefilters/setup.php
+++ b/modules/sievefilters/setup.php
@@ -141,7 +141,7 @@ return array(
         'actions_json' => FILTER_UNSAFE_RAW,
         'filter_test_type' => FILTER_DEFAULT,
         'imap_msg_uid' => FILTER_VALIDATE_INT,
-        'imap_server_id' => FILTER_VALIDATE_INT,
+        'imap_server_id' => FILTER_DEFAULT,
         'folder' => FILTER_DEFAULT,
         'sender' => FILTER_UNSAFE_RAW,
         'selected_behaviour' => FILTER_DEFAULT,


### PR DESCRIPTION
Now Cypht uses uniqid for entities id, block domain/user action and default block behavior where affected by this issue.

Fixes also PHP Fatal error:  Uncaught Error: Non-static method Hm_Sieve_Client_Factory::init() cannot be called statically in /path/to/cypht/modules/imap/functions.php:1462