### PR TITLE
[UDP] Sieve: Update php-sieve-manager to latest version 1.0.8

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -398,16 +398,16 @@
         },
         {
             "name": "henrique-borba/php-sieve-manager",
-            "version": "v1.0.6",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cypht-org/php-sieve-manager.git",
-                "reference": "d013d044059ea7141ad69b874eba5fb577f3da11"
+                "reference": "1b2819ca294bfa943fd90c7d922c5cef5f8cd8e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cypht-org/php-sieve-manager/zipball/d013d044059ea7141ad69b874eba5fb577f3da11",
-                "reference": "d013d044059ea7141ad69b874eba5fb577f3da11",
+                "url": "https://api.github.com/repos/cypht-org/php-sieve-manager/zipball/1b2819ca294bfa943fd90c7d922c5cef5f8cd8e4",
+                "reference": "1b2819ca294bfa943fd90c7d922c5cef5f8cd8e4",
                 "shasum": ""
             },
             "require": {
@@ -463,7 +463,7 @@
                 "source": "https://github.com/cypht-org/php-sieve-manager",
                 "wiki": "https://github.com/cypht-org/php-sieve-manager/wiki"
             },
-            "time": "2024-06-17T21:00:27+00:00"
+            "time": "2024-08-29T06:33:14+00:00"
         },
         {
             "name": "league/commonmark",


### PR DESCRIPTION
Cherry-picked from https://github.com/cypht-org/cypht/pull/1206/commits/833e75d3d800a6102b1e4ce9636878e0f3fd2797