### PR TITLE
Add pass to server array while connecting sieve

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1469,7 +1469,7 @@ if (!hm_exists('connect_to_imap_server')) {
             }
         }
 
-        $server = Hm_IMAP_List::get($imap_server_id, false);
+        $server = Hm_IMAP_List::get($imap_server_id, true);
 
         if ($enableSieve &&
             $imap_sieve_host &&


### PR DESCRIPTION
Stawart is connecting via PLAIN username and password, in this PR We add pass to be used in PlainAuthMechanism class while connecting. Related Issue: https://github.com/cypht-org/cypht/issues/931