### PR TITLE
[FIX]Fix bootstrap icon issue on collapse folder subfolders

### DIFF
--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -53,7 +53,7 @@ var expand_folders_page_list = function(path, container, link_class, target, id_
         }
     }
     else {
-        $('.expand_link', list).html('+');
+        $('.expand_link', list).html('<i class="bi bi-plus-circle-fill"></i>');
         $('ul', list).remove();
     }
     return false;


### PR DESCRIPTION
This PR is fixing the bootstrap icon issue when subfolders are collapsed when managing IMAP folders as we can see in the video below:


https://github.com/cypht-org/cypht/assets/44422833/9a557b63-be99-4c3d-99b5-fa170e83ce9c

