### PR TITLE
Removed forget/save actions

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -523,7 +523,6 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
             $disabled = isset($vals['default']) ? ' disabled': '';
             if (!isset($vals['user']) || !$vals['user']) {
                 $res .= '<input type="submit" value="'.$this->trans('Delete').'" class="imap_delete btn btn-outline-danger btn-sm me-2 mt-3" />';
-                $res .= '<input type="submit" value="'.$this->trans('Save').'" class="save_imap_connection btn btn-primary btn-sm me-2 mt-3" />';
             } else {
                 $keysToRemove = array('object', 'connected', 'default', 'nopass');
                 $serverDetails = array_diff_key($vals, array_flip($keysToRemove));
@@ -532,7 +531,6 @@ class Hm_Output_display_configured_imap_servers extends Hm_Output_Module {
                 $res .= '<input type="submit" value="'.$this->trans('Edit').'" class="edit_server_connection btn btn-outline-success btn-sm me-2 mt-3"'.$disabled.' data-server-details=\''.$this->html_safe(json_encode($serverDetails)).'\' data-id="'.$this->html_safe($serverDetails['name']).'" data-type="'.$type.'" />';
                 $res .= '<input type="submit" value="'.$this->trans('Test').'" class="test_imap_connect btn btn-outline-primary btn-sm me-2 mt-3" />';
                 $res .= '<input type="submit" value="'.$this->trans('Delete').'" class="imap_delete btn btn-outline-danger btn-sm me-2 mt-3"'.$disabled.' />';
-                $res .= '<input type="submit" value="'.$this->trans('Forget').'" class="forget_imap_connection btn btn-outline-warning btn-sm me-2 mt-3"'.$disabled.' />';
             }
 
             // Hide/Unhide Buttons
@@ -700,11 +698,9 @@ class Hm_Output_display_configured_jmap_servers extends Hm_Output_Module {
             // Buttons
             if (!isset($vals['user']) || !$vals['user']) {
                 $res .= '<input type="submit" value="'.$this->trans('Delete').'" class="btn btn-outline-danger btn-sm imap_delete me-2" />';
-                $res .= '<input type="submit" value="'.$this->trans('Save').'" class="btn btn-outline-success btn-sm save_imap_connection me-2" />';
             } else {
                 $res .= '<input type="submit" value="'.$this->trans('Test').'" class="btn btn-primary btn-sm test_imap_connect me-2" />';
                 $res .= '<input type="submit" value="'.$this->trans('Delete').'" class="btn btn-danger btn-sm imap_delete me-2" />';
-                $res .= '<input type="submit" value="'.$this->trans('Forget').'" class="btn btn-outline-warning btn-sm forget_imap_connection me-2" />';
             }
 
             // Hide/Unhide Button Logic

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -119,8 +119,6 @@ add_handler('ajax_imap_debug', 'imap_oauth2_token_check', true);
 add_handler('ajax_imap_debug', 'imap_hide', true);
 add_handler('ajax_imap_debug', 'imap_connect', true);
 add_handler('ajax_imap_debug', 'imap_delete', true);
-add_handler('ajax_imap_debug', 'imap_forget', true);
-add_handler('ajax_imap_debug', 'imap_save', true);
 add_handler('ajax_imap_debug', 'save_imap_cache',  true);
 add_handler('ajax_imap_debug', 'save_imap_servers',  true);
 add_handler('ajax_imap_debug', 'save_user_data',  true, 'core');
@@ -405,8 +403,6 @@ return array(
         'imap_connect' => FILTER_DEFAULT,
         'imap_remember' => FILTER_VALIDATE_INT,
         'imap_folder_ids' => FILTER_DEFAULT,
-        'imap_forget' => FILTER_DEFAULT,
-        'imap_save' => FILTER_DEFAULT,
         'submit_imap_server' => FILTER_DEFAULT,
         'submit_jmap_server' => FILTER_DEFAULT,
         'new_jmap_address' => FILTER_SANITIZE_URL,

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -57,58 +57,14 @@ var imap_unhide = function(event) {
     imap_hide_action(form, server_id, 0);
 };
 
-var imap_forget_action = function(event) {
-    event.preventDefault();
-    Hm_Notices.hide(true);
-    var form = $(this).closest('.imap_connect');
-    var btnContainer = $(this).parent();
-    Hm_Ajax.request(
-        form.serializeArray(),
-        function(res) {
-            if (res.just_forgot_credentials) {
-                form.find('.credentials').prop('disabled', false);
-                form.find('.credentials').val('');
-                btnContainer.append('<input type="submit" value="Save" class="save_imap_connection btn btn-outline-secondary btn-sm me-2" />');
-                $('.save_imap_connection').on('click', imap_save_action);
-                $('.forget_imap_connection', form).hide();
-                Hm_Utils.set_unsaved_changes(1);
-                Hm_Folders.reload_folders(true);
-            }
-        },
-        {'imap_forget': 1}
-    );
-};
-
-var imap_save_action = function(event) {
-    event.preventDefault();
-    Hm_Notices.hide(true);
-    var form = $(this).closest('.imap_connect');
-    var btnContainer = $(this).parent();
-    Hm_Ajax.request(
-        form.serializeArray(),
-        function(res) {
-            if (res.just_saved_credentials) {
-                form.find('.credentials').attr('disabled', true);
-                form.find('.save_imap_connection').hide();
-                form.find('.imap_password').val('');
-                form.find('.imap_password').attr('placeholder', '[saved]');
-                btnContainer.append('<input type="submit" value="Forget" class="forget_imap_connection btn btn-outline-warning btn-sm me-2" />');
-                $('.forget_imap_connection').on('click', imap_forget_action);
-                Hm_Utils.set_unsaved_changes(1);
-                Hm_Folders.reload_folders(true);
-            }
-        },
-        {'imap_save': 1}
-    );
-};
-
-var imap_test_action = function(event) {
+var imap_test_action = function(event) {    
     $('.imap_folder_data').empty();
     event.preventDefault();
     Hm_Notices.hide(true);
     var form = $(this).closest('.imap_connect');
     Hm_Ajax.request(
-        form.serializeArray(),
+        [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_debug'},
+            {'name': 'imap_server_id', 'value': $('.imap_server_id', form).val()}],
         false,
         {'imap_connect': 1}
     );
@@ -116,10 +72,8 @@ var imap_test_action = function(event) {
 
 var imapServersPageHandler = function() {
     $('.imap_delete').on('click', imap_delete_action);
-    $('.save_imap_connection').on('click', imap_save_action);
     $('.hide_imap_connection').on('click', imap_hide);
     $('.unhide_imap_connection').on('click', imap_unhide);
-    $('.forget_imap_connection').on('click', imap_forget_action);
     $('.test_imap_connect').on('click', imap_test_action);
 
     var dsp = Hm_Utils.get_from_local_storage('.imap_section');

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -221,10 +221,10 @@ class Hm_Handler_process_folder_rename extends Hm_Handler_Module {
                         $imap_account = $imap_servers[$form['imap_server_id']];
                         $linked_mailboxes = get_sieve_linked_mailbox($imap_account, $this);
                         if ($linked_mailboxes && in_array($old_folder, $linked_mailboxes)) {
-                            list($sieve_host, $sieve_port, $sieve_tls) = parse_sieve_config_host($imap_account['sieve_config_host']);
+                            list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_account['sieve_config_host']);
                             try {
                                 $client = new \PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
-                                $client->connect($imap_account['user'], $imap_account['pass'], $sieve_tls, "", "PLAIN");
+                                $client->connect($imap_account['user'], $imap_account['pass'], $imap_account['sieve_tls'], "", "PLAIN");
                                 $script_names = array_filter(
                                     $linked_mailboxes,
                                     function ($value) use($old_folder) {
@@ -831,10 +831,10 @@ if (!hm_exists('get_sieve_linked_mailbox')) {
         if (!$module->module_is_supported('sievefilters') && $module->user_config->get('enable_sieve_filter_setting', DEFAULT_ENABLE_SIEVE_FILTER)) {
             return;
         }
-        list($sieve_host, $sieve_port, $sieve_tls) = parse_sieve_config_host($imap_account['sieve_config_host']);
+        list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_account['sieve_config_host']);
         $client = new \PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
         try {
-            $client->connect($imap_account['user'], $imap_account['pass'], $sieve_tls, "", "PLAIN");
+            $client->connect($imap_account['user'], $imap_account['pass'], $imap_account['sieve_tls'], "", "PLAIN");
             $scripts = $client->listScripts();
             $folders = [];
             foreach ($scripts as $s) {

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -52,8 +52,6 @@ add_handler('ajax_smtp_debug', 'load_smtp_servers_from_config',  true);
 add_handler('ajax_smtp_debug', 'add_smtp_servers_to_page_data',  true);
 add_handler('ajax_smtp_debug', 'smtp_connect', true);
 add_handler('ajax_smtp_debug', 'smtp_delete', true);
-add_handler('ajax_smtp_debug', 'smtp_forget', true);
-add_handler('ajax_smtp_debug', 'smtp_save', true);
 add_handler('ajax_smtp_debug', 'save_smtp_servers', true);
 add_handler('ajax_smtp_debug', 'save_user_data',  true, 'core');
 add_handler('ajax_smtp_debug', 'date', true, 'core');
@@ -155,8 +153,6 @@ return array(
         'new_smtp_address' => FILTER_DEFAULT,
         'new_smtp_port' => FILTER_DEFAULT,
         'smtp_connect' => FILTER_VALIDATE_INT,
-        'smtp_forget' => FILTER_VALIDATE_INT,
-        'smtp_save' => FILTER_VALIDATE_INT,
         'smtp_delete' => FILTER_VALIDATE_INT,
         'smtp_send' => FILTER_VALIDATE_INT,
         'submit_smtp_server' => FILTER_DEFAULT,

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -23,56 +23,12 @@ var smtp_test_action = function(event) {
     var form = $(this).closest('.smtp_connect');
     Hm_Notices.hide(true);
     Hm_Ajax.request(
-        form.serializeArray(),
+        [{'name': 'hm_ajax_hook', 'value': 'ajax_smtp_debug'},
+            {'name': 'smtp_server_id', 'value': $('.smtp_server_id', form).val()}],
         false,
         {'smtp_connect': 1}
     );
-};
-
-var smtp_save_action = function(event) {
-    event.preventDefault();
-    var form = $(this).closest('.smtp_connect');
-    var btnContainer = $(this).parent();
-    Hm_Notices.hide(true);
-    Hm_Ajax.request(
-        form.serializeArray(),
-        function(res) {
-            if (res.just_saved_credentials) {
-                form.find('.credentials').attr('disabled', true);
-                form.find('.save_smtp_connection').hide();
-                form.find('.smtp_password').val('');
-                form.find('.smtp_password').attr('placeholder', '[saved]');
-                btnContainer.append('<input type="submit" value="Forget" class="forget_smtp_connection btn btn-outline-secondary btn-sm me-2" />');
-                $('.forget_smtp_connection').on('click', smtp_forget_action);
-                Hm_Utils.set_unsaved_changes(1);
-                Hm_Folders.reload_folders(true);
-            }
-        },
-        {'smtp_save': 1}
-    );
-};
-
-var smtp_forget_action = function(event) {
-    event.preventDefault();
-    var form = $(this).closest('.smtp_connect');
-    var btnContainer = $(this).parent();
-    Hm_Notices.hide(true);
-    Hm_Ajax.request(
-        form.serializeArray(),
-        function(res) {
-            if (res.just_forgot_credentials) {
-                form.find('.credentials').prop('disabled', false);
-                form.find('.credentials').val('');
-                btnContainer.append('<input type="submit" value="Save" class="save_smtp_connection btn btn-outline-secondary btn-sm me-2" />');
-                $('.save_smtp_connection').on('click', smtp_save_action);
-                $('.forget_smtp_connection', form).remove();
-                Hm_Utils.set_unsaved_changes(1);
-                Hm_Folders.reload_folders(true);
-            }
-        },
-        {'smtp_forget': 1}
-    );
-};
+};             
 
 var smtp_delete_action = function(event) {
     if (!hm_delete_prompt()) {
@@ -175,8 +131,6 @@ var toggle_recip_flds = function() {
 
 function smtpServersPageHandler() {
     $('.test_smtp_connect').on('click', smtp_test_action);
-    $('.save_smtp_connection').on('click', smtp_save_action);
-    $('.forget_smtp_connection').on('click', smtp_forget_action);
     $('.delete_smtp_connection').on('click', smtp_delete_action);
     var dsp = Hm_Utils.get_from_local_storage('.smtp_section');
     if (dsp === 'block' || dsp === 'none') {


### PR DESCRIPTION
This PR removes server forget/save buttons in favor of edit button.
The context is that many fields are being added on server page (lately sieve_tls) and others may come. The forget/save cannot handle these in the future. Edit button instead allows users to edit all together SMTP and IMAP + Sieve with all the fields.
