### PR TITLE
fix(backend): restrict the message_list worker access to CLI only

### DIFF
--- a/modules/imap/workers/messages_list.php
+++ b/modules/imap/workers/messages_list.php
@@ -1,4 +1,9 @@
 <?php
+
+if (mb_strtolower(php_sapi_name()) !== 'cli') {
+    die("Must be run from the command line\n");
+}
+
 const APP_PATH = '';
 
 require 'lib/framework.php';


### PR DESCRIPTION
A spin-off from https://github.com/cypht-org/cypht/pull/1452