### PR TITLE
[FIX]hm-smtp.php: Declare properties to avoid deprecated dynamic prop…

### DIFF
--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -80,6 +80,9 @@ class Hm_SMTP {
     public $state;
     private $request_auths = array();
     private $scramAuthenticator;
+    private $supports_tls;
+    private $supports_auth;
+    private $max_message_size;
 
     function __construct($conf) {
     $this->scramAuthenticator = new ScramAuthenticator();


### PR DESCRIPTION
Having : 
`    [Sat Sep 21 17:30:09.314935 2024] [php:notice] [pid 7488:tid 1180] [client ::1:4662] PHP Deprecated:  Creation of dynamic property Hm_SMTP::$supports_tls is deprecated in C:\\Apache24\\htdocs\\my_cypht\\modules\\smtp\\hm-smtp.php on line 134
    [Sat Sep 21 17:30:09.314935 2024] [php:notice] [pid 7488:tid 1180] [client ::1:4662] PHP Deprecated:  Creation of dynamic property Hm_SMTP::$supports_auth is deprecated in C:\\Apache24\\htdocs\\my_cypht\\modules\\smtp\\hm-smtp.php on line 135
    [Sat Sep 21 17:30:09.314935 2024] [php:notice] [pid 7488:tid 1180] [client ::1:4662] PHP Deprecated:  Creation of dynamic property Hm_SMTP::$max_message_size is deprecated in C:\\Apache24\\htdocs\\my_cypht\\modules\\smtp\\hm-smtp.php on line 148` while trying to add an email from other provider with STARTTLS or unencrypted.
[Related PR](https://github.com/cypht-org/cypht/pull/1151)