### PR TITLE
[FIX]Cypht in Tiki: fixing errors in Tiki webmail

### DIFF
--- a/lib/framework.php
+++ b/lib/framework.php
@@ -211,7 +211,11 @@ if (!class_exists('Hm_Functions')) {
             if ($type === INPUT_SERVER) {
                 $value = array();
                 foreach ($filters as $var => $flag) {
-                    $value[$var] = filter_var($_SERVER[$var], $flag);
+                    if (isset($_SERVER[$var])) {
+                        $value[$var] = filter_var($_SERVER[$var], $flag);
+                    } else {
+                        $value[$var] = null;
+                    }
                 }
                 return $value;
             }

--- a/lib/request.php
+++ b/lib/request.php
@@ -192,7 +192,7 @@ class Hm_Request {
      * @return void
      */
     private function is_tls() {
-        if (array_key_exists('HTTPS', $this->server) && strtolower($this->server['HTTPS']) == 'on') {
+        if (array_key_exists('HTTPS', $this->server) && !is_null($this->server['HTTPS']) && strtolower($this->server['HTTPS']) == 'on') {
             $this->tls = true;
         } elseif (array_key_exists('REQUEST_SCHEME', $this->server) && strtolower($this->server['REQUEST_SCHEME']) == 'https') {
             $this->tls = true;
@@ -218,7 +218,9 @@ class Hm_Request {
      * @return bool true if the request is from an AJAX call
      */
     public function is_ajax() {
-        return array_key_exists('HTTP_X_REQUESTED_WITH', $this->server) && strtolower($this->server['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+        return array_key_exists('HTTP_X_REQUESTED_WITH', $this->server)
+        && !is_null($this->server['HTTP_X_REQUESTED_WITH'])
+        && strtolower($this->server['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
     }
 
     /**

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1545,6 +1545,7 @@ class Hm_Handler_load_imap_servers_from_config extends Hm_Handler_Module {
             }
         }
         $auth_server = $this->session->get('imap_auth_server_settings', array());
+        $imap_details = array();
         if (!empty($auth_server)) {
             if (array_key_exists('name', $auth_server)) {
                 $name = $auth_server['name'];

--- a/modules/profiles/hm-profiles.php
+++ b/modules/profiles/hm-profiles.php
@@ -88,6 +88,9 @@ class Hm_Profiles {
     public static function loadLegacy($hmod) {
         if ($hmod->module_is_supported('imap')) {
             foreach (Hm_IMAP_List::dump() as $id => $server) {
+                if (!array_key_exists('server', $server) || !array_key_exists('user', $server)) {
+                    continue;
+                }
                 $profile = $hmod->user_config->get('profile_imap_'.$server['server'].'_'.$server['user'], array(
                     'profile_default' => false, 'profile_name' => '', 'profile_address' => '',
                     'profile_replyto' => '', 'profile_smtp' => '', 'profile_sig' => '', 'profile_rmk' => ''));


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] Warnings
![Capture d'écran 2024-07-02 212031](https://github.com/cypht-org/cypht/assets/81784141/a519149b-cb5d-499d-95f7-2e8b5a3fac12)
- [X]  ` NOTICE (E_DEPRECATED): strtolower(): Passing null to parameter #1 ($string) of type string is deprecated `

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] Go to tiki-webmail.php
