### PR TITLE
Fix left navigation menu toggle buttons

### DIFF
--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -23,7 +23,7 @@ class Hm_Output_search_from_folder_list extends Hm_Output_Module {
         }
         $res .= '<div class=""><input type="hidden" name="page" value="search" />'.
             '<input type="search" class="search_terms form-control form-control-sm" '.
-            'name="search_terms" placeholder="'.$this->trans('Search').'" /></div></form></div></li>';
+            'name="search_terms" placeholder="'.$this->trans('Search').'" /></div></div></form></li>';
         if ($this->format == 'HTML5') {
             return $res;
         }
@@ -1449,7 +1449,7 @@ class Hm_Output_settings_menu_start extends Hm_Output_Module {
     protected function output() {
         $res = '<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">'.$this->trans('Settings').
             '<i class="bi bi-chevron-down"></i></div>'.
-            '</div><ul style="display: none;" class="settings folders">';
+            '<ul style="display: none;" class="settings folders">';
         $res .= '<li class="menu_home"><a class="unread_link" href="?page=home">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-house-door-fill fs-5 me-2"></i>';

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -1259,7 +1259,7 @@ class Hm_Output_folder_list_start extends Hm_Output_Module {
      * Opens the folder list nav tag
      */
     protected function output() {
-        $res = '<a class="folder_toggle" href="#"><i class="bi bi-list"></i></a>'.
+        $res = '<a class="folder_toggle" href="#">'.$this->trans('Show folders').'<i class="bi bi-list fs-5"></i></a>'.
             '<nav class="folder_cell"><div class="folder_list">';
         return $res;
     }
@@ -1588,7 +1588,7 @@ class Hm_Output_folder_list_content_end extends Hm_Output_Module {
      */
     protected function output() {
         $res = '<a href="#" class="update_message_list">'.$this->trans('[reload]').'</a>';
-        $res .= '<a href="#" class="hide_folders">'.$this->trans('Hide folders').'<i class="bi bi-caret-down-fill"'.'" alt="'.$this->trans('Collapse').'></i></a>';
+        $res .= '<a href="#" class="hide_folders">'.$this->trans('Hide folders').'<i class="bi bi-caret-left-fill fs-5"></i></a>';
         if ($this->format == 'HTML5') {
             return $res;
         }

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -612,11 +612,11 @@ button {
 .folder_toggle {
   font-size: 0px;
   float: left;
-  margin: 10px 15px;
+  margin: 15px 15px 10px 15px;
   display: none;
 }
-.folder_toggle img {
-  opacity: 0.5;
+.folder_toggle i {
+  color: var(--bs-body-color);
 }
 .prevnext {
   font-size: 1.3rem;
@@ -651,11 +651,11 @@ button {
   font-size: 0px;
   float: left;
   clear: none;
-  margin-top: 10px;
+  margin-top: 5px;
   margin-left: 23px;
 }
-.hide_folders img {
-  opacity: 0.4;
+.hide_folders i {
+  color: var(--bs-body-color);
 }
 .section_caret {
   opacity: 0.15;
@@ -990,9 +990,8 @@ div.unseen,
   display: block;
   top: 0px;
   left: -3px;
-  font-size: 20px;
   font-weight: bold;
-  margin-top: 17px !important;
+  margin-top: 15px !important;
   position: fixed;
   z-index: 101;
 }

--- a/tests/phpunit/modules/core/output_modules.php
+++ b/tests/phpunit/modules/core/output_modules.php
@@ -758,7 +758,7 @@ class Hm_Test_Core_Output_Modules extends TestCase {
     public function test_folder_list_start() {
         $test = new Output_Test('folder_list_start', 'core');
         $res = $test->run();
-        $this->assertEquals(array('<a class="folder_toggle" href="#"><i class="bi bi-list"></i></a><nav class="folder_cell"><div class="folder_list">'), $res->output_response);
+        $this->assertEquals(array('<a class="folder_toggle" href="#">Show folders<i class="bi bi-list fs-5"></i></a><nav class="folder_cell"><div class="folder_list">'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled
@@ -910,10 +910,10 @@ class Hm_Test_Core_Output_Modules extends TestCase {
     public function test_folder_list_content_end() {
         $test = new Output_Test('folder_list_content_end', 'core');
         $res = $test->run();
-        $this->assertEquals(array('<a href="#" class="update_message_list">[reload]</a><a href="#" class="hide_folders">Hide folders<i class="bi bi-caret-down-fill"" alt="Collapse></i></a>'), $res->output_response);
+        $this->assertEquals(array('<a href="#" class="update_message_list">[reload]</a><a href="#" class="hide_folders">Hide folders<i class="bi bi-caret-left-fill fs-5"></i></a>'), $res->output_response);
         $test->rtype = 'AJAX';
         $res = $test->run();
-        $this->assertEquals(array('formatted_folder_list' => '<a href="#" class="update_message_list">[reload]</a><a href="#" class="hide_folders">Hide folders<i class="bi bi-caret-down-fill"" alt="Collapse></i></a>'), $res->output_response);
+        $this->assertEquals(array('formatted_folder_list' => '<a href="#" class="update_message_list">[reload]</a><a href="#" class="hide_folders">Hide folders<i class="bi bi-caret-left-fill fs-5"></i></a>'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/modules/core/output_modules.php
+++ b/tests/phpunit/modules/core/output_modules.php
@@ -18,7 +18,7 @@ class Hm_Test_Core_Output_Modules extends TestCase {
         $test->run();
         $test->rtype = 'AJAX';
         $res = $test->run();
-        $this->assertEquals('<li class="menu_search"><form method="get"><div class="d-flex align-items-center"><div class="ps-1 pe-2"><a class="unread_link" href="?page=search"><i class="bi bi-search"></i></a></div><div class=""><input type="hidden" name="page" value="search" /><input type="search" class="search_terms form-control form-control-sm" name="search_terms" placeholder="Search" /></div></form></div></li>', $res->output_data['formatted_folder_list']);
+        $this->assertEquals('<li class="menu_search"><form method="get"><div class="d-flex align-items-center"><div class="ps-1 pe-2"><a class="unread_link" href="?page=search"><i class="bi bi-search"></i></a></div><div class=""><input type="hidden" name="page" value="search" /><input type="search" class="search_terms form-control form-control-sm" name="search_terms" placeholder="Search" /></div></div></form></li>', $res->output_data['formatted_folder_list']);
     }
     /**
      * @preserveGlobalState disabled
@@ -844,10 +844,10 @@ class Hm_Test_Core_Output_Modules extends TestCase {
     public function test_settings_menu_start() {
         $test = new Output_Test('settings_menu_start', 'core');
         $res = $test->run();
-        $this->assertEquals(array('<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">Settings<i class="bi bi-chevron-down"></i></div></div><ul style="display: none;" class="settings folders"><li class="menu_home"><a class="unread_link" href="?page=home"><i class="bi bi-house-door-fill fs-5 me-2"></i>Home</a></li>'), $res->output_response);
+        $this->assertEquals(array('<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">Settings<i class="bi bi-chevron-down"></i></div><ul style="display: none;" class="settings folders"><li class="menu_home"><a class="unread_link" href="?page=home"><i class="bi bi-house-door-fill fs-5 me-2"></i>Home</a></li>'), $res->output_response);
         $test->rtype = 'AJAX';
         $res = $test->run();
-        $this->assertEquals(array('formatted_folder_list' => '<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">Settings<i class="bi bi-chevron-down"></i></div></div><ul style="display: none;" class="settings folders"><li class="menu_home"><a class="unread_link" href="?page=home"><i class="bi bi-house-door-fill fs-5 me-2"></i>Home</a></li>'), $res->output_response);
+        $this->assertEquals(array('formatted_folder_list' => '<div class="src_name d-flex justify-content-between pe-2" data-source=".settings">Settings<i class="bi bi-chevron-down"></i></div><ul style="display: none;" class="settings folders"><li class="menu_home"><a class="unread_link" href="?page=home"><i class="bi bi-house-door-fill fs-5 me-2"></i>Home</a></li>'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/selenium/folder_list.py
+++ b/tests/selenium/folder_list.py
@@ -31,7 +31,7 @@ class FolderListTests(WebTest):
         assert link.is_displayed() == False
 
     def hide_folders(self):
-        self.by_css('[data-source=".settings"]').click()
+        self.by_class('hide_folders').click()
         list_item = self.by_class('menu_home')
         link = list_item.find_element(By.TAG_NAME, 'a');
         assert link.is_displayed() == False

--- a/tests/selenium/folder_list.py
+++ b/tests/selenium/folder_list.py
@@ -37,7 +37,7 @@ class FolderListTests(WebTest):
         assert link.is_displayed() == False
 
     def show_folders(self):
-        self.by_css('[data-source=".settings"]').click()
+        self.by_class('folder_toggle').click()
         list_item = self.by_class('menu_home')
         list_item.find_element(By.TAG_NAME, 'a').click()
         self.wait_with_folder_list()


### PR DESCRIPTION
After migrating to Bootstrap 5 icons in version 2.x.x , the toggle buttons in the left navigation menu were not working anymore.
As described on the image below

![2024-08-11_103335](https://github.com/user-attachments/assets/6af80def-a034-42fa-9c05-f913b2513d92)
