### PR TITLE
Update .gitignore to exclude Docker's persistence directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ composer.phar
 lib/hm3/users/
 .env
 /data/
+/docker/data/


### PR DESCRIPTION
Docker's persistence folder **(data)** was not being ignored.

This is a small update to [https://github.com/cypht-org/cypht/pull/1001](https://github.com/cypht-org/cypht/pull/1001)