### PR TITLE
fix(docker): missing ext-soap error on docker image building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,8 @@ docker-php-ext-install \
     pdo \
     pdo_pgsql \
     pdo_mysql \
-    mysqli
+    mysqli \
+    soap
 docker-php-ext-configure zip
 docker-php-ext-install zip
 curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \

--- a/scripts/setup_system.sh
+++ b/scripts/setup_system.sh
@@ -21,7 +21,7 @@ echo "Creating directory for attachments ${ATTACHMENT_DIR}"
 mkdir -p ${ATTACHMENT_DIR}
 
 # TODO: should a user be created if USER_CONFIG_TYPE=file  ?
-if [[ "${USER_CONFIG_TYPE}" = "DB" && -n "${AUTH_USERNAME}" ]]
+if [ "${USER_CONFIG_TYPE}" = "DB" ] && [ -n "${AUTH_USERNAME}" ]
 then
     php ${SCRIPT_DIR}/../scripts/create_account.php ${AUTH_USERNAME} ${AUTH_PASSWORD}
 fi


### PR DESCRIPTION
This merge request addresses two issues encountered during the Docker image build and setup process:

1. Fixes an issue where the ext-soap extension was missing during the Docker image build, causing build failures.
2. Resolve the issue where the setup_system.sh script failed to create a user in the database when the configuration type was set to DB (BASH syntax error)
