### PR TITLE
[FIX]hm-mime-message.php: Replace the mb_convert_encoding() function …

### DIFF
--- a/modules/smtp/hm-mime-message.php
+++ b/modules/smtp/hm-mime-message.php
@@ -229,8 +229,7 @@ class Hm_MIME_Msg {
     function prep_message_body() {
         $body = $this->body;
         if (!$this->html) {
-            $body = mb_convert_encoding(trim($body), "HTML-ENTITIES", "UTF-8");
-            $body = mb_convert_encoding($body, "UTF-8", "HTML-ENTITIES");
+            $body = htmlspecialchars(trim($body), ENT_QUOTES | ENT_HTML5, 'UTF-8');
             if (!empty($this->attachments)) {
                 $this->headers['Content-Type'] = 'multipart/mixed; boundary='.$this->boundary;
                 $body = sprintf("--%s\r\nContent-Type: text/plain; charset=UTF-8; format=flowed\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n%s",


### PR DESCRIPTION
…with htmlspecialchars() for encoding HTML entities.

(cherry picked from commit ebfb77731e2d7faa2d26631db239ce1197dfa1c5)

As of [Comment](https://github.com/cypht-org/cypht/pull/1182#issuecomment-2304816283)

[Related PR](https://github.com/cypht-org/cypht/pull/1272)