### PR TITLE
fix(other): display a blank page for an email in a tracker for tiki-webmail

### DIFF
--- a/modules/core/js_modules/route_handlers.js
+++ b/modules/core/js_modules/route_handlers.js
@@ -102,6 +102,7 @@ function applyMessagePageHandlers(routeParams) {
     
     switch (path) {
         case 'imap':
+        case 'trac':
             return applyImapMessageContentPageHandlers(routeParams);
         case 'feed':
             return applyFeedMessageContentPageHandlers(routeParams);


### PR DESCRIPTION
This pull request fixes an issue where attempting to display an email stored in a tracker in Tiki Webmail resulted in a blank page