### PR TITLE
Update database credentials in docker-compose.dev.yaml for local development

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -36,8 +36,8 @@ services:
       - DB_DRIVER=mysql
       - DB_HOST=db
       - DB_NAME=cypht
-      - DB_USER=testuser
-      - DB_PASS=testuser
+      - DB_USER=cypht
+      - DB_PASS=cypht_password
       - SESSION_TYPE=DB
       - USER_CONFIG_TYPE=DB
     extra_hosts:


### PR DESCRIPTION
This PR updates the database credentials in the docker-compose.dev.yaml file to align with the credentials created by the container when running in development mode with `make docker-up`