### PR TITLE
fix(backend): search since a date did not respect global choice of sort date field

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1142,6 +1142,19 @@ function process_sort_arg($sort, $default = 'arrival') {
 /**
  * @subpackage imap/functions
  */
+if (!hm_exists('search_since_based_on_setting')) {
+function search_since_based_on_setting($config) {
+    if ($config->get('default_sort_order_setting', 'arrival') === 'arrival') {
+        return 'SINCE';
+    } else {
+        return 'SENTSINCE';
+    }
+}}
+
+
+/**
+ * @subpackage imap/functions
+ */
 if (!hm_exists('imap_server_type')) {
 function imap_server_type($id) {
     $type = 'IMAP';

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1222,7 +1222,7 @@ class Hm_Handler_imap_search extends Hm_Handler_Module {
             if (array_key_exists('folder', $this->request->post)) {
                 $folder = $this->request->post['folder'];
             }
-            list($status, $msg_list) = merge_imap_search_results($ids, 'ALL', $this->session, $this->cache, array(hex2bin($folder)), MAX_PER_SOURCE, array(array('SINCE', $date), array($fld, $terms)));
+            list($status, $msg_list) = merge_imap_search_results($ids, 'ALL', $this->session, $this->cache, array(hex2bin($folder)), MAX_PER_SOURCE, array(array(search_since_based_on_setting($this->user_config), $date), array($fld, $terms)));
             $this->out('imap_search_results', $msg_list);
             $this->out('folder_status', $status);
             $this->out('imap_server_ids', $form['imap_server_ids']);
@@ -1287,7 +1287,7 @@ class Hm_Handler_imap_combined_inbox extends Hm_Handler_Module {
         }
 
         $result = getCombinedMessagesLists($data_sources, $this->cache, [
-            'terms' => [['SINCE', $date]],
+            'terms' => [[search_since_based_on_setting($this->user_config), $date]],
             'listPage' => $list_page,
             'limit' => $limit,
             'offsets' => $offsets,
@@ -1354,7 +1354,7 @@ class Hm_Handler_imap_filter_by_type extends Hm_Handler_Module {
         if ($offsets) {
             $offsets = explode(',', $offsets);
         }
-        $searchTerms[] = ['SINCE', $date];
+        $searchTerms[] = [search_since_based_on_setting($this->user_config), $date];
         
         $result = getCombinedMessagesLists($data_sources, $this->cache, [
             'terms' => $searchTerms,
@@ -2121,7 +2121,7 @@ class Hm_Handler_imap_folder_data extends Hm_Handler_Module {
         if ($offsets) {
             $offsets = explode(',', $offsets);
         }
-        $searchTerms[] = ['SINCE', $date];
+        $searchTerms[] = [search_since_based_on_setting($this->user_config), $date];
 
         $result = getCombinedMessagesLists($data_sources, $this->cache, [
             'listPage' => $list_page,

--- a/modules/imap/hm-ews.php
+++ b/modules/imap/hm-ews.php
@@ -376,6 +376,9 @@ class Hm_EWS {
                     case 'SINCE':
                         $qs[] = "Received:>$term[1]";
                         break;
+                    case 'SENTSINCE':
+                        $qs[] = "Sent:>$term[1]";
+                        break;
                     case 'FROM':
                         $qs[] = "From:($term[1])";
                         break;

--- a/modules/imap/hm-jmap.php
+++ b/modules/imap/hm-jmap.php
@@ -1265,6 +1265,7 @@ class Hm_JMAP {
         $converted_terms = array();
         $map = array(
             'SINCE' => 'after',
+            'SENTSINCE' => 'after', // JMAP protocol does not seem to support searching by sentAt date, so we resort to receivedAt date
             'SUBJECT' => 'subject',
             'TO' => 'to',
             'FROM' => 'from',
@@ -1273,7 +1274,7 @@ class Hm_JMAP {
         );
         foreach ($terms as $vals) {
             if (array_key_exists($vals[0], $map)) {
-                if ($vals[0] == 'SINCE') {
+                if ($vals[0] == 'SINCE' || $vals[0] == 'SENTSINCE') {
                     $vals[1] = gmdate("Y-m-d\TH:i:s\Z", strtotime($vals[1]));
                 }
                 $converted_terms[$map[$vals[0]]] = $vals[1];


### PR DESCRIPTION
Arrival vs Sent Date and thus making it confusing to user to search since a date but showing messages before that date.

This fix respects the setting, so search since works on Arrival date if that is shown in the list and Sent Date if that is shown in the list.
