### PR TITLE
Resolve Creation of dynamic property Hm_IMAP::$ banner is deprecated

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -142,6 +142,8 @@ if (!class_exists('Hm_IMAP')) {
         public $con_error_msg = '';
         public $con_error_num = 0;
 
+        public $banner = '';
+
         /* holds information about the currently selected mailbox */
         public $selected_mailbox = false;
 


### PR DESCRIPTION
Resolve:
[Tue Jun 04 15:55:53.353593 2024] [php:notice] [pid 12692:tid 1896] [client ::1:14290] PHP Deprecated:  Creation of dynamic property Hm_IMAP::$banner is deprecated in hm-imap.php