### PR TITLE
fix(docker): replace php:8.1-fpm-alpine image by php:8.1-fpm-bookworm: alpine doesn't support GLOB_BRACE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,42 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.1-fpm-bookworm
 
-WORKDIR "/usr/local/share/cypht"
+WORKDIR /usr/local/share/cypht
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV COMPOSER_CACHE_DIR=/tmp/composer_cache
+ENV COMPOSER_HOME=/tmp/composer_home
 
 RUN set -e \
-    && apk add --no-cache \
-    supervisor nginx composer sqlite freetype libpng libjpeg-turbo \
-    php-session php-fileinfo php-dom php-xml libxml2-dev php-xmlwriter php-tokenizer \
-    && apk add --no-cache --virtual .build-deps \
+    && apt-get update && apt-get install -y \
+    supervisor nginx sqlite3 libfreetype6-dev libpng-dev libjpeg-dev \
+    libxml2-dev libzip-dev unzip \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
-    libpng-dev libjpeg-turbo-dev freetype-dev \
-    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
-    && docker-php-ext-install gd pdo pdo_mysql mysqli \
+    && apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    && docker-php-ext-configure gd \
+    && docker-php-ext-install session fileinfo dom xml xmlwriter gd pdo pdo_mysql mysqli \
+    && docker-php-ext-configure zip \
+    && docker-php-ext-install zip \
     && curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
     xdebug redis gnupg memcached \
-    && composer self-update --2 \
-    && apk del .build-deps \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
     && ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
-COPY <<EOF /tmp/xdebug.ini
-[xdebug]
-zend_extension=xdebug.so
+RUN printf "[xdebug] \n\
+    zend_extension=xdebug.so \n\
+    xdebug.mode=debug \n\
+    xdebug.client_host=host.docker.internal" > /tmp/xdebug.ini
 
-xdebug.mode=debug
-xdebug.client_host=host.docker.internal
-EOF
+RUN printf "post_max_size = 60M \n\
+    upload_max_filesize = 50M \n\
+    open_basedir = /var/lib/hm3/:/usr/local/share/cypht/:/tmp:/usr/local/bin:/tmp/composer_cache:/tmp/composer_home:/etc" > /usr/local/etc/php/conf.d/cypht.ini
 
-COPY <<EOF /usr/local/etc/php/conf.d/cypht.ini
-post_max_size = 60M
-upload_max_filesize = 50M
-# the following is needed for sqlite access
-open_basedir = /var/lib/hm3/:/usr/local/share/cypht/:/tmp
-EOF
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer \
+    && composer self-update --2
 
 COPY docker/nginx.conf /etc/nginx/nginx.conf
 COPY docker/supervisord.conf /etc/supervisord.conf
@@ -40,7 +44,9 @@ COPY composer.* .
 
 ARG WITH_DEBUG=false
 
-RUN [ "$WITH_DEBUG" = "true" ] && mv /tmp/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini || true
+RUN if [ "$WITH_DEBUG" = "true" ]; then \
+        mv /tmp/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    fi
 
 RUN composer install
 


### PR DESCRIPTION
## Replace php:8.1-fpm-alpine docker base image by php:8.1-fpm-bookworm

This merge request replaces the php:8.1-fpm-alpine image with php:8.1-fpm-bookworm in our Docker setup. The change addresses the challenges caused by the minimalistic nature of the Alpine-based image, which often lacks key features and extensions required for smooth development and runtime environments.

* [Related issue](https://github.com/cypht-org/cypht/issues/1322)