### PR TITLE
Fix Class ScramAuthenticator not found

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -11,6 +11,7 @@ require_once('hm-imap-parser.php');
 require_once('hm-imap-cache.php');
 require_once('hm-imap-bodystructure.php');
 require_once('hm-jmap.php');
+require_once('../scram/scram.php');
 
 /**
  * IMAP connection manager

--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -5,6 +5,7 @@
  * @package modules
  * @subpackage smtp
  */
+require_once('../scram/scram.php');
 
 /**
  * SMTP connection manager
@@ -51,7 +52,6 @@ class Hm_SMTP_List {
         return $addrs;
     }
 }
-
 /**
  * Connect to and interact with SMTP servers
  * @subpackage smtp/lib


### PR DESCRIPTION
Related issue
![photo_2024-06-13_16-02-00](https://github.com/cypht-org/cypht/assets/60602749/de262fbc-e782-41ca-8056-6a02c9e8b662)
