### PR TITLE
Fixed phpunit broken test

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1564,12 +1564,12 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
             if (! empty($auth_server['sieve_config_host'])) {
                 $imap_details['sieve_config_host'] = $auth_server['sieve_config_host'];
             }
-        }
-        if (!$default_server_id) {
-            Hm_IMAP_List::add($imap_details);
-        } else {
-            // Perhaps something as changed
-            Hm_IMAP_List::edit($default_server_id, $imap_details);
+            if (!$default_server_id) {
+                Hm_IMAP_List::add($imap_details);
+            } else {
+                // Perhaps something as changed
+                Hm_IMAP_List::edit($default_server_id, $imap_details);
+            }
         }
     }
 }

--- a/tests/phpunit/config.php
+++ b/tests/phpunit/config.php
@@ -41,7 +41,7 @@ class Hm_Test_User_File_Config extends TestCase {
         $this->assertEquals(array('imap_servers' => array(array())), $this->config->filter_servers());
 
         $this->config->set('imap_servers', array(array('default' => 1, 'server' => 'localhost')));
-        $this->assertEquals(array('imap_servers' => array(array('default' => 1, 'server' => 'localhost'))), $this->config->filter_servers());
+        $this->assertEquals(array(), $this->config->filter_servers());
 
         $this->config->set('imap_servers', array(array('pass' => 'foo', 'server' => 'localhost')));
         $this->config->set('no_password_save_setting', true);


### PR DESCRIPTION
Follow up to https://github.com/cypht-org/cypht/pull/1099 to fix access to $imap_details when no imap auth server and also unit test