### PR TITLE
[FIX]Displaying multiple messages with the same content for a given a…

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -257,7 +257,7 @@ var Hm_Ajax_Request = function() { return {
                 Hm_Ajax.err_condition = false;
                 Hm_Notices.hide(true);
             }
-            if (res.router_user_msgs && !$.isEmptyObject(res.router_user_msgs)) {
+            if (res.router_user_msgs && !$.isEmptyObject(res.router_user_msgs)) {             
                 Hm_Notices.show(res.router_user_msgs);
             }
             if (res.folder_status) {

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -280,9 +280,6 @@ class Hm_Handler_imap_process_move extends Hm_Handler_Module {
             elseif (count($moved) == 0) {
                 Hm_Msgs::add('ERRUnable to move/copy selected messages');
             }
-            if ($form['imap_move_action'] == 'move' && $form['imap_move_page'] == 'message') {
-                $this->save_hm_msgs();
-            }
             $this->out('move_count', $moved);
         }
     }
@@ -875,7 +872,6 @@ class Hm_Handler_imap_delete_message extends Hm_Handler_Module {
                 Hm_Msgs::add('Message deleted');
                 $this->out('imap_delete_error', false);
             }
-            $this->save_hm_msgs();
         }
     }
 }
@@ -940,7 +936,6 @@ class Hm_Handler_imap_archive_message extends Hm_Handler_Module {
                 Hm_Msgs::add('ERRAn error occurred archiving the message');
             }
         }
-        $this->save_hm_msgs();
     }
 }
 
@@ -1020,7 +1015,6 @@ class Hm_Handler_imap_snooze_message extends Hm_Handler_Module {
             $msg = 'ERRFailed to snooze selected messages';
         }
         Hm_Msgs::add($msg);
-        $this->save_hm_msgs();
     }
 }
 

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -196,7 +196,6 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     $this->session->record_unsaved('SMTP server added');
                     $this->session->secure_cookie($this->request, 'hm_reload_folders', '1');
                     Hm_Msgs::add('E-mail account successfully added');
-                    $this->save_hm_msgs();
                     $this->session->close_early();
                     $this->out('nux_account_added', true);
                     if ($this->module_is_supported('imap_folders')) {


### PR DESCRIPTION
Displaying multiple messages with the same content for a given action

Here are 2 cases that this PR solves:
1. First case: After sending a message, and you have 2 or 3 tabs open, you keep that the message indicating that "the message is sent" is displayed several times on the other tabs open.

Ilistration:
![01-first-case](https://github.com/cypht-org/cypht/assets/62720246/e5e7c5e6-698c-45c0-8758-6b27b7775107)


3. 2nd case: When deleting a message in inline mode, we have the message "Message deleted" which also comes up as many times.
Ilistration:
![02-second-case](https://github.com/cypht-org/cypht/assets/62720246/b639d913-6b65-4c36-9228-5861938bf26e)
