### PR TITLE
Map new message identifiers to all existing entries (from the Tags repository & the client message cache storage) of the same message when it is moved

### DIFF
--- a/modules/core/js_modules/Hm_MessagesStore.js
+++ b/modules/core/js_modules/Hm_MessagesStore.js
@@ -123,6 +123,17 @@ class Hm_MessagesStore {
         }
         return false;
     }
+    
+    removeRow(uid) {
+        const rows = Object.entries(this.rows);
+        const row = this.#getRowByUid(uid);
+        if (row) {
+            const newRows = rows.filter((_, i) => i !== row.index);
+            this.rows = Object.fromEntries(newRows);
+            this.#saveToLocalStorage();
+        }
+        
+    }
 
     #fetch(hideLoadingState = false) {
         return new Promise((resolve, reject) => {

--- a/modules/core/js_modules/utils/sortable.js
+++ b/modules/core/js_modules/utils/sortable.js
@@ -75,11 +75,14 @@ function handleMessagesDragAndDrop() {
                 {'name': 'imap_move_to', 'value': targetFolder},
                 {'name': 'imap_move_page', 'value': page},
                 {'name': 'imap_move_action', 'value': 'move'}],
-                (res) =>{
-                    for (const index in res.move_count) {
-                        $('.'+Hm_Utils.clean_selector(res.move_count[index])).remove();
-                        select_imap_folder(getListPathParam());
-                    }
+                async (res) =>{
+                    const store = new Hm_MessagesStore(getListPathParam(), Hm_Utils.get_url_page_number());
+                    await store.load(false, true, true);
+                    const moveResponses = Object.values(res['move_responses']);
+                    moveResponses.forEach((response) => {
+                        store.removeRow(response.oldUid);
+                    });
+                    display_imap_mailbox(store.rows, store.links, getListPathParam());
                 }
             );
     

--- a/modules/core/navigation/utils.js
+++ b/modules/core/navigation/utils.js
@@ -4,7 +4,7 @@ function showRoutingToast() {
 }
 
 function hideRoutingToast() {
-    window.routingToast.hide();
+    window.routingToast?.hide();
     window.routingToast = null;
 }
 

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -274,7 +274,8 @@ class Hm_Handler_imap_process_move extends Hm_Handler_Module {
                 $moved = array_merge($moved, $action['moved']);
             }
             if (count($other_server_ids) > 0) {
-                $moved = array_merge($moved, imap_move_different_server($other_server_ids, $form['imap_move_action'], $dest_path, $this->cache));
+                $action = imap_move_different_server($other_server_ids, $form['imap_move_action'], $dest_path, $this->cache);
+                $moved = array_merge($moved, $action['moved']);
 
             }
             if (count($moved) > 0) {

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -270,11 +270,15 @@ class Hm_Handler_imap_process_move extends Hm_Handler_Module {
             list($msg_ids, $dest_path, $same_server_ids, $other_server_ids) = process_move_to_arguments($form);
             $moved = array();
             if (count($same_server_ids) > 0) {
-                $moved = array_merge($moved, imap_move_same_server($same_server_ids, $form['imap_move_action'], $this->cache, $dest_path, $screen));
+                $action = imap_move_same_server($same_server_ids, $form['imap_move_action'], $this->cache, $dest_path, $screen);
+                $moved = array_merge($moved, $action['moved']);
             }
             if (count($other_server_ids) > 0) {
                 $moved = array_merge($moved, imap_move_different_server($other_server_ids, $form['imap_move_action'], $dest_path, $this->cache));
 
+            }
+            if (count($moved) > 0) {
+                $this->out('move_responses', $action['responses']);
             }
             if (count($moved) > 0 && count($moved) == count($msg_ids)) {
                 if ($form['imap_move_action'] == 'move') {

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1883,7 +1883,11 @@ if (!class_exists('Hm_IMAP')) {
          */
         public function append_end() {
             $result = $this->get_response(false, true);
-            return $this->check_response($result, true);
+            $uid = $result[0][5];
+            if ($this->check_response($result, true)) {
+                return $uid;
+            }
+            return false;
         }
 
         /* ------------------ HELPERS ------------------------------------------ */

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1753,7 +1753,7 @@ if (!class_exists('Hm_IMAP')) {
             foreach ($uid_strings as $uid_string) {
                 if ($uid_string) {
                     if (!$this->is_clean($uid_string, 'uid_list')) {
-                        return false;
+                        break;
                     }
                 }
                 switch ($action) {
@@ -1793,13 +1793,13 @@ if (!class_exists('Hm_IMAP')) {
                         break;
                     case 'COPY':
                         if (!$this->is_clean($mailbox, 'mailbox')) {
-                            return false;
+                            break;
                         }
                         $command = "UID COPY $uid_string \"".$this->utf7_encode($mailbox)."\"\r\n";
                         break;
                     case 'MOVE':
                         if (!$this->is_clean($mailbox, 'mailbox')) {
-                            return false;
+                            break;
                         }
 
                         $parseResponseFn = function($response) {
@@ -1811,8 +1811,8 @@ if (!class_exists('Hm_IMAP')) {
                             $command = "UID MOVE $uid_string \"".$this->utf7_encode($mailbox)."\"\r\n";
                         }
                         else {
-                            if ($this->message_action('COPY', $uids, $mailbox, $keyword)) {
-                                if ($this->message_action('DELETE', $uids, $mailbox, $keyword)) {
+                            if ($this->message_action('COPY', $uids, $mailbox, $keyword)['status']) {
+                                if ($this->message_action('DELETE', $uids, $mailbox, $keyword)['status']) {
                                     $command = "EXPUNGE\r\n";
                                 }
                             }

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -370,6 +370,7 @@ return array(
         'auto_advance_email_enabled' => array(FILTER_VALIDATE_BOOLEAN, false),
         'do_not_flag_as_read_on_open' => array(FILTER_VALIDATE_BOOLEAN, false),
         'ajax_imap_folders_permissions' => array(FILTER_UNSAFE_RAW, FILTER_REQUIRE_ARRAY),
+        'move_responses' => array(FILTER_DEFAULT, FILTER_REQUIRE_ARRAY),
     ),
 
     'allowed_get' => array(

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -928,8 +928,14 @@ var imap_perform_move_copy = function(dest_id, context, action = null) {
             {'name': 'imap_move_to', 'value': dest_id},
             {'name': 'imap_move_page', 'value': page},
             {'name': 'imap_move_action', 'value': action}],
-            function(res) {
+            async function(res) {
                 var index;
+                const store = new Hm_MessagesStore(getListPathParam(), Hm_Utils.get_url_page_number());
+                await store.load(false, true, true);
+                const moveResponses = Object.values(res['move_responses']);
+                moveResponses.forEach((response) => {
+                    store.removeRow(response.oldUid);
+                });
                 if (getPageNameParam() == 'message_list') {
                     Hm_Message_List.reset_checkboxes();
                     if (action == 'move' || action == 'screen_mail') {
@@ -938,7 +944,7 @@ var imap_perform_move_copy = function(dest_id, context, action = null) {
                         }
                     }
                     if (getListPathParam().substr(0, 4) === 'imap') {
-                        select_imap_folder(getListPathParam());
+                        display_imap_mailbox(store.rows, store.links, getListPathParam());
                     }
                     else {
                         Hm_Message_List.load_sources();

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1737,7 +1737,7 @@ function delete_draft($id, $cache, $imap_server_id, $folder) {
         return false;
     }
     if ($imap->select_mailbox($folder)) {
-        if ($imap->message_action('DELETE', array($id))) {
+        if ($imap->message_action('DELETE', array($id))['status']) {
             $imap->message_action('EXPUNGE', array($id));
             return true;
         }

--- a/modules/tags/handler_modules.php
+++ b/modules/tags/handler_modules.php
@@ -196,7 +196,6 @@ class Hm_Handler_move_message extends Hm_Handler_Module {
     {
         $moveResponses = $this->get('move_responses', []);
         foreach ($moveResponses as $response) {
-            Hm_Msgs::add('Syncing Tags Repository: '. json_encode($response));
             Hm_Tags::moveMessageToADifferentFolder([
                 'oldId' => $response['oldUid'],
                 'newId' => $response['newUid'],

--- a/modules/tags/handler_modules.php
+++ b/modules/tags/handler_modules.php
@@ -190,3 +190,21 @@ class Hm_Handler_tag_data extends Hm_Handler_Module {
         $this->out('tags', Hm_Tags::getAll());
     }
 }
+
+class Hm_Handler_move_message extends Hm_Handler_Module {
+    public function process()
+    {
+        $moveResponses = $this->get('move_responses', []);
+        foreach ($moveResponses as $response) {
+            Hm_Msgs::add('Syncing Tags Repository: '. json_encode($response));
+            Hm_Tags::moveMessageToADifferentFolder([
+                'oldId' => $response['oldUid'],
+                'newId' => $response['newUid'],
+                'oldFolder' => $response['oldFolder'],
+                'newFolder' => $response['newFolder'],
+                'oldServer' => $response['oldServer'],
+                'newServer' => $response['newServer'] ?? '',
+            ]);
+        }
+    }
+}

--- a/modules/tags/hm-tags.php
+++ b/modules/tags/hm-tags.php
@@ -94,19 +94,31 @@ class Hm_Tags {
             $folders = $tag['server'][$oldServer];
             $messages = $folders[$oldFolder];
             $newMessages = [];
+
             foreach ($messages as $messageId) {
                 if ($messageId == $oldId) {
                     continue;
                 }
                 $newMessages[] = $messageId;
             }
+
             $folders[$oldFolder] = $newMessages;
-            if (!isset($folders[$newFolder])) {
-                $folders[$newFolder] = [];
+
+            if ($newServer) {
+                if (!isset($tag['server'][$newServer])) {
+                    $tag['server'][$newServer] = [];
+                }
+                if (!isset($tag['server'][$newServer][$newFolder])) {
+                    $tag['server'][$newServer][$newFolder] = [];
+                }
+                $tag['server'][$newServer][$newFolder][] = $newId;
+            } else {
+                if (!isset($folders[$newFolder])) {
+                    $folders[$newFolder] = [];
+                }
+                $folders[$newFolder][] = $newId;
+                $tag['server'][$oldServer] = $folders;
             }
-            $folders[$newFolder][] = $newId;
-            $tag['server'][$oldServer] = $folders;
-            Hm_Msgs::add('Moving message from old id'.$oldId.' to '.$newId.' in tag '.$tag['name']);
             self::edit($tagId, $tag);
         }
     }

--- a/modules/tags/setup.php
+++ b/modules/tags/setup.php
@@ -48,6 +48,10 @@ add_handler('ajax_imap_tag', 'close_session_early',  true, 'core');
 add_handler('ajax_imap_tag', 'tag_data', true, 'tags', 'load_user_data', 'after');
 add_handler('ajax_imap_tag', 'add_tag_to_message',  true, 'tags', 'save_imap_cache', 'after');
 
+/* Sync the Tags Repository when moving messages */
+add_handler('ajax_imap_move_copy_action', 'tag_data', true, 'tags', 'load_user_data', 'after');
+add_handler('ajax_imap_move_copy_action', 'move_message', true, 'tags', 'imap_process_move', 'after');
+
 return array(
     'allowed_pages' => array(
         'ajax_process_tag_update',

--- a/tests/phpunit/modules/imap/hm_imap.php
+++ b/tests/phpunit/modules/imap/hm_imap.php
@@ -392,17 +392,17 @@ class Hm_Test_Hm_IMAP extends TestCase {
      */
     public function test_message_action() {
         /* TODO: coverage and assertions */
-        $this->assertTrue($this->imap->message_action('DELETE', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('READ', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('FLAG', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('UNFLAG', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('ANSWERED', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('UNREAD', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('UNDELETE', array(1), 'foo'));
-        $this->assertTrue($this->imap->message_action('CUSTOM', array(1), 'foo', 'bar'));
-        $this->assertTrue($this->imap->message_action('MOVE', array(1), 'Sent'));
-        $this->assertTrue($this->imap->message_action('EXPUNGE', array(1)));
-        $this->assertTrue($this->imap->message_action('COPY', array(1), 'Sent'));
+        $this->assertTrue($this->imap->message_action('DELETE', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('READ', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('FLAG', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('UNFLAG', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('ANSWERED', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('UNREAD', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('UNDELETE', array(1), 'foo')['status']);
+        $this->assertTrue($this->imap->message_action('CUSTOM', array(1), 'foo', 'bar')['status']);
+        $this->assertTrue($this->imap->message_action('MOVE', array(1), 'Sent')['status']);
+        $this->assertTrue($this->imap->message_action('EXPUNGE', array(1))['status']);
+        $this->assertTrue($this->imap->message_action('COPY', array(1), 'Sent')['status']);
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
TODO:
- [x] The Tags repository works so far only when a message is moved to a different folder within the same IMAP server. This should also work when the server changes.
- [x] The client storage key of the moved messages should be updated as well.