### PR TITLE
fix(frontend/backend): block sender and Screen email (dislike email) not working

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -77,7 +77,7 @@ class Hm_Output_imap_custom_controls extends Hm_Output_Module {
             }
             if ($this->get('folder')) {
                 if ($this->get('screen_emails')) {
-                    $custom .= '<a title="Disike" href="#" class="screen-email-unlike"><i class="bi bi-hand-thumbs-down-fill"></i></a><a title="Like" href="#" class="screen-email-like"></i><i class="bi bi-hand-thumbs-up-fill"></i></a>';
+                    $custom .= '<span title="Disike" class="screen-email-unlike cursor-pointer"><i class="bi bi-hand-thumbs-down-fill"></i></span><span title="Like" class="screen-email-like cursor-pointer"></i><i class="bi bi-hand-thumbs-up-fill"></i></span>';
                     if ($this->get('move_messages_in_screen_email')) {
                         $custom .= '<input type="hidden" value="1" id="move_messages_in_screen_email"/>';
                     } else {

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -285,13 +285,13 @@ if (!hm_exists('get_sieve_client_factory')) {
 }
 
 if (!hm_exists('prepare_sieve_script ')) {
-    function prepare_sieve_script ($script, $index = 1, $action = "decode")
+    function prepare_sieve_script ($script, $index = 1, $action = "decode", $object_to_array = true)
     {
         $blocked_list = [];
         if ($script != '') {
             $base64_obj = str_replace("# ", "", preg_split('#\r?\n#', $script, 0)[$index]);
             if ($action == "decode") {
-                $blocked_list = json_decode(str_replace("*", "", base64_decode($base64_obj)));
+                $blocked_list = json_decode(str_replace("*", "", base64_decode($base64_obj)), $object_to_array);
             } else {
                 $blocked_list = json_encode(base64_decode($base64_obj));
             }


### PR DESCRIPTION
1. For email server that supports Sieve, opening a message, in the headers section try to click "Block Sender".
A php error is returned in the server logs.

2. When you click on dislike email, there are 2 behaviors that are random:
- sometimes the page reloads again
- If the page does not reload, there is a PHP error is returned.

PHP error "Fatal error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, stdClass given in"