### PR TITLE
refactor(frontend/backend): improve folder page by using default profile to auto-select server

### DIFF
--- a/lib/servers.php
+++ b/lib/servers.php
@@ -216,6 +216,27 @@ trait Hm_Server_List {
     }
 
     /**
+     * Return server details matching $match in column $column.
+     *
+     * @param mixed  $match        Value to match.
+     * @param string $column       Column name to match against.
+     * @param bool   $returnFirst  If true, return only the first matching server.
+     * @return array|null          Array of matches, or a single server array, or null if no match.
+     */
+    public static function getBy($match, $column = 'id', $returnFirst = false) {
+        $results = [];
+        foreach (self::$server_list as $server) {
+            if (isset($server[$column]) && $server[$column] === $match) {
+                if ($returnFirst) {
+                    return $server;
+                }
+                $results[] = $server;
+            }
+        }
+        return $returnFirst ? null : $results;
+    }
+
+    /**
      * @param int $id server id to fetch
      * @param bool $full true to return passwords for server connections. CAREFUL!
      * @return array

--- a/modules/imap_folders/js_modules/route_handlers.js
+++ b/modules/imap_folders/js_modules/route_handlers.js
@@ -5,6 +5,13 @@ function applyFoldersPageHandlers() {
     $('.settings_subtitle').on("click", function() { return Hm_Utils.toggle_page_section($(this).data('target')); });
     
     bindFoldersEventHandlers();
+    $(function() {
+        const form = $('#form_folder_imap');
+        const autoSubmit = form.data('auto-submit');
+        if (autoSubmit && autoSubmit === 1) {
+            form.submit();
+        }
+    })
 }
 
 function applyFoldersSubscriptionPageHandlers() {

--- a/modules/imap_folders/modules.php
+++ b/modules/imap_folders/modules.php
@@ -185,7 +185,7 @@ class Hm_Handler_process_folder_create extends Hm_Handler_Module {
                     $this->out('imap_folders_success', true);
                 }
                 else {
-                    Hm_Msgs::add('An error occurred creating the folder', 'danger');
+                    Hm_Msgs::add('Failed to create folder '.$form['folder'].'. It might already exist. Please check and try again.', 'danger');
                 }
             }
         }
@@ -319,6 +319,7 @@ class Hm_Handler_folders_server_id extends Hm_Handler_Module {
         if (array_key_exists('imap_server_id', $this->request->get)) {
             $this->out('folder_server', $this->request->get['imap_server_id']);
             $this->out('page', $this->request->get['page']);
+            $this->out('trigger_default_submit', false);
         }
     }
 }
@@ -375,7 +376,10 @@ class Hm_Handler_process_only_subscribed_folders_setting extends Hm_Handler_Modu
 class Hm_Output_folders_server_select extends Hm_Output_Module {
     protected function output() {
         $server_id = $this->get('folder_server', '');
-        $res = '<div class="folders_page mt-4 row mb-4"><div class="col-xl-6 col-sm-12"><form id="form_folder_imap" method="get">';
+        // exit(var_dump($server_id));
+        // $res = '<div class="folders_page mt-4 row mb-4"><div class="col-xl-6 col-sm-12"><form id="form_folder_imap" method="get">';
+        $data_auto_submit = !empty($this->get('trigger_default_submit')) ? ' data-auto-submit="1"' : 'data-auto-submit="0"';
+        $res = '<div class="folders_page mt-4 row mb-4"><div class="col-xl-6 col-sm-12"><form id="form_folder_imap" method="get"'.$data_auto_submit.'>';
         $res .= '<input type="hidden" name="page" value="'.$this->get('page', 'folders').'" />';
         $res .= '<div class="form-floating"><select class="form-select" id="imap_server_folder" name="imap_server_id">';
         $res .= '<option ';

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -9,7 +9,25 @@ var folder_page_folder_list = function(container, title, link_class, target, id_
     $('.imap_folder_link', folders).addClass(link_class).removeClass('imap_folder_link');
     folder_location.prepend(folders);
     folder_location.show();
-    $('.'+link_class, folder_location).on("click", function() { return expand_folders_page_list($(this).data('target'), container, link_class, target, id_dest, subscription); });
+
+    // 1. Get the <a> element
+    const link = document.querySelector('.'+link_class);
+    // 2. Save the <i> element
+    const original_icon = link.querySelector('i');
+    const original_icon_clone = original_icon.cloneNode(true);
+    // 3. Create the spinner
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner-border text-info spinner-border-sm';
+    spinner.setAttribute('role', 'status');
+    spinner.setAttribute('id', 'imap-spinner');
+    spinner.innerHTML = '<span class="sr-only"></span>';
+    // 4. Replace the icon with the spinner
+    if (original_icon.parentNode === link) {
+        link.replaceChild(spinner, original_icon);
+    }
+ 
+    var child_link_target =  folder_location.find('a.'+link_class).data('target')
+    $('.' + link_class, folder_location).on("click", function () { return expand_folders_page_list($(this).data('target'), container, link_class, target, id_dest, subscription); });
     $('a', folder_location).not('.'+link_class).not('.close').off('click');
     $('a', folder_location).not('.'+link_class).not('.close').on("click", function() { set_folders_page_value($(this).data('id'), container, target, id_dest); return false; });
     $('.close', folder_location).on("click", function() {
@@ -23,7 +41,7 @@ var folder_page_folder_list = function(container, title, link_class, target, id_
     return false;
 };
 
-var expand_folders_page_list = function(path, container, link_class, target, id_dest, lsub) {
+var expand_folders_page_list = function(path, container, link_class, target, id_dest, lsub, original_icon = null, parent_icon_link = null) {
     var detail = Hm_Utils.parse_folder_path(path, 'imap');
     var list = $('.imap_'+detail.server_id+'_'+Hm_Utils.clean_selector(detail.folder), $('.'+container));
     if ($('li', list).length === 0) {

--- a/modules/profiles/hm-profiles.php
+++ b/modules/profiles/hm-profiles.php
@@ -56,6 +56,15 @@ class Hm_Profiles {
         return true;
     }
 
+    public static function getDefault() {
+        foreach (self::$data as $vals) {
+            if ($vals['default'] && $vals['default'] = true) {
+                return $vals;
+            }
+        }
+        return null;
+    }
+
     public static function createDefault($hmod) {
         if (! $hmod->module_is_supported('imap') || ! $hmod->module_is_supported('smtp')) {
             return;

--- a/modules/profiles/modules.php
+++ b/modules/profiles/modules.php
@@ -159,6 +159,26 @@ class Hm_Handler_process_profile_update extends Hm_Handler_Module {
 
 /**
  * @subpackage profile/handler
+ * If no 'imap_server_id' is provided, we select a default server based on the user profile.
+ * This handler works in conjunction with imap_folders/Hm_Handler_folders_server_id,
+ * which handles the case where 'imap_server_id' is explicitly provided.
+ */
+class Hm_Handler_load_default_server_from_profiles extends Hm_Handler_Module {
+    public function process() {
+        if (!array_key_exists('imap_server_id', $this->request->get)) {
+            Hm_Profiles::init($this);
+            $defaultProfile = Hm_Profiles::getDefault();
+            $server = Hm_IMAP_List::getBy($defaultProfile['server'],'server', true);
+            if (!is_null($server) && !empty($server['id'])) {
+                $this->out('folder_server', $server['id']);
+                $this->out('trigger_default_submit', true);
+            }
+        }
+    }
+}
+
+/**
+ * @subpackage profile/handler
  */
 class Hm_Handler_profile_data extends Hm_Handler_Module {
     public function process() {

--- a/modules/profiles/setup.php
+++ b/modules/profiles/setup.php
@@ -14,6 +14,8 @@ add_handler('profiles', 'process_profile_update', true, 'profiles', 'process_pro
 add_output('profiles', 'profile_edit_form', true, 'profiles', 'content_section_start', 'after');
 add_output('profiles', 'profile_content', true, 'profiles', 'profile_edit_form', 'after');
 
+add_handler('folders', 'load_default_server_from_profiles', true, 'profiles', 'folders_server_id', 'before');
+
 add_output('ajax_hm_folders', 'profile_page_link', true, 'profiles', 'settings_menu_end', 'before');
 add_output('compose', 'compose_signature_button', true, 'profiles', 'compose_form_end', 'before');
 add_output('compose', 'compose_signature_values', true, 'profiles', 'compose_form_start', 'before');


### PR DESCRIPTION
 On the folder page, added support for selecting a default server using the default profile, instead of waiting for the user to manually choose one. This implements a feature requested by John.
 
 I separated from https://github.com/cypht-org/cypht/pull/1536