### PR TITLE
[Fix]Extension check introduced for Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN set -e \
     ca-certificates \
     libpng-dev libjpeg-turbo-dev freetype-dev \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
-    && docker-php-ext-install gd pdo pdo_mysql \
+    && docker-php-ext-install gd pdo pdo_mysql mysqli \
     && curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
     xdebug redis gnupg memcached \
     && composer self-update --2 \


### PR DESCRIPTION
## Pullrequest
Update Dockerfile to install the `mysqli` PHP extension, resolving the required extensions check introduced in PR #1251 for Docker builds.

### Issues
- relates #1251 

### Checklist
- [X] None

### How2Test
- [X] Build Docker image
- [X] Run

### Todo
- [X] None