### PR TITLE
[FIX]Site Settings/General/:Warn for Unsaved Changes parameter once set cannot be unset

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -974,7 +974,7 @@ class Hm_Handler_process_warn_for_unsaved_changes_setting extends Hm_Handler_Mod
         function warn_for_unsaved_changes_callback($val) {
             return $val;
         }
-        process_site_setting('warn_for_unsaved_changes', $this, 'warn_for_unsaved_changes_callback');
+        process_site_setting('warn_for_unsaved_changes', $this, 'warn_for_unsaved_changes_callback', false, true);
     }
 }
 


### PR DESCRIPTION
[Related issue](https://github.com/cypht-org/cypht/issues/1178)