### PR TITLE
[FIX]Bulk-import accounts using yaml or csv template: Allow both text…

### DIFF
--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -284,7 +284,7 @@ class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
                 $extension = pathinfo($this->request->files['accounts_sample']['name'], PATHINFO_EXTENSION);
                 if (in_array(strtolower($extension), ['yaml', 'yml'])) {
                     $servers = Yaml::parseFile($this->request->files['accounts_sample']['tmp_name']);
-                } elseif ($this->request->files['accounts_sample']['type'] == 'text/csv'){
+                } elseif (in_array($this->request->files['accounts_sample']['type'], ['text/csv', 'text/plain'])) {
                     $servers = [];
                     $server_data = parse_csv_with_headers($this->request->files['accounts_sample']['tmp_name']);
 
@@ -364,7 +364,7 @@ class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
                             continue;
                         }
                     }
-                } 
+                }
                 if (! empty($server['smtp']['server'])) {
                     if (!$this->module_is_supported('smtp')) {
                         $errors[] = 'SMTP module is not enabled';


### PR DESCRIPTION
…/csv and text/plain files to be parsed as CSV, accommodating Tiki’s MIME type handling

(cherry picked from commit 71967b5ec4fb4c130e759f1b661f3414bed0c841)