### PR TITLE
Fix undeclared properties in hm-feed.php

### DIFF
--- a/modules/feeds/hm-feed.php
+++ b/modules/feeds/hm-feed.php
@@ -75,6 +75,8 @@ class Hm_Feed {
     var $init_cache;
     var $cache_limit;
     var $sort;
+    var $status_code;
+    var $feed_type;
 
     /**
      * Setup defaults


### PR DESCRIPTION
Fixes `PHP Fatal error:  Uncaught Error: Call to undefined method Hm_Contact::dump() in /path/to/cypht/lib/repository.php:59` and creation of dynamic proporties