### PR TITLE
[FIX]hm-mime-message.php: Replace the mb_convert_encoding() function …

### DIFF
--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -229,8 +229,7 @@ class Hm_MIME_Msg {
     function prep_message_body() {
         $body = $this->body;
         if (!$this->html) {
-            $body = mb_convert_encoding(trim($body), "HTML-ENTITIES", "UTF-8");
-            $body = mb_convert_encoding($body, "UTF-8", "HTML-ENTITIES");
+            $body = htmlspecialchars(trim($body), ENT_QUOTES | ENT_HTML5, 'UTF-8');
             if (!empty($this->attachments)) {
                 $this->headers['Content-Type'] = 'multipart/mixed; boundary='.$this->boundary;
                 $body = sprintf("--%s\r\nContent-Type: text/plain; charset=UTF-8; format=flowed\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n%s",


### PR DESCRIPTION
While sending message in Cyph, we have this in our php error log file:
`[Sat Oct 05 23:40:48.530169 2024] [php:notice] [pid 3960:tid 1196] [client ::1:8870] PHP Deprecated:  mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in C:\\Apache24\\htdocs\\my_cypht\\modules\\smtp\\hm-mime-message.php on line 232`

