### PR TITLE
fix(other): fix null reference error when smtp account has no mailbox attached.

### DIFF
--- a/modules/nux/modules.php
+++ b/modules/nux/modules.php
@@ -122,7 +122,8 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
                         'pass' => $result['access_token'],
                         'expiration' => strtotime(sprintf("+%d seconds", $result['expires_in'])),
                         'refresh_token' => $result['refresh_token'],
-                        'auth' => 'xoauth2'
+			'auth' => 'xoauth2',
+			'type' => $details['type']
                     ));
                     if (isset($details['smtp'])) {
                         Hm_SMTP_List::add(array(
@@ -134,7 +135,8 @@ class Hm_Handler_process_oauth2_authorization extends Hm_Handler_Module {
                             'user' => $details['email'],
                             'pass' => $result['access_token'],
                             'expiration' => strtotime(sprintf("+%d seconds", $result['expires_in'])),
-                            'refresh_token' => $result['refresh_token']
+			    'refresh_token' => $result['refresh_token'],
+			    'type' => 'smtp'
                         ));
                         $this->session->record_unsaved('SMTP server added');
                     }
@@ -182,6 +184,7 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                     'tls' => $details['tls'],
                     'user' => $form['nux_email'],
                     'pass' => $form['nux_pass'],
+		    'type' => $details['type']
                 );
                 if ($details['sieve'] && $this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', DEFAULT_ENABLE_SIEVE_FILTER)) {
                     $imap_list['sieve_config_host'] = $details['sieve']['host'].':'.$details['sieve']['port'];
@@ -200,7 +203,8 @@ class Hm_Handler_process_nux_add_service extends Hm_Handler_Module {
                             'port' => $details['smtp']['port'],
                             'tls' => $details['smtp']['tls'],
                             'user' => $form['nux_email'],
-                            'pass' => $form['nux_pass']
+			    'pass' => $form['nux_pass'],
+			    'type' => 'smtp'
                         ));
                         if (can_save_last_added_server('Hm_SMTP_List', $form['nux_email'])) {
                             $this->session->record_unsaved('SMTP server added');
@@ -386,6 +390,7 @@ class Hm_Handler_process_import_accouts_servers extends Hm_Handler_Module
                             $server['username'],
                             $server['password'],
                             $server['smtp']['tls'],
+			    $server['type'],
                             false
                         );
                         if (! $smtp_server_id) {

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1576,18 +1576,20 @@ class Hm_Handler_send_scheduled_messages extends Hm_Handler_Module {
 
         foreach ($servers as $server_id => $config) {
             $mailbox = new Hm_Mailbox($server_id, $this->user_config, $this->session, $config);
-            if ($mailbox->connect()) {
-                $folder = 'Scheduled';
-                $ret = $mailbox->get_messages($folder, 'DATE', false, 'ALL');
-                foreach ($ret[1] as $msg) {
-                    $msg_headers = $mailbox->get_message_headers($folder, $msg['uid']);
-                    if (! empty($msg_headers['X-Schedule'])) {
-                        $scheduled_msg_count++;
-                    } else {
-                        continue;
-                    }
-                    if (send_scheduled_message($this, $mailbox, $folder, $msg['uid'])) {
-                        $scheduled_msg_count++;
+            if (!is_null($mailbox->get_connection())) {
+                if ($mailbox->connect()) {
+                    $folder = 'Scheduled';
+                    $ret = $mailbox->get_messages($folder, 'DATE', false, 'ALL');
+                    foreach ($ret[1] as $msg) {
+                        $msg_headers = $mailbox->get_message_headers($folder, $msg['uid']);
+                        if (! empty($msg_headers['X-Schedule'])) {
+                            $scheduled_msg_count++;
+                        } else {
+                            continue;
+                        }
+                        if (send_scheduled_message($this, $mailbox, $folder, $msg['uid'])) {
+                            $scheduled_msg_count++;
+                        }
                     }
                 }
             }

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -1576,20 +1576,18 @@ class Hm_Handler_send_scheduled_messages extends Hm_Handler_Module {
 
         foreach ($servers as $server_id => $config) {
             $mailbox = new Hm_Mailbox($server_id, $this->user_config, $this->session, $config);
-            if (!is_null($mailbox->get_connection())) {
-                if ($mailbox->connect()) {
-                    $folder = 'Scheduled';
-                    $ret = $mailbox->get_messages($folder, 'DATE', false, 'ALL');
-                    foreach ($ret[1] as $msg) {
-                        $msg_headers = $mailbox->get_message_headers($folder, $msg['uid']);
-                        if (! empty($msg_headers['X-Schedule'])) {
-                            $scheduled_msg_count++;
-                        } else {
-                            continue;
-                        }
-                        if (send_scheduled_message($this, $mailbox, $folder, $msg['uid'])) {
-                            $scheduled_msg_count++;
-                        }
+            if ($mailbox->connect()) {
+                $folder = 'Scheduled';
+                $ret = $mailbox->get_messages($folder, 'DATE', false, 'ALL');
+                foreach ($ret[1] as $msg) {
+                    $msg_headers = $mailbox->get_message_headers($folder, $msg['uid']);
+                    if (! empty($msg_headers['X-Schedule'])) {
+                        $scheduled_msg_count++;
+                    } else {
+                        continue;
+                    }
+                    if (send_scheduled_message($this, $mailbox, $folder, $msg['uid'])) {
+                        $scheduled_msg_count++;
                     }
                 }
             }


### PR DESCRIPTION
## 🍰 Pullrequest
Issue #1450 says it all. For some reason, I have an smtp account with no mailbox attached (I promise I didn't do anything funky with the config, all standard server configs through the web gui). This gives rise to a null reference error in the php code and an endless series of red "server error" warning dialogs in the web page.

### Issues
#1450