### PR TITLE
[FIX]setup_database.php: Check if the required MySQL extensions are loaded

### DIFF
--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -27,6 +27,39 @@ $bad_driver = "Unsupported db driver: {$db_driver}";
 
 // NOTE: these sql commands could be db agnostic if we change the blobs to text
 
+// Check if the required extensions for the configured DB driver are loaded
+if ($db_driver == 'mysql') {
+    $required_extensions = ['mysqli', 'mysqlnd', 'pdo_mysql'];
+    $missing_extensions = [];
+
+    foreach ($required_extensions as $extension) {
+        if (!extension_loaded($extension)) {
+            $missing_extensions[] = $extension;
+        }
+    }
+
+    if (!empty($missing_extensions)) {
+        error_log('The following required MySQL extensions are missing: ' . implode(', ', $missing_extensions) . ". Please install them.\n");
+        exit(1);
+    }
+} elseif ($db_driver == 'pgsql') {
+    $required_extensions = ['pgsql', 'pdo_pgsql'];
+    $missing_extensions = [];
+
+    foreach ($required_extensions as $extension) {
+        if (!extension_loaded($extension)) {
+            $missing_extensions[] = $extension;
+        }
+    }
+
+    if (!empty($missing_extensions)) {
+        error_log('The following required PostgreSQL extensions are missing: ' . implode(', ', $missing_extensions) . ". Please install them.\n");
+        exit(1);
+    }
+} else {
+    error_log("Unsupported DB driver: {$db_driver}");
+    exit(1);
+}
 
 $connection_tries=0;
 $max_tries=10;
@@ -43,7 +76,7 @@ while (!$connected) {
         printf("Attempting to connect to database ... ({$connection_tries}/{$max_tries})\n");
         sleep(1);
     }
-        
+
     if ($connection_tries >= $max_tries) {
         error_log('Unable to connect to database');
         exit(1);
@@ -85,7 +118,7 @@ if (strcasecmp($auth_type, 'DB')==0) {
 
 }
 if (strcasecmp($user_config_type, 'DB')==0) {
-    
+
     printf("Creating database table hm_user_settings ...\n");
 
     if ($db_driver == 'mysql' || $db_driver == 'sqlite') {
@@ -95,7 +128,7 @@ if (strcasecmp($user_config_type, 'DB')==0) {
     } else {
         die($bad_driver);
     }
-    
+
     $conn->exec($stmt);
 }
 


### PR DESCRIPTION
Having: 
`
Attempting to connect to database ... (1/10)
Attempting to connect to database ... (2/10)
Attempting to connect to database ... (3/10)
Attempting to connect to database ... (4/10)
Attempting to connect to database ... (5/10)
Attempting to connect to database ... (6/10)
Attempting to connect to database ... (7/10)
Attempting to connect to database ... (8/10)
Attempting to connect to database ... (9/10)
Attempting to connect to database ... (10/10)
Unable to connect to database
`
while running `$ php ./scripts/setup_database.php results` on a fresh Ubuntu 22.04.