### PR TITLE
fix(backend): sieve initialization

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1526,20 +1526,6 @@ if (!hm_exists('forward_dropdown')) {
     }
 }
 
-/**
- * @subpackage imap/functions
- */
-if (!hm_exists('parse_sieve_config_host')) {
-function parse_sieve_config_host($host) {
-    $url = parse_url($host);
-    if ($url === false) {
-        return $host;
-    }
-    $host = $url['host'] ?? $url['path'];
-    $port = $url['port'] ?? '4190';
-    return [$host, $port];
-}}
-
 if (!hm_exists('connect_to_imap_server')) {
     function connect_to_imap_server($address, $name, $port, $user, $pass, $tls, $imap_sieve_host, $enableSieve, $type, $context, $hidden = false, $server_id = false, $sieve_tls = false, $show_errors = true) {
         $imap_list = array(

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -1905,10 +1905,9 @@ class Hm_Handler_imap_connect extends Hm_Handler_Module {
             $imap_details = Hm_IMAP_List::dump($form['imap_server_id'], true);
             if ($success && $imap_details) {
                 if ($this->module_is_supported('sievefilters') && $this->user_config->get('enable_sieve_filter_setting', DEFAULT_ENABLE_SIEVE_FILTER)) {
+                    $factory = get_sieve_client_factory($this->site_config);
                     try {
-                        list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_details['sieve_config_host']);
-                        $client = new \PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
-                        $client->connect($imap_details['user'], $imap_details['pass'], $imap_details['sieve_tls'], "", "PLAIN");
+                        $client = $factory->init($this->user_config, $imap_details, $this->module_is_supported('nux'));
                     } catch (Exception $e) {
                         Hm_Msgs::add("Failed to authenticate to the Sieve host", "danger");
                         return;

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -284,6 +284,23 @@ if (!hm_exists('get_sieve_client_factory')) {
     }
 }
 
+if (!hm_exists('parse_sieve_config_host')) {
+function parse_sieve_config_host($imap_account) {
+    $host = $imap_account['sieve_config_host'];
+    $url = parse_url($host);
+    if ($url === false) {
+        return $host;
+    }
+    $host = $url['host'] ?? $url['path'];
+    $port = $url['port'] ?? '4190';
+    if (isset($url['scheme'])) {
+        $tls = $url['scheme'] == 'tls';
+    } else {
+        $tls = $imap_account['tls'] ?? true;
+    }
+    return [$host, $port, $tls];
+}}
+
 if (!hm_exists('prepare_sieve_script ')) {
     function prepare_sieve_script ($script, $index = 1, $action = "decode")
     {
@@ -554,6 +571,7 @@ if (!hm_exists('get_sieve_host_from_services')) {
                 return [
                     'host' => $service['sieve']['host'],
                     'port' => $service['sieve']['port'] ?? 4190,
+                    'tls' => $service['sieve']['tls'] ?? true,
                 ];
             }
         }

--- a/modules/sievefilters/hm-sieve.php
+++ b/modules/sievefilters/hm-sieve.php
@@ -11,11 +11,12 @@ class Hm_Sieve_Client_Factory {
             if($is_nux_supported && $sieve_config = get_sieve_host_from_services($imap_account['server'])) {
                 $sieve_host = $sieve_config['host'];
                 $sieve_port = $sieve_config['port'];
+                $sieve_tls = $sieve_config['tls'];
             } else {
-                list($sieve_host, $sieve_port) = parse_sieve_config_host($imap_account['sieve_config_host']);
+                list($sieve_host, $sieve_port, $sieve_tls) = parse_sieve_config_host($imap_account);
             }
             $client = new PhpSieveManager\ManageSieve\Client($sieve_host, $sieve_port);
-            $client->connect($imap_account['user'], $imap_account['pass'], $imap_account['sieve_tls'], "", "PLAIN");
+            $client->connect($imap_account['user'], $imap_account['pass'], $sieve_tls, "", "PLAIN");
             return $client;
         } else {
             $errorMsg = 'Invalid config host';


### PR DESCRIPTION
move parsing of sieve config to sievefilters module and re-use client factory for every initialization except nux connection test
