### PR TITLE
[FIX]hm-smtp.php: Initialize  to avoid undefined variable warning

### DIFF
--- a/modules/smtp/hm-smtp.php
+++ b/modules/smtp/hm-smtp.php
@@ -408,8 +408,8 @@ class Hm_SMTP {
                     break;
             }
         }
-    
-        if (!$result) {
+
+        if (!isset($result)) {
             $result = 'An error occurred authenticating to the SMTP server';
             $res = $this->get_response();
             if ($this->compare_response($res, '235') == 0) {


### PR DESCRIPTION
Having :
`[Sat Sep 21 17:47:57.485528 2024] [php:warn] [pid 7488:tid 1208] [client ::1:5430] PHP Warning:  Undefined variable $result in C:\\Apache24\\htdocs\\my_cypht\\modules\\smtp\\hm-smtp.php on line 415`
 while trying to add an email from other provider with STARTTLS or unencrypted.
