### PR TITLE
Fix flags issue breaking email copied from tiki tracker to be read

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1434,6 +1434,10 @@ if (!class_exists('Hm_IMAP')) {
                     $results[$vals[0]] = $vals[1];
                 }
             }
+            if ($flags && is_array($results['Flags'])) {
+                $results['Flags'] = array_unique($results['Flags']);
+                $results['Flags'] = implode(' ', $results['Flags']);
+            }
             if ($status) {
                 return $this->cache_return_val($results, $cache_command);
             }


### PR DESCRIPTION
The context is that Cypht in tiki uses Flags header to store flags. But once a email from tracker folder is copied/moved to an imap server the get_message_headers mixes imap flags and header flags making it an array of flags which breaks it usage. Because it is only used as a string.

To reproduce:
1. Copy/Move a mail to a tracker
2. Open the mail copied/moved in the tracker
3. Copy/Move the email to a folder in imap server
4. Open the email copied/moved on the imap server which won't show.