### PR TITLE
[EHN]Email filtering: Cypht Sieve filters: Better handling of 'Stop processing more rules'

### DIFF
--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -87,6 +87,15 @@ if (!hm_exists('get_classic_filter_modal_content')) {
                         </table>
                     </div>
                 </div>
+                <hr/>
+                <div class="p-3">
+                    <div class="d-flex">
+                        <div class="col-sm-10">
+                            <input type="checkbox" id="stop_filtering"/>
+                            <label for="stop_filtering" class="form-label">Stop filtering</label>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>';
     }

--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -86,12 +86,6 @@ var hm_sieve_possible_actions = function() {
             extra_field: false
         },
         {
-            name: 'stop',
-            description: 'Stop Filtering',
-            type: 'none',
-            extra_field: false
-        },
-        {
             name: 'copy',
             description: 'Copy email to mailbox',
             placeholder: 'Mailbox Name (Folder)',
@@ -456,6 +450,16 @@ $(function () {
                 idx = idx + 1;
             });
 
+            if ($('#stop_filtering').is(':checked')) {
+                actions_parsed.push(
+                    {
+                        'action': "stop",
+                        'value': "",
+                        'extra_option': "",
+                        'extra_option_value': "",
+                    }
+                )
+            }
             if ($('.modal_sieve_filter_name').val() == "") {
                 Hm_Utils.add_sys_message(hm_trans('Filter name is required'), 'danger');
                 return false;
@@ -523,6 +527,9 @@ $(function () {
         });
         $('.add_filter').on('click', function () {
             edit_filter_modal.setTitle('Add Filter');
+            $('.modal_sieve_filter_priority').val('');
+            $('.modal_sieve_filter_test').val('ALLOF');
+            $('#stop_filtering').prop('checked', false);
             current_account = $(this).attr('account');
             edit_filter_modal.open();
         });
@@ -648,7 +655,6 @@ $(function () {
                 }
                 possible_actions_html += '<option value="'+value.name+'">' + value.description + '</option>';
             });
-
             let extra_options = '<td class="col-sm-3"><input type="hidden" class="condition_extra_action_value form-control form-control-sm" name="sieve_selected_extra_action_value[]" /></td>';
             $('.filter_actions_modal_table').append(
                 '<tr class="border" default_value="'+default_value+'">' +
@@ -905,6 +911,7 @@ $(function () {
             is_editing_filter = true;
             current_editing_filter_name = $(this).attr('script_name');
             current_account = $(this).attr('imap_account');
+            // $('#stop_filtering').prop('checked', false);
             $('.modal_sieve_filter_name').val($(this).attr('script_name_parsed'));
             $('.modal_sieve_filter_priority').val($(this).attr('priority'));
             $('.sieve_list_conditions_modal').html('');
@@ -930,14 +937,18 @@ $(function () {
                     });
 
                     actions.forEach(function (action) {
-                        add_filter_action(action.value);
-                        $(".sieve_actions_select").last().val(action.action);
-                        $(".sieve_actions_select").last().trigger('change');
-                        $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
-                        if ($("[name^=sieve_selected_action_value]").last().is('input')) {
-                            $("[name^=sieve_selected_action_value]").last().val(action.value);
-                        } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
-                            $("[name^=sieve_selected_action_value]").last().text(action.value);
+                        if (action.action === "stop") {
+                            $('#stop_filtering').prop('checked', true);
+                        } else {
+                            add_filter_action(action.value);
+                            $(".sieve_actions_select").last().val(action.action);
+                            $(".sieve_actions_select").last().trigger('change');
+                            $("[name^=sieve_selected_extra_action_value]").last().val(action.extra_option_value);
+                            if ($("[name^=sieve_selected_action_value]").last().is('input')) {
+                                $("[name^=sieve_selected_action_value]").last().val(action.value);
+                            } else if ($("[name^=sieve_selected_action_value]").last().is('textarea')) {
+                                $("[name^=sieve_selected_action_value]").last().text(action.value);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Sometimes, you might set up several rules that could apply to a single message. If you created a rule to move all messages with a subject line of "Wedding plans" to a folder, for example, and then created another rule to delete all messages with attachments, you probably wouldn't want a message related to wedding plans that has an attachment to be deleted. To prevent this from happening, you can set the option Stop processing more rules on the first rule.

![stop-filtering](https://github.com/cypht-org/cypht/assets/62720246/6ad18221-b151-4f40-81dc-6a7488128476)
