### PR TITLE
Fixed AllInkl provider in Cypht V2

### DIFF
--- a/modules/nux/site.css
+++ b/modules/nux/site.css
@@ -4,7 +4,7 @@
 /* .nux_step_two_title { padding-top: 20px; font-size: 110%; padding-bottom: 10px; } */
 /* .nux_step_one, .nux_step_two { padding-left: 40px; max-width: 600px; } */
 /* .enable_auth2 { float: left; padding: 20px; padding-left: 0px; padding-bottom: 40px; font-size: 110%; } */
-.nux_password, .app_password { margin: 10px; margin-left: 0px; margin-top: 0px; width: 280px; }
+.nux_password, .app_password { margin: 10px; margin-left: 0px; margin-top: 0px; }
 /* .reset_nux_form { float: right; padding: 20px; padding-bottom: 40px; font-size: 110%; } */
 /* .nux_submit { margin-bottom: 20px; } */
 /* .nux_account_name, .nux_username, #service_select, .nux_extra_fields { margin-bottom: 10px; width: 280px; padding: 3px; } */

--- a/modules/nux/site.js
+++ b/modules/nux/site.js
@@ -9,7 +9,7 @@ var display_next_nux_step = function(res) {
         $('.nux_step_two').html('');
         document.getElementById('service_select').getElementsByTagName('option')[0].selected = 'selected';
         $('.nux_username').val('');
-        $('.nux_extra_fields').remove();
+        $('.nux_extra_fields_container').remove();
         return false;
     });
 };
@@ -118,7 +118,7 @@ var expand_server_settings = function() {
 };
 
 var add_extra_fields = function(select, id, label, placeholder) {
-    $(select).next().next().after('<input type="text" id="nux_'+id+'" class="nux_extra_fields" placeholder="'+placeholder+'"><label class="screen_reader nux_extra_fields" for="nux_'+id+'">'+label+'</label><br class="nux_extra_fields">');
+    $(select).parent().after('<div class="form-floating mb-3 nux_extra_fields_container"><input type="text" id="nux_'+id+'" class="nux_extra_fields form-control" placeholder="'+placeholder+'"><label for="nux_'+id+'">'+label+'</label></div>');
 };
 
 $(function() {
@@ -129,7 +129,7 @@ $(function() {
             if ($(this).val() == 'all-inkl') {
                 add_extra_fields(this, 'all_inkl_login', 'Login', hm_trans('Your All-inkl Login'));
             } else {
-                $('.nux_extra_fields').remove();
+                $('.nux_extra_fields_container').remove();
             }
         });
     }


### PR DESCRIPTION
#683 introduced support for AllInkl in Cypht V1
Migrating to bootstrap 5 broke this because of the selector used
This MR fixes makes again the login field for AllInkl provider visible