### PR TITLE
Refresh lists after adding a account using New User Experience 

### DIFF
--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -57,7 +57,7 @@ var display_final_nux_step = function(res) {
                 }
             );
         } else {
-            Hm_Utils.redirect();
+            Hm_Utils.redirect('?page=servers');
         }
     }
 };


### PR DESCRIPTION
## Pullrequest
This fix allows the refresh of the server list after adding an account through the new user experience wizard.


