### PR TITLE
[FIX]Profiles: Fixing undefined array key rmk on Profiles page

### DIFF
--- a/modules/profiles/functions.php
+++ b/modules/profiles/functions.php
@@ -3,10 +3,11 @@
 if (!defined('DEBUG_MODE')) { die(); }
 
 if (!hm_exists('add_profile')) {
-    function add_profile($name, $signature, $reply_to, $is_default, $email, $server_mail, $smtp_server_id, $imap_server_id, $context) {
+    function add_profile($name, $signature, $reply_to, $is_default, $email, $server_mail, $smtp_server_id, $imap_server_id, $context, $remark = '') {
         $profile = array(
             'name' => $name,
             'sig' => $signature,
+            'rmk' => $remark,
             'smtp_id' => $smtp_server_id,
             'replyto' => $reply_to,
             'default' => $is_default,


### PR DESCRIPTION
Fixing: 
`
[Thu Aug 22 15:57:39.322175 2024] [php:warn] [pid 7452:tid 1204] [client ::1:13054] PHP Warning:  Undefined array key "rmk" in C:\\Apache24\\htdocs\\my_cypht\\modules\\profiles\\modules.php on line 289, referer: http://localhost/my_cypht/?page=profiles
[Thu Aug 22 15:57:39.322175 2024] [php:notice] [pid 7452:tid 1204] [client ::1:13054] PHP Deprecated:  mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated in C:\\Apache24\\htdocs\\my_cypht\\modules\\profiles\\modules.php on line 289, referer: http://localhost/my_cypht/?page=profiles
`
or
![rmk](https://github.com/user-attachments/assets/f4f73668-4bbd-412f-8527-7177095a508e)

This happens when we just add a new server to Cypht while **Set this profile default** checkbox is checked.