### PR TITLE
fix(backend): fix error when adding new mail server

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1127,7 +1127,9 @@ class Hm_Handler_quick_servers_setup extends Hm_Handler_Module {
                         Hm_Msgs::add("SMTP module is not enabled", "danger");
                         return;
                     }
-                    $this->smtp_server_id = connect_to_smtp_server($smtpAddress, $profileName, $smtpPort, $email, $password, $smtpTls, 'smtp', $smtpServerId);
+                    if(!isset($this->smtp_server_id)){
+                        $this->smtp_server_id = connect_to_smtp_server($smtpAddress, $profileName, $smtpPort, $email, $password, $smtpTls, 'smtp', $smtpServerId);
+                    }
                     if(!isset($this->smtp_server_id)){
                         Hm_Msgs::add("Could not save SMTP server", "warning");
                         return;


### PR DESCRIPTION
## 🍰 Pullrequest
When adding a new mailserver, sometimes there is an error when adding the smtp server (adding only imap server sidesteps the error message). This is probably a regression from pr #1425. 

### To Review
- Review that adding smtp server still works for ews or jmap servers - the code from #1425 that added a call to `connect_to_smtp_server` addressed an issue with those kinds of servers. The change in this PR  shouldn't affect that code, but I can't really test it reliably.