### PR TITLE
[FIX]Hm_Carddav class: Declare the 'api' property to avoid deprecated dynamic  property creation in PHP 8.2+

### DIFF
--- a/modules/carddav_contacts/hm-carddav.php
+++ b/modules/carddav_contacts/hm-carddav.php
@@ -29,6 +29,7 @@ class Hm_Carddav {
         'carddav_phone' => 'tel',
         'carddav_fn' => 'fn'
     );
+    private $api;
 
     public function __construct($src, $url, $user, $pass) {
         $this->user = $user;


### PR DESCRIPTION
### Steps to reproduce:
1. Being on master login your Cypht
2. Go to compose page
3. Look at your apache error logs depending on your config: e.g. C:\Apache24\logs\error.log and get: 
`PHP Deprecated:  Creation of dynamic property Hm_Carddav::$api is deprecated in C:\\Apache24\\htdocs\\my_cypht\\modules\\carddav_contacts\\hm-carddav.php on line 38`

### Proposed fix
- Added a private property `$api` to the Hm_Carddav class.
- This fix addresses the deprecation warning in PHP 8.2+ for dynamic property creation.