### PR TITLE
fix(backend): manually reconnect cache services after deserialize in message worker

### DIFF
--- a/lib/cache.php
+++ b/lib/cache.php
@@ -266,6 +266,13 @@ class Hm_Redis {
     }
 
     /**
+     * @return boolean
+     */
+    public function reconnect() {
+        return $this->connect();
+    }
+
+    /**
      * @return void
      */
     private function auth() {
@@ -343,6 +350,13 @@ class Hm_Memcached {
     }
 
     /**
+     * @return boolean
+     */
+    public function reconnect() {
+        return $this->connect();
+    }
+
+    /**
      * @return mixed
      */
     public function last_err() {
@@ -375,6 +389,13 @@ class Hm_Noop_Cache {
 
     public function set($key, $val, $lifetime, $crypt_key) {
         return false;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function reconnect(){
+        return true;
     }
 }
 
@@ -609,6 +630,14 @@ class Hm_Cache {
     protected function generic_set($key, $val, $lifetime) {
         $this->log($key, 'save');
         return $this->backend->set($this->key_hash($key), $val, $lifetime, $this->session->enc_key);
+    }
+
+    /**
+     * Manually reconnect to cache service
+     * @return boolean
+     */
+    public function reconnect() {
+        return $this->backend->reconnect();
     }
 }
 

--- a/modules/imap/workers/messages_list.php
+++ b/modules/imap/workers/messages_list.php
@@ -38,6 +38,7 @@ $index = $data['index'];
 $search = $data['search'];
 $dataSource = $data['dataSource'];
 $cache = unserialize($data['cache']);
+$cache->reconnect();
 $session = unserialize($data['session']);
 $user_config = unserialize($data['config']);
 


### PR DESCRIPTION
## 🍰 Pullrequest
PR #1452 serializes/unserializes the cache class when handing it to the worker process.
The Redis cache class (and presumably also the memcached class) don't survive this, as the connection to the service is not preserved when serializing. Thus the fetching of messages fails, with a `Redis server went away` exception message. In some cases, the scripts seems to sort-of work and fetch messages, but it takes longer, since the cache is probably not used.

This PR tries to fix that by adding a public manual `reconnect' function to the hm_cache class, which reconnects the redis or memcached backends.