### PR TITLE
fix(other): php deprecated:  Hm_Repository::initRepo()

### DIFF
--- a/lib/repository.php
+++ b/lib/repository.php
@@ -7,7 +7,7 @@ trait Hm_Repository {
     protected static $session;
     protected static $entities;
 
-    protected static function initRepo($name, $user_config, $session, &$entities, callable $init = null) {
+    protected static function initRepo($name, $user_config, $session, &$entities, ? callable $init = null) {
         self::$name = $name;
         self::$user_config = $user_config;
         self::$session = $session;


### PR DESCRIPTION
This PR resolved this error:
PHP Deprecated:  Hm_Repository::initRepo(): Implicitly marking parameter $init as nullable is deprecated, the explicit nullable type must be used instead in lib\repository.php on line 10

REF [issue](https://github.com/cypht-org/cypht/issues/1431)