### PR TITLE
reset form on add_filter click action

### DIFF
--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -532,6 +532,12 @@ $(function () {
             edit_filter_modal.setTitle('Add Filter');
             current_account = $(this).attr('account');
             edit_filter_modal.open();
+
+            // Reset the form fields when opening the modal
+            $(".modal_sieve_filter_name").val('');
+            $(".modal_sieve_script_priority").val('');
+            $(".sieve_list_conditions_modal").empty();
+            $(".filter_actions_modal_table").empty();
         });
         $('.add_script').on('click', function () {
             edit_script_modal.setTitle('Add Script');


### PR DESCRIPTION
When you click edit filter on sieve_filters page if you cancel(close) the modal and then click `Add Filter` the form is keeping old data while editing.

In this PR we make sure on Add Filter we reset the form after the  modal is opened.