### PR TITLE
feat(other): add HTML email sanitizer to remove external background images

### DIFF
--- a/modules/core/message_functions.php
+++ b/modules/core/message_functions.php
@@ -46,6 +46,19 @@ function format_msg_html($str, $images=false) {
 }}
 
 /**
+ * Sanitize HTML for email
+ * @subpackage core/functions
+ * @param string $html content to sanitize
+ * @return string
+ */
+if (!hm_exists('sanitize_email_html')) {
+function sanitize_email_html($html) {
+    $html = preg_replace('/<([^>]+)style\s*=\s*["\'][^"\']*background-image\s*:\s*url\((["\']?)https?:\/\/.*?\2\)[^"\']*["\']/i', '<$1', $html);
+
+    return $html;
+}}
+
+/**
  * Convert HTML to plain text
  * @param string $html content to convert
  * @return string

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -126,6 +126,7 @@ class Hm_Output_filter_message_body extends Hm_Output_Module {
                     }
                 }
 
+                $msgText = sanitize_email_html($msgText);
                 $txt .= format_msg_html($msgText, $allowed);
             }
             elseif (isset($struct['type']) && mb_strtolower($struct['type']) == 'image') {
@@ -1677,7 +1678,7 @@ class Hm_Output_setting_ceo_detection_fraud extends Hm_Output_Module {
                 $ceo_rate_limit = $settings['ceo_rate_limit'];
             }
         }
-        
+
         $res = '<tr class="general_setting"><td><label for="ceo_use_detect_ceo_fraud">'.
             $this->trans('CEO fraud: Use Detect CEO Fraud').
             '</label></td><td><input class="form-check-input" type="checkbox" role="switch" id="ceo_use_detect_ceo_fraud" name="ceo_use_detect_ceo_fraud" '. $ceo_use_detect_ceo_fraud .' ></td></tr>';


### PR DESCRIPTION


<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/cypht-org/cypht/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(frontend): my fix
- feat(backend): my feature
- docs(docker): my docs
- refactor(frontend/backend) : my refactor
- test(unit): my test
-->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
Add sanitize_email_html function that:
- Parses HTML content with DOMDocument
- Removes potentially dangerous background-image URLs (http/https)
- Preserves all other HTML structure and styling
- Handles malformed HTML gracefully with libxml error suppression

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Test Cypht With [Email Privacy Tester](https://www.emailprivacytester.com/)
