### PR TITLE
[FIX] Setting cookie SameSite to Lax when session type is set to DB

### DIFF
--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -327,6 +327,7 @@ abstract class Hm_Session {
      * @param string $value cookie value
      * @param string $path cookie path
      * @param string $domain cookie domain
+     * @param string $same_site cookie SameSite
      * @return boolean
      */
     public function secure_cookie($request, $name, $value, $path='', $domain='', $same_site = 'Strict') {

--- a/lib/session_db.php
+++ b/lib/session_db.php
@@ -50,7 +50,7 @@ class Hm_DB_Session extends Hm_PHP_Session {
      */
     public function start_new($request) {
         $this->session_key = Hm_Crypt::unique_id();
-        $this->secure_cookie($request, $this->cname, $this->session_key);
+        $this->secure_cookie($request, $this->cname, $this->session_key,  '', '', 'Lax');
         if ($this->insert_session_row()) {
             Hm_Debug::add('LOGGED IN');
             $this->active = true;


### PR DESCRIPTION
This PR follows up on [https://github.com/cypht-org/cypht/pull/1021](https://github.com/cypht-org/cypht/pull/1021); it sets the cookie attribute SameSite to `Lax` when the session type is set to DB, fixing the OAUTH2 authorization callback issue where the user was logged out after performing the authorization flow.

**Related issue:** [https://github.com/cypht-org/cypht/issues/1112](https://github.com/cypht-org/cypht/issues/1112)