### PR TITLE
Change the frequency at which messages are prefetched

### DIFF
--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -986,14 +986,14 @@ function Message_List() {
         }
     };
 
-    this.prev_next_links = function() {
+    this.prev_next_links = function(msgUid) {
         let phref;
         let nhref;
         const target = $('.msg_headers tr').last();
         const messages = new Hm_MessagesStore(getListPathParam(), Hm_Utils.get_url_page_number());
         messages.load(false, true);
-        const next = messages.getNextRowForMessage(getMessageUidParam());
-        const prev = messages.getPreviousRowForMessage(getMessageUidParam());
+        const next = messages.getNextRowForMessage(msgUid);
+        const prev = messages.getPreviousRowForMessage(msgUid);
         if (prev) {
             const prevSubject = $(prev['0']).find('.subject');
             phref = prevSubject.find('a').prop('href');

--- a/modules/imap/js_modules/route_handlers.js
+++ b/modules/imap/js_modules/route_handlers.js
@@ -34,6 +34,19 @@ function applyImapMessageContentPageHandlers(routeParams) {
     imap_setup_snooze();
     imap_setup_tags();
 
+    const messages = new Hm_MessagesStore(routeParams.list_path, routeParams.list_page);
+    messages.load(false);
+    const next = messages.getNextRowForMessage(routeParams.uid);
+    const prev = messages.getPreviousRowForMessage(routeParams.uid);
+    if (next) {
+        const nextMessageUid = $(next['0']).data('uid');
+        preFetchMessageContent(false, nextMessageUid, routeParams.list_path);
+    }
+    if (prev) {
+        const prevMessageUid = $(prev['0']).data('uid');
+        preFetchMessageContent(false, prevMessageUid, routeParams.list_path);
+    }
+
     if (window.feedMessageContentPageHandler) feedMessageContentPageHandler(routeParams);
     if (window.githubMessageContentPageHandler) githubMessageContentPageHandler(routeParams);
     if (window.pgpMessageContentPageHandler) pgpMessageContentPageHandler();


### PR DESCRIPTION
Instead of prefetching the entire message list when the mailbox loads, these changes only prefetch the next and previous messages relative to the one currently displayed.

This is a workaround for the issue of the server processing multiple requests synchronously (as mentioned in #1279), which prevents it from handling further actions. This leads to high load times when message content is requested, especially when the mailbox is displayed for the first time with a large list of messages.