### PR TITLE
Check for null in quota-root. Some servers yield null values here

### DIFF
--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -757,13 +757,15 @@ class Hm_Handler_imap_folder_expand extends Hm_Handler_Module {
             $imap = Hm_IMAP_List::connect($form['imap_server_id'], $cache);
             if (imap_authed($imap)) {
                 $quota_root = $imap->get_quota_root($folder ? $folder : 'INBOX');
-                $quota = $imap->get_quota($quota_root[0]['name']);
-                if ($quota) {
-                    $current = floatval($quota[0]['current']);
-                    $max = floatval($quota[0]['max']);
-                    if ($max > 0) {
-                        $this->out('quota', ceil(($current / $max) * 100));
-                        $this->out('quota_max', $max / 1024);
+                if ($quota_root) {
+                    $quota = $imap->get_quota($quota_root[0]['name']);
+                    if ($quota) {
+                        $current = floatval($quota[0]['current']);
+                        $max = floatval($quota[0]['max']);
+                        if ($max > 0) {
+                            $this->out('quota', ceil(($current / $max) * 100));
+                            $this->out('quota_max', $max / 1024);
+                        }
                     }
                 }
             }

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -757,7 +757,7 @@ class Hm_Handler_imap_folder_expand extends Hm_Handler_Module {
             $imap = Hm_IMAP_List::connect($form['imap_server_id'], $cache);
             if (imap_authed($imap)) {
                 $quota_root = $imap->get_quota_root($folder ? $folder : 'INBOX');
-                if ($quota_root) {
+                if ($quota_root && isset($quota_root[0]['name'])) {
                     $quota = $imap->get_quota($quota_root[0]['name']);
                     if ($quota) {
                         $current = floatval($quota[0]['current']);


### PR DESCRIPTION
## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
- fixes #1201

### Checklist
should be fairly straightforward, very unlikely to cause issues. 

### How2Test

- [ ] Check that imap servers with user quotas are displayed correctly.
- [ ] Check that imap servers without quotas, but for which quota check is still performed for some reasons, are bailed out silently, instead of logging an error message to the logs.