### PR TITLE
[FIX]: Update setup_database.php to load environment before getting config object

### DIFF
--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -8,6 +8,10 @@ define('VENDOR_PATH', APP_PATH.'vendor/');
 require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
 
+$environment = Hm_Environment::getInstance();
+$environment->load();
+
+/* get config object */
 $config = new Hm_Site_Config_File();
 
 $session_type = $config->get('session_type');


### PR DESCRIPTION
## Pullrequest
When trying to run the script `php ./scripts/setup_database.php`, the system is using the default config values and not loading values from the `.env` file.
This script is also being used by docker when it is trying to setup database tables

### Related Issue
[https://github.com/cypht-org/cypht/issues/1089](https://github.com/cypht-org/cypht/issues/1089)
