### PR TITLE
fix imap sorting

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -682,7 +682,8 @@ function Message_List() {
                 }
             });
         }
-        if (element) {
+        // apply JS pagination only on aggregate folders; imap ones already have the messages sorted
+        if (hm_list_path().substring(0, 5) != 'imap_' && element) {
             $(row, msg_rows).insertBefore(element);
         }
         else {

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1059,6 +1059,7 @@ if (!class_exists('Hm_IMAP')) {
                     }
                 }
             }
+            $original_uids_order = $uids;
             if (!empty($uids)) {
                 if (is_array($uids)) {
                     $uids = implode(',', $uids);
@@ -1138,6 +1139,17 @@ if (!class_exists('Hm_IMAP')) {
                 }
                 if ($esearch_enabled) {
                     $res = $esearch_res;
+                }
+                // keep original sort order of UIDS as fetch command might not return in requested order
+                // this is needed for pagination to work
+                if (! empty($original_uids_order)) {
+                    $unordered = $res;
+                    $res = [];
+                    foreach ($original_uids_order as $uid) {
+                        if (in_array($uid, $unordered)) {
+                            $res[] = $uid;
+                        }
+                    }
                 }
                 return $this->cache_return_val($res, $cache_command);
             }


### PR DESCRIPTION
* apply the sorting server-side even after searching
* disable front-size sorting in imap folders as sort dropdown has different meaning and results are already sorted server-side
