### PR TITLE
fix(backend): allow deletion of auto-created profiles when server is already deleted

### DIFF
--- a/modules/profiles/modules.php
+++ b/modules/profiles/modules.php
@@ -67,7 +67,10 @@ class Hm_Handler_process_profile_delete extends Hm_Handler_Module {
         }
 
         if (($profile = Hm_Profiles::get($form['profile_id']))) {
-            if (array_key_exists('autocreate', $profile)) {
+
+            $server = Hm_SMTP_List::get($profile['smtp_id'], false);
+
+            if (array_key_exists('autocreate', $profile) && $server) {
                 Hm_Msgs::add('Automatically created profile cannot be deleted', 'warning');
                 return;
             }


### PR DESCRIPTION
This PR allows the deletion of automatically created profiles even when the associated server has already been deleted. Previously, the deletion logic did not allow auto-created profiles to be removed, even if the server had already been deleted