### PR TITLE
[FIX] Docker image build error: unknown instruction: [XDEBUG]

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,20 +19,15 @@ RUN set -e \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
     && ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-COPY <<EOF /tmp/xdebug.ini
-[xdebug]
-zend_extension=xdebug.so
+RUN echo "[xdebug]" > /tmp/xdebug.ini && \
+    echo "zend_extension=xdebug.so" >> /tmp/xdebug.ini && \
+    echo "xdebug.mode=debug" >> /tmp/xdebug.ini && \
+    echo "xdebug.client_host=host.docker.internal" >> /tmp/xdebug.ini
 
-xdebug.mode=debug
-xdebug.client_host=host.docker.internal
-EOF
+RUN echo "post_max_size = 60M" > /usr/local/etc/php/conf.d/cypht.ini && \
+    echo "upload_max_filesize = 50M" >> /usr/local/etc/php/conf.d/cypht.ini && \
+    echo "open_basedir = /var/lib/hm3/:/usr/local/share/cypht/:/tmp" >> /usr/local/etc/php/conf.d/cypht.ini
 
-COPY <<EOF /usr/local/etc/php/conf.d/cypht.ini
-post_max_size = 60M
-upload_max_filesize = 50M
-# the following is needed for sqlite access
-open_basedir = /var/lib/hm3/:/usr/local/share/cypht/:/tmp
-EOF
 
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
This merge request aim to fix this error I'm getting this error while trying to run docker for development:

```
make docker-up     
docker compose -f docker-compose.dev.yaml up --build || true # --abort-on-container-exit
[+] Building 0.4s (2/2) FINISHED                                                                 docker:default
 => [cypht internal] load build definition from Dockerfile                                                 0.0s
 => => transferring dockerfile: 1.94kB                                                                     0.0s
 => [cypht internal] load .dockerignore                                                                    0.0s
 => => transferring context: 52B                                                                           0.0s
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: 
failed to create LLB definition: dockerfile parse error line 23: unknown instruction: [XDEBUG]
```