### PR TITLE
update total_unread_count no matter where we are

### DIFF
--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -1038,9 +1038,13 @@ var imap_background_unread_content = function(id, folder) {
         imap_background_unread_content_result,
         [],
         false,
-        function() {
+        function(r) {
+            var total_unread_count = $('.total_unread_count').text()
             var cache = $('<tbody></tbody>').append($(Hm_Utils.get_from_local_storage('formatted_unread_data')));
-            Hm_Message_List.adjust_unread_total($('tr', cache).length, true);
+            const formatted_message_list_length = Object.keys(r.formatted_message_list).length;
+            if(parseInt(total_unread_count) !== parseInt(formatted_message_list_length)) {
+                Hm_Message_List.adjust_unread_total(formatted_message_list_length, true);
+            }
         }
     );
     return false;


### PR DESCRIPTION
On other pages total_unread_count was not updated every time there was a new message, with this PR it doesn't matter which page you are on the badge is updated.

Baraka relied on this change at one point in this PR: https://github.com/cypht-org/cypht/pull/1056