### PR TITLE
fix(frontend): edit_filter actin not triggering modal

### DIFF
--- a/modules/sievefilters/site.js
+++ b/modules/sievefilters/site.js
@@ -577,12 +577,6 @@ function sieveFiltersPageHandler() {
         current_account = $(this).attr('account');
         edit_script_modal.open();
     });
-    $('.edit_filter').on('click', function (e) {
-        e.preventDefault();
-        let script_name = $(this).parent().parent().children().next().html();
-        edit_filter_modal.setTitle(script_name);
-        edit_filter_modal.open();
-    });
 
     /**
      * Delete action Button
@@ -997,6 +991,8 @@ function sieveFiltersPageHandler() {
                         }
                     }
                 });
+                edit_filter_modal.setTitle(current_editing_filter_name);
+                edit_filter_modal.open();
             }
         );
     });


### PR DESCRIPTION
## 🛠️ What’s Fixed  
Fixes an issue where the `edit_filter` action did not open the modal as expected.

## ✅ Changes  
- Ensured the modal is triggered correctly when `edit_filter` is used.
