### PR TITLE
[FIX]Fixing the display of parent folder when creating subfolder

### DIFF
--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -62,8 +62,8 @@ var expand_folders_page_list = function(path, container, link_class, target, id_
 var set_folders_page_value = function(id, container, target, id_dest) {
     var list = $('.'+container);
     var list_item = $('.'+Hm_Utils.clean_selector(id), list);
-    var link = $('a', list_item).first().text();
-    if (link == '+' || link == '-') {
+    var link = $('a', list_item).not('.expand_link').first().text();
+    if (! link) {
         link = $('a', list_item).eq(1).text();
     }
     $('.'+target).html(link);


### PR DESCRIPTION
This PR fixes the display of parent folder when creating subfolder as we can see from the two videos bellow.

Before fix

https://github.com/cypht-org/cypht/assets/44422833/2dd9cd88-c7eb-409e-bead-19e5468cdc46



After fix

https://github.com/cypht-org/cypht/assets/44422833/60757959-931d-402b-abe7-f2d81e296149



