### PR TITLE
fix(frontend): only check sieve block lists if sieve module is enabled

### DIFF
--- a/modules/core/js_modules/route_handlers.js
+++ b/modules/core/js_modules/route_handlers.js
@@ -82,7 +82,9 @@ function applyMessaleListPageHandlers(routeParams) {
         Hm_Message_List.toggle_rows();
     });
 
-    get_list_block_sieve();
+    if (hm_module_is_supported('sievefilters')) {
+        get_list_block_sieve();
+    }
 
     if (routeParams.list_path === 'github_all') {
         return applyGithubMessageListPageHandler(routeParams);


### PR DESCRIPTION
## 🍰 Pullrequest
Javascript code is calling `ajax_list_block_sieve` on page load (on combined_inbox at least), even if I don't have sievefilters module enabled. This causes an error in the backend ('not callable'), since the sieve stuff isn't available. This in turn gives rise to an error message on the web gui, each time the site is reloaded.

This PR makes sure this isn't called unless the module is enabled.