### PR TITLE
Fix reload_folder_list browser test

### DIFF
--- a/tests/selenium/folder_list.py
+++ b/tests/selenium/folder_list.py
@@ -3,6 +3,10 @@
 from base import WebTest, USER, PASS
 from selenium.webdriver.common.by import By
 from runner import test_runner
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import StaleElementReferenceException
 
 class FolderListTests(WebTest):
 
@@ -12,10 +16,20 @@ class FolderListTests(WebTest):
         self.wait_with_folder_list()
 
     def reload_folder_list(self):
-        assert self.by_class('main_menu').text.startswith('Main')
+        main_menu = self.by_class('main_menu')
+        assert main_menu.text.startswith('Main')
         self.by_class('update_message_list').click()
         self.safari_workaround(3)
-        assert self.by_class('main_menu').text.startswith('Main')
+        # update_message_list triggers site reload, so we explicitly wait for element to become stale
+        WebDriverWait(self.driver, 20).until(EC.staleness_of(main_menu))
+        ignored_exceptions=(NoSuchElementException,StaleElementReferenceException,)
+        # And once it is stale, we can now wait for it to become available again as the page contents are loaded again.
+        main_menu = WebDriverWait(self.driver, 10,ignored_exceptions=ignored_exceptions).until(
+        EC.presence_of_element_located((By.CLASS_NAME, 'main_menu'))
+        )
+        main_menu = self.by_class('main_menu')
+        #and finally perform our test on the actual, refreshed element.
+        assert main_menu.text.startswith('Main')
 
     def expand_section(self):
         self.by_css('[data-source=".settings"]').click()
@@ -59,7 +73,7 @@ if __name__ == '__main__':
 
     print("FOLDER LIST TESTS")
     test_runner(FolderListTests, [
-        # 'reload_folder_list',
+        'reload_folder_list',
         'expand_section',
         'collapse_section',
         'hide_folders',


### PR DESCRIPTION
## Pullrequest
Recently, the reload_folder_list selenium test started randomly failing. 
Sometimes it passed, sometimes it failed.
My (un)educated guess is that this is a race condition.
Basically:
1. the site is loaded and checked that the main menu button is available and has the right text.
2. Then we refresh the message list
3. Afterwards, we ensure that the button is still there, and with the right text.

Thing is, after (2), the site is reloaded, the old element in the page becomes stale and a new one is created in its place (my understanding of DOM and browser engines is limited, but that's how I understand it...).
So it depends on execution speed, and how long it takes to load the message list whether or not the menu button has been re-created once we check for it the second time, it (3).

This PR explicitly waits for the menu button to become stale. Then waits for it to become present again. There are timeouts for both waits, so the test will fail with a timeout error if either condition is not met within the timeout, which are rather randomly set at 20 and 10 seconds, respectively.

### How2Test
Check that this actually fixes the test. 
Guess the test runs have to be initiated a few times for it to be reliably confirmed, as the underlying issue is not deterministic, and the test tails only fails sometimes.