### PR TITLE
fix(backend): crash when messages key is null in IMAP result

### DIFF
--- a/modules/imap/functions.php
+++ b/modules/imap/functions.php
@@ -1708,7 +1708,7 @@ function getCombinedMessagesLists($sources, $context, $search) {
             $msg['server_name'] = $result['dataSource']['name'];
             $msg['folder'] = $result['folder'];
             return $msg;
-        }, $result['messages']);
+        }, is_array($result['messages']) ? $result['messages'] : []);
     }
 
     return ['lists' => $messagesLists, 'total' => $totalMessages, 'status' => $status];


### PR DESCRIPTION
<img width="779" alt="Screenshot 2025-05-28 at 04 57 12" src="https://github.com/user-attachments/assets/0de6e541-8ccc-4c19-8cef-777905f8767d" />
