### PR TITLE
fix(backend): delete cached imap responses for servers that don't support SORT extension

### DIFF
--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -1653,6 +1653,7 @@ if (!class_exists('Hm_IMAP')) {
             }
             $command = $command1.$command2;
             $cache_command = $command.(string)$reverse;
+            $this->set_fetch_command($cache_command);
             $cache = $this->check_cache($cache_command);
             if ($cache !== false) {
                 return $cache;


### PR DESCRIPTION
## 🍰 Pullrequest
See issue in #1479 for how to reproduce the bug.

 This appears to be due to the fact that gmail does not support the SORT imap extension. For that case, there is a separate code path taken when checking for new messages, using `UID FETCH [...]` to check for messages.

When noticing new messages, there is an attempt to remove the relevant commands from the imap cache, but the `UID FETCH` was not removed. Therefore, the results from the last FETCH commands are retreived from the cache and served up, but the new message isn't in that list, so is missing. If you use cypht for a bit, opening some messages, then in the end, the relevant cache item is purged and the message shows up, but that could take an hour or 2.

This PR tries to set up a store for the particular imap command that is used for fetching the message list, and ensure it is removed from the cache when appropriate.

### Issues
- fixes #1479