### PR TITLE
[FIX]apache errors in its log:Already registered module for compose re-attempted: load_contacts AND Already registered module for contacts re-attempted: process_import_contact

### DIFF
--- a/modules/contacts/setup.php
+++ b/modules/contacts/setup.php
@@ -20,7 +20,6 @@ add_output('ajax_hm_folders', 'contacts_page_link', true, 'contacts', 'logout_me
 
 add_handler('compose', 'load_contacts', true, 'contacts', 'load_user_data', 'after');
 add_handler('compose', 'process_send_to_contact', true, 'contacts', 'save_user_data', 'before');
-add_handler('compose', 'load_contacts', true, 'contacts', 'process_compose_form_submit', 'after');
 add_handler('compose', 'store_contact_message', true, 'contacts', 'load_contacts', 'after');
 
 add_handler('ajax_imap_folder_display', 'load_contacts', true, 'contacts', 'load_user_data', 'after');

--- a/modules/local_contacts/setup.php
+++ b/modules/local_contacts/setup.php
@@ -22,6 +22,5 @@ add_handler('ajax_add_contact', 'process_add_contact_from_message', true, 'local
 add_handler('ajax_delete_contact', 'load_local_contacts', true, 'local_contacts', 'load_contacts', 'after');
 add_handler('ajax_delete_contact', 'process_delete_contact', true, 'local_contacts', 'save_user_data', 'before');
 
-add_handler('contacts', 'process_import_contact', true, 'local_contacts', 'login', 'after');
 
 return array();


### PR DESCRIPTION
This PR fix apache errors in its log :
[1] => Already registered module for compose re-attempted: load_contacts
[2] => Already registered module for contacts re-attempted: process_import_contact