### PR TITLE
Disable duplicate redis extension from Github actions

### DIFF
--- a/.github/workflows/Test-Build.yml
+++ b/.github/workflows/Test-Build.yml
@@ -69,6 +69,7 @@ jobs:
           tools: phpunit, composer
           ini-values: cgi.fix_pathinfo=1
         env:
+          update: true
           fail-fast: true
 
       - name: "Script: setup.sh"
@@ -128,6 +129,7 @@ jobs:
           tools: phpunit, composer
           ini-values: cgi.fix_pathinfo=1
         env:
+          update: true
           fail-fast: true
 
       - name: "Composer Install Dependencies"


### PR DESCRIPTION
Getting error `PHP Warning:  Module "redis" is already loaded in Unknown on line 0` at: https://github.com/cypht-org/cypht/actions/runs/11374213670/job/31642437449?pr=1275#step:8:13

I added those 2 lines to make sure we don't have any `redis` before we install at step: `Set up PHP`