### PR TITLE
[FIX] Prefetch IMAP folders after login and redirect to a page containing an ID

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1610,7 +1610,7 @@ class Hm_Handler_imap_oauth2_token_check extends Hm_Handler_Module {
         $updated = 0;
         foreach ($active as $server_id) {
             $server = Hm_IMAP_List::dump($server_id, true);
-            if (array_key_exists('auth', $server) && $server['auth'] == 'xoauth2') {
+            if ( $server && array_key_exists('auth', $server) && $server['auth'] == 'xoauth2') {
                 $results = imap_refresh_oauth2_token($server, $this->config);
                 if (!empty($results)) {
                     if (Hm_IMAP_List::update_oauth2_token($server_id, $results[1], $results[0])) {

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -528,7 +528,11 @@ var prefetch_imap_folders = function() {
         {'name': 'imap_server_id', 'value': id},
         {'name': 'imap_prefetch', 'value': true},
         {'name': 'folder', 'value': ''}],
-        function(res) { $('#imap_prefetch_ids').val(ids.join(',')); prefetch_imap_folders(); },
+        function(res) { 
+            $('#imap_prefetch_ids').val(ids.join(',')); 
+            prefetch_imap_folders();
+            expand_imap_mailbox(res);
+        },
         [],
         true
     );


### PR DESCRIPTION
This PR fixes the related issue below by ensuring the server exists before trying to refresh the oauth2_token. It also ensures that the prefetched IMAP folders are populated.

**Related issue:** [https://github.com/cypht-org/cypht/issues/928](https://github.com/cypht-org/cypht/issues/928)