### PR TITLE
Fix adding one server multiple times

### DIFF
--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -546,6 +546,28 @@ function in_server_list($list, $id, $user) {
 }}
 
 /**
+ * Perform a check on last added server
+ * It gets deleted if already configured
+ * 
+ * @param string $list class to process on check
+ * @param string $user username to check for
+ * @return bool
+ */
+if (!hm_exists('can_save_last_added_server')) {
+function can_save_last_added_server($list, $user) {
+    $servers = $list::dump(false, true);
+    $ids = array_keys($servers);
+    $new_id = array_pop($ids);
+    if (in_server_list($list, $new_id, $user)) {
+        $list::del($new_id);
+        $type = explode('_', $list)[1];
+        Hm_Msgs::add('ERRThis ' . $type . ' server and username are already configured');
+        return false;
+    }
+    return true;
+}}
+
+/**
  * @subpackage core/functions
  */
 if (!hm_exists('profiles_by_smtp_id')) {

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -2186,7 +2186,6 @@ function submitSmtpImapServer() {
     Hm_Ajax.request(requestData, function(res) {
         $('#srv_setup_stepper_form_loader').addClass('hide');
         $('.step_config-actions').removeClass('hide');
-        Hm_Notices.show(res.router_user_msgs);
 
         if (res.just_saved_credentials) {
             if (res.imap_server_id) {

--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1449,6 +1449,10 @@ if (!hm_exists('connect_to_imap_server')) {
         }
 
         $imap_server_id = Hm_IMAP_List::add($imap_list);
+        if (! can_save_last_added_server('Hm_IMAP_List', $user)) {
+            return;
+        }
+
         $server = Hm_IMAP_List::get($imap_server_id, false);
 
         if ($enableSieve &&

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -172,13 +172,8 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                 if ($details['sieve'] && $this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', true)) {
                     $imap_list['sieve_config_host'] = $details['sieve']['host'].':'.$details['sieve']['port'];
                 }
-                Hm_IMAP_List::add($imap_list);
-                $servers = Hm_IMAP_List::dump(false, true);
-                $ids = array_keys($servers);
-                $new_id = array_pop($ids);
-                if (in_server_list('Hm_IMAP_List', $new_id, $form['nux_email'])) {
-                    Hm_IMAP_List::del($new_id);
-                    Hm_Msgs::add('ERRThis IMAP server and username are already configured');
+                $new_id = Hm_IMAP_List::add($imap_list);
+                if (! can_save_last_added_server('Hm_IMAP_List', $form['nux_email'])) {
                     return;
                 }
                 $imap = Hm_IMAP_List::connect($new_id, false);
@@ -192,13 +187,8 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                             'user' => $form['nux_email'],
                             'pass' => $form['nux_pass']
                         ));
-                        $this->session->record_unsaved('SMTP server added');
-                        $smtp_servers = Hm_SMTP_List::dump(false, true);
-                        $ids = array_keys($servers);
-                        $new_smtp_id = array_pop($ids);
-                        if (in_server_list('Hm_SMTP_List', $new_smtp_id, $form['nux_email'])) {
-                            Hm_SMTP_List::del($new_smtp_id);
-                            Hm_Msgs::add('ERRThis SMTP server and username are already configured');
+                        if (can_save_last_added_server('Hm_SMTP_List', $form['nux_email'])) {
+                            $this->session->record_unsaved('SMTP server added');
                         }
                     }
                     Hm_IMAP_List::clean_up();

--- a/modules/smtp/functions.php
+++ b/modules/smtp/functions.php
@@ -15,6 +15,9 @@ if (!hm_exists('connect_to_smtp_server')) {
             'tls' => $tls);
 
         $smtp_server_id =  Hm_SMTP_List::add($smtp_list);
+        if (! can_save_last_added_server('Hm_SMTP_List', $user)) {
+            return;
+        }
 
         $smtp = Hm_SMTP_List::connect($smtp_server_id, false);
         if (smtp_authed($smtp)) {


### PR DESCRIPTION
Added constraint to only store a server if it is not already configured. Also fixed displaying error messages twice in smtp-imap-jmap section, 