### PR TITLE
Make bootstrap icons available on dockerized installs

### DIFF
--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -307,8 +307,8 @@ function append_bootstrap_icons_files() {
     if (!is_dir("site/fonts")) {
         mkdir('site/fonts', 0755);
     }
-    $source_folder = 'vendor/twbs/bootstrap-icons/font/fonts/';
-    $files = glob(VENDOR_PATH . "$source_folder*.*");
+    $source_folder = VENDOR_PATH.'twbs/bootstrap-icons/font/fonts/';
+    $files = glob("$source_folder*.*");
     foreach($files as $file){
         $dest_forlder = str_replace($source_folder, "site/fonts/", $file);
         copy($file, $dest_forlder);


### PR DESCRIPTION
## Pullrequest
bootstrap-icons.woff and bootstrap-icons.woff2 are not in the location where the config_gen.php script is expecting them. 

This PR fixes that issue, at least on a containerized setup, where install is performed through the docker/Dockerfile script.
### Issues
- fixes #1174


### Checklist
- [ ] This seems to have arisen through commit a6ea5b6 which is for easing integration with Tiki. I'm not familiar with that setup, and can't reliably test it. This PR might actually break what was being fixed there, so needs to be scrutinized a bit w.r.t. different install scenarios.

### How2Test
- [ ] Check that logos and characters are displayed correctly (see issue #1174) on the main page for all supported install scenarios (standalone, docker, Tiki)