### PR TITLE
[FIX]compose&reply_all: Remove Selected Email or Sender Email from Recipients List While Using 'Reply All'

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1524,7 +1524,7 @@ function smtp_server_dropdown($data, $output_mod, $recip, $selected_id=false) {
             $smtp_profiles = profiles_by_smtp_id($profiles, $vals['id']);
             if (count($smtp_profiles) > 0) {
                 foreach ($smtp_profiles as $index => $profile) {
-                    $res .= '<option ';
+                    $res .= '<option data-email="'.$profile['address'].'"';
                     if ((string) $selected === sprintf('%s.%s', $vals['id'], ($index + 1)) || (! mb_strstr(strval($selected), '.') && strval($selected) === strval($vals['id']))) {
                         $res .= 'selected="selected" ';
                     }
@@ -1534,7 +1534,7 @@ function smtp_server_dropdown($data, $output_mod, $recip, $selected_id=false) {
                 }
             }
             else {
-                $res .= '<option ';
+                $res .= '<option data-email="'.$vals['user'].'"';
                 if ($selected === $id) {
                     $res .= 'selected="selected" ';
                 }

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -611,5 +611,37 @@ $(function () {
             $(".bubble_dropdown-content").remove();
             $(this).parent().remove();
         });
+
+        var selectedOption = $('#compose_smtp_id option[selected]');
+        var selectedEmail = selectedOption.data('email');
+        var selectedVal = selectedOption.val();
+
+        var recipientsInput = $('#compose_cc');
+        var excludedEmail = null;
+
+        const excludeEmail = function () {
+            var newRecipients = recipientsInput.val().split(',').filter(function(email) {
+                if (email.includes(selectedEmail)) {
+                    excludedEmail = email;
+                    return false;
+                }
+                return true;
+            }).join(', ');
+            recipientsInput.val(newRecipients);
+        };
+
+        if (recipientsInput.val().includes(selectedEmail)) {
+            excludeEmail();
+            $(document).on('change', '#compose_smtp_id', function() {
+                if ($(this).val() !== selectedVal) {
+                    if (!recipientsInput.val().includes(selectedEmail)) {
+                        recipientsInput.val(recipientsInput.val() + ', ' + excludedEmail);
+                    }
+                } else {
+                    excludeEmail();
+                }
+            });
+        }
+
     }
 });


### PR DESCRIPTION
This PR enhances the functionality of the email composer by ensuring that the selected email or sender email is removed from the recipients list when using the "Reply All" feature.