### PR TITLE
make sieve data format automatic on connect

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1576,7 +1576,7 @@ if (!hm_exists('connect_to_imap_server')) {
 
                 include_once APP_PATH.'modules/sievefilters/hm-sieve.php';
                 $sieveClientFactory = new Hm_Sieve_Client_Factory();
-                $client = $sieveClientFactory->init(null, $server);
+                $client = $sieveClientFactory->init(null, $server, $context->module_is_supported('nux'));
 
                 if (!$client && $show_errors) {
                     Hm_Msgs::add("ERRFailed to authenticate to the Sieve host");

--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -709,4 +709,8 @@ class Nux_Quick_Services {
         }
         return array();
     }
+
+    static public function get() {
+        return self::$services;
+    }
 }

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -106,7 +106,7 @@ if (!hm_exists('get_mailbox_filters')) {
     {
         $factory = get_sieve_client_factory($site_config);
         try {
-            $client = $factory->init($user_config, $mailbox);
+            $client = $factory->init($user_config, $mailbox, in_array(mb_strtolower('nux'), $site_config->get_modules(true), true));
             $scripts = [];
             foreach ($client->listScripts() as $script) {
                 if (mb_strstr($script, 'cypht')) {
@@ -414,7 +414,7 @@ if (!hm_exists('get_blocked_senders_array')) {
     {
         $factory = get_sieve_client_factory($site_config);
         try {
-            $client = $factory->init($user_config, $mailbox);
+            $client = $factory->init($user_config, $mailbox, in_array(mb_strtolower('nux'), $site_config->get_modules(true), true));
             $scripts = $client->listScripts();
 
             if (array_search('blocked_senders', $scripts, true) === false) {
@@ -450,7 +450,7 @@ if (!hm_exists('get_blocked_senders')){
     function get_blocked_senders($mailbox, $mailbox_id, $icon_svg, $icon_block_domain_svg, $site_config, $user_config, $module) {
         $factory = get_sieve_client_factory($site_config);
         try {
-            $client = $factory->init($user_config, $mailbox);
+            $client = $factory->init($user_config, $mailbox, in_array(mb_strtolower('nux'), $site_config->get_modules(true), true));
             $scripts = $client->listScripts();
             if (array_search('blocked_senders', $scripts, true) === false) {
                 return '';
@@ -521,6 +521,22 @@ if (!hm_exists('get_blocked_senders')){
 if (!hm_exists('initialize_sieve_client_factory')) {
     function initialize_sieve_client_factory($site_config, $user_config, $imapServer) {
         $factory = get_sieve_client_factory($site_config);
-        return $factory->init($user_config, $imapServer);
+        return $factory->init($user_config, $imapServer, in_array(mb_strtolower('nux'), $site_config->get_modules(true), true));
+    }
+}
+
+if (!hm_exists('get_sieve_host_from_services')) {
+    require_once APP_PATH.'modules/nux/modules.php';
+    function get_sieve_host_from_services($imap_host) {
+        $services = Nux_Quick_Services::get();
+        foreach ($services as $service) {
+            if (isset($service['server']) && $service['server'] === $imap_host && isset($service['sieve'])) {
+                return [
+                    'host' => $service['sieve']['host'],
+                    'port' => $service['sieve']['port'] ?? 4190,
+                ];
+            }
+        }
+        return null;
     }
 }

--- a/modules/sievefilters/hm-sieve.php
+++ b/modules/sievefilters/hm-sieve.php
@@ -2,10 +2,16 @@
 <?php
 
 class Hm_Sieve_Client_Factory {
-    public function init($user_config = null, $imap_account = null)
+    public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
     {
         if ($imap_account && ! empty($imap_account['sieve_config_host'])) {
-            list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_account['sieve_config_host']);
+            // Check if module nux is enabled and if it is, get the sieve host from the services
+            if($is_nux_supported && $sieve_config = get_sieve_host_from_services($imap_account['server'])) {
+                $sieve_host = $sieve_config['host'];
+                $sieve_port = $sieve_config['port'];
+            } else {
+                list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_account['sieve_config_host']);
+            }
             $client = new PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
             $client->connect($imap_account['user'], $imap_account['pass'], $imap_account['sieve_tls'], "", "PLAIN");
             return $client;

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -28,7 +28,7 @@ class Hm_Handler_sieve_edit_filter extends Hm_Handler_Module {
 
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $script = $client->getScript($this->request->post['sieve_script_name']);
             $base64_obj = str_replace("# ", "", preg_split('#\r?\n#', $script, 0)[1]);
             $this->out('conditions', json_encode(base64_decode($base64_obj)));
@@ -66,7 +66,7 @@ class Hm_Handler_sieve_filters_enabled_message_content extends Hm_Handler_Module
         if ($sieve_filters_enabled && !empty($server['sieve_config_host'])) {
             $factory = get_sieve_client_factory($this->config);
             try {
-                $client = $factory->init($this->user_config, $server);
+                $client = $factory->init($this->user_config, $server, $this->module_is_supported('nux'));
                 $sieve_filters_enabled = true;
                 $this->out('sieve_filters_client', $client);
             } catch (Exception $e) {
@@ -103,7 +103,7 @@ class Hm_Handler_sieve_edit_script extends Hm_Handler_Module {
         }
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $script = $client->getScript($this->request->post['sieve_script_name']);
             $client->close();
             $this->out('script', $script);
@@ -136,7 +136,7 @@ class Hm_Handler_sieve_delete_filter extends Hm_Handler_Module {
         }
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
 
             $scripts = $client->listScripts();
             foreach ($scripts as $script) {
@@ -173,7 +173,7 @@ class Hm_Handler_sieve_delete_script extends Hm_Handler_Module {
         }
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
 
             $scripts = $client->listScripts();
             foreach ($scripts as $script) {
@@ -212,7 +212,7 @@ class Hm_Handler_sieve_block_domain_script extends Hm_Handler_Module {
         $email_sender = $this->request->post['sender'];
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $scripts = $client->listScripts();
 
             $current_script = $client->getScript('blocked_senders');
@@ -344,7 +344,7 @@ class Hm_Handler_sieve_unblock_sender extends Hm_Handler_Module {
 
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $scripts = $client->listScripts();
 
             if(array_search('blocked_senders', $scripts, true) === false) {
@@ -482,7 +482,7 @@ class Hm_Handler_sieve_block_unblock_script extends Hm_Handler_Module {
 
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $scripts = $client->listScripts();
 
             if(array_search('blocked_senders', $scripts, true) === false) {
@@ -978,7 +978,7 @@ class Hm_Handler_sieve_save_filter extends Hm_Handler_Module {
 
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $scripts = $client->listScripts();
             foreach ($scripts as $script) {
                 if ($script == 'main_script') {
@@ -1024,7 +1024,7 @@ class Hm_Handler_sieve_save_script extends Hm_Handler_Module {
         }
         $factory = get_sieve_client_factory($this->config);
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $scripts = $client->listScripts();
             foreach ($scripts as $script) {
                 if ($script == $this->request->post['current_editing_script']) {
@@ -1359,7 +1359,7 @@ class Hm_Handler_sieve_toggle_script_state extends Hm_Handler_Module {
         $factory = get_sieve_client_factory($this->config);
         $success = false;
         try {
-            $client = $factory->init($this->user_config, $imap_account);
+            $client = $factory->init($this->user_config, $imap_account, $this->module_is_supported('nux'));
             $state = $form['script_state'] ? 'enabled': 'disabled';
             $scripts = $client->listScripts();
             foreach ($scripts as $key => $script) {


### PR DESCRIPTION
Related comment from @marclaporte : https://avan.tech/item119173#threadId81209

To support both Cypht 1.4 (which uses `tls://` prefixes for Sieve hostnames) and newer versions (which omit `tls://`), we’ve implemented an automated way to determine the correct Sieve hostname format using `Nux_Quick_Services`. Here's how it works:

1. **Automatic Host Detection**: The code checks `Nux_Quick_Services` to retrieve the correct Sieve host for each service. For example, for `migadu`, it will use `domain.com:port`.
   
2. **Version Compatibility**: If the running version is Cypht 1.4, it will prepend `tls://` to the hostname (e.g., `tls://domain.com:port`). For newer versions, it uses the plain hostname format (`domain.com:port`).

3. **Seamless Integration**: This ensures compatibility with both Cypht 1.4 and newer versions without manual configuration changes, reducing user setup errors and simplifying support.


