### PR TITLE
fix(other): preg_match(): Passing null to parameter # deprecated warning

### DIFF
--- a/lib/request.php
+++ b/lib/request.php
@@ -176,7 +176,7 @@ class Hm_Request {
             return;
         }
         if (!empty($this->server['HTTP_USER_AGENT'])) {
-            if (preg_match("/(iphone|ipod|ipad|android|blackberry|webos|opera mini)/i", $this->server['HTTP_USER_AGENT'])) {
+            if (preg_match("/(iphone|ipod|ipad|android|blackberry|webos|opera mini)/i", $this->server['HTTP_USER_AGENT'] ?? '')) {
                 $this->mobile = true;
             }
         }


### PR DESCRIPTION
### Issue  
Running `php console.php sieve:filters` in **Tiki** results in the following deprecation warning from **Cypht integration**:  

```
preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated 
on line 179 of /var/www/html/tiki27x/vendor_bundled/vendor/jason-munro/cypht/lib/request.php
```

This occurs because `$this->server['HTTP_USER_AGENT']` is `null`, and `preg_match()` requires a **string**, causing a deprecation warning.
