### PR TITLE
[FIX]Fix deprecated warnings for preg_match() and mb_strtolower() in Webmail sieve filters

### DIFF
--- a/lib/module.php
+++ b/lib/module.php
@@ -191,14 +191,22 @@ trait Hm_Handler_Validate {
      * @return bool
      */
     public function validate_method($session, $request) {
-        if (!in_array(mb_strtolower($request->method), ['get', 'post'], true)) {
-            if ($session->loaded) {
-                $session->destroy($request);
-                Hm_Debug::add(sprintf('LOGGED OUT: invalid method %s', $request->method));
+        if (!empty($request->method) && is_string($request->method)) {
+            if (!in_array(mb_strtolower($request->method), ['get', 'post'], true)) {
+                if ($session->loaded) {
+                    $session->destroy($request);
+                    Hm_Debug::add(sprintf('LOGGED OUT: invalid method %s', $request->method));
+                }
+                return false;
             }
-            return false;
+            return true;
         }
-        return true;
+        // Handle the case where method is null or invalid
+        if ($session->loaded) {
+            $session->destroy($request);
+            Hm_Debug::add('LOGGED OUT: missing or invalid request method');
+        }
+        return false;
     }
 
     /**

--- a/lib/request.php
+++ b/lib/request.php
@@ -175,7 +175,7 @@ class Hm_Request {
             $this->mobile = true;
             return;
         }
-        if (array_key_exists('HTTP_USER_AGENT', $this->server)) {
+        if (!empty($this->server['HTTP_USER_AGENT'])) {
             if (preg_match("/(iphone|ipod|ipad|android|blackberry|webos|opera mini)/i", $this->server['HTTP_USER_AGENT'])) {
                 $this->mobile = true;
             }


### PR DESCRIPTION
While running: `php console.php sieve:filters` in Tiki  [see handle the filtering in Tiki](https://doc.tiki.org/Email-filters) , we are getting:

`$ php console.php sieve:filters`

`Undefined variable $tikiroot on line 16 of C:\Apache24\htdocs\tiki1\tiki\lib\cypht\integration\classes.php      
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated on line 179 of C:\Apache24\ht
docs\tiki1\tiki\vendor_bundled\vendor\jason-munro\cypht\lib\request.php
mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated on line 194 of C:\Apache24\
htdocs\tiki1\tiki\vendor_bundled\vendor\jason-munro\cypht\lib\module.php
`

- The first issue has been resolved in [Merge request](https://gitlab.com/tikiwiki/tiki/-/merge_requests/6045)