### PR TITLE
style(docker): use heredoc syntax for installphase in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bookworm
+FROM docker.io/php:8.1-fpm-bookworm
 
 WORKDIR /usr/local/share/cypht
 
@@ -6,25 +6,46 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPOSER_CACHE_DIR=/tmp/composer_cache
 ENV COMPOSER_HOME=/tmp/composer_home
 
-RUN set -e \
-    && apt-get update && apt-get install -y \
-    supervisor nginx sqlite3 libfreetype6-dev libpng-dev libjpeg-dev \
-    libxml2-dev libzip-dev unzip \
-    && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && apt-get install -y --no-install-recommends \
+RUN <<BASH
+set -e
+apt-get update
+apt-get install -y \
+    supervisor \
+    nginx \
+    sqlite3 \
     libfreetype6-dev \
-    && docker-php-ext-configure gd \
-    && docker-php-ext-install session fileinfo dom xml xmlwriter gd pdo pdo_mysql mysqli \
-    && docker-php-ext-configure zip \
-    && docker-php-ext-install zip \
-    && curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
-    xdebug redis gnupg memcached \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean \
-    && ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+    libpng-dev \
+    libjpeg-dev \
+    libxml2-dev \
+    libzip-dev \
+    libpq-dev \
+    unzip
+apt-get install -y --no-install-recommends \
+    ca-certificates
+apt-get install -y --no-install-recommends \
+    libfreetype6-dev
+docker-php-ext-configure gd
+docker-php-ext-install \
+    session \
+    fileinfo \
+    dom \
+    xml \
+    xmlwriter \
+    gd \
+    pdo \
+    pdo_pgsql \
+    pdo_mysql \
+    mysqli
+docker-php-ext-configure zip
+docker-php-ext-install zip
+curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
+    xdebug redis gnupg memcached
+rm -rf /var/lib/apt/lists/*
+apt-get clean
+ln -sf /dev/stdout /var/log/nginx/access.log
+ln -sf /dev/stderr /var/log/nginx/error.log
+ln -s /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+BASH
 
 RUN printf "[xdebug] \n\
     zend_extension=xdebug.so \n\


### PR DESCRIPTION
Uses [heredoc syntax](https://docs.docker.com/reference/dockerfile/#here-documents) in the Dockerfile.

Works with Buildah and Docker at least.

However I can't build the image at all because ext-soap is missing (I tried adding it but I've never used composer so I'm yet to succeed)

```
STEP 15/27: RUN composer install
Composer plugins have been disabled for safety in this non-interactive session.
Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.
Composer is operating slower than normal because you have Xdebug enabled. See https://getcomposer.org/xdebug
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - Root composer.json requires PHP extension ext-soap * but it is missing from your system. Install or enable PHP's soap extension.
  Problem 2
    - garethp/php-ews is locked to version dev-master and an update of this package was not requested.
    - garethp/php-ews dev-master requires ext-soap * -> it is missing from your system. Install or enable PHP's soap extension.

To enable extensions, verify that they are enabled in your .ini files:
    - /usr/local/etc/php/php.ini
    - /usr/local/etc/php/conf.d/cypht.ini
    - /usr/local/etc/php/conf.d/docker-fpm.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-gd.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-gnupg.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-mysqli.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-pdo_mysql.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-pdo_pgsql.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-redis.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
    - /usr/local/etc/php/conf.d/docker-php-ext-zip.ini
    - /usr/local/etc/php/conf.d/xx-php-ext-memcached.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-soap` to temporarily ignore these required extensions.
Error: building at STEP "RUN composer install": while running runtime: exit status 2
```

Heredoc syntax along with ```set -e``` makes for much more readable Dockerfiles 😄 

TODO: Add docs for how to build docker image? (I had to run builah from repo root like ```buildah build -f ./docker/Dockerfile```