### PR TITLE
fix(frontend): improve move/copy email interaction

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -361,33 +361,33 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
 
             $txt .= '<tr><td class="header_space" colspan="2"></td></tr>';
             $txt .= '<tr><th colspan="2" class="header_links">';
-            $txt .= '<div class="msg_move_to">'.
-                '<a href="#" class="hlink all_headers">'.$this->trans('All headers').'</a>'.
-                '<a class="hlink small_headers" style="display: none;" href="#">'.$this->trans('Small headers').'</a>';
+            $txt .= '<ul class="msg_move_to">'.
+                '<li><a href="#" class="hlink all_headers">'.$this->trans('All headers').'</a></li>'.
+                '<li><a class="hlink small_headers" style="display: none;" href="#">'.$this->trans('Small headers').'</a></li>';
             if (!isset($headers['Flags']) || !mb_stristr($headers['Flags'], 'draft')) {
-                $txt .= ' | <a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a>';
+                $txt .= ' | <li><a class="reply_link hlink" href="?page=compose&amp;reply=1'.$reply_args.'">'.$this->trans('Reply').'</a></li>';
                 if ($size > 1) {
-                    $txt .= ' | <a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a>';
+                    $txt .= ' | <li><a class="reply_all_link hlink" href="?page=compose&amp;reply_all=1'.$reply_args.'">'.$this->trans('Reply-all').'</a></li>';
                 }
                 else {
-                    $txt .= ' | <a class="reply_all_link hlink disabled_link">'.$this->trans('Reply-all').'</a>';
+                    $txt .= ' | <li><a class="reply_all_link hlink disabled_link">'.$this->trans('Reply-all').'</a></li>';
                 }
                 $txt .= ' | ' . forward_dropdown($this, $reply_args);
             }
             if (isset($headers['Flags']) && mb_stristr($headers['Flags'], 'flagged')) {
-                $txt .= ' | <a style="display: none;" class="flagged_link hlink" id="flag_msg" data-state="unflagged" href="#">'.$this->trans('Flag').'</a>';
-                $txt .= '<a id="unflag_msg" class="unflagged_link hlink" data-state="flagged" href="#">'.$this->trans('Unflag').'</a>';
+                $txt .= ' | <li><a style="display: none;" class="flagged_link hlink" id="flag_msg" data-state="unflagged" href="#">'.$this->trans('Flag').'</a></li>';
+                $txt .= '<li><a id="unflag_msg" class="unflagged_link hlink" data-state="flagged" href="#">'.$this->trans('Unflag').'</a></li>';
             }
             else {
-                $txt .= ' | <a id="flag_msg" class="unflagged_link hlink" data-state="unflagged" href="#">'.$this->trans('Flag').'</a>';
-                $txt .= '<a style="display: none;" class="flagged_link hlink" id="unflag_msg" data-state="flagged" href="#">'.$this->trans('Unflag').'</a>';
+                $txt .= ' | <li><a id="flag_msg" class="unflagged_link hlink" data-state="unflagged" href="#">'.$this->trans('Flag').'</a></li>';
+                $txt .= '<li><a style="display: none;" class="flagged_link hlink" id="unflag_msg" data-state="flagged" href="#">'.$this->trans('Unflag').'</a></li>';
             }
 
-            $txt .= ' | <a class="hlink" id="unread_message" href="#" >'.$this->trans('Unread').'</a>';
-            $txt .= ' | <a class="delete_link hlink" id="delete_message" href="#">'.$this->trans('Delete').'</a>';
-            $txt .= ' | <a class="hlink" id="copy_message" href="#">'.$this->trans('Copy').'</a>';
-            $txt .= ' | <a class="hlink" id="move_message" href="#">'.$this->trans('Move').'</a>';
-            $txt .= ' | <a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a>';
+            $txt .= ' | <li><a class="hlink" id="unread_message" href="#" >'.$this->trans('Unread').'</a></li>';
+            $txt .= ' | <li><a class="delete_link hlink" id="delete_message" href="#">'.$this->trans('Delete').'</a></li>';
+            $txt .= ' | <li><a class="hlink" id="copy_message" href="#">'.$this->trans('Copy').'</a><div class="move_to_location"></div></li>';
+            $txt .= ' | <li><a class="hlink" id="move_message" href="#">'.$this->trans('Move').'</a><div class="move_to_location"></div></li>';
+            $txt .= ' | <li><a class="archive_link hlink" id="archive_message" href="#">'.$this->trans('Archive').'</a></li>';
             if($this->get('tags')){
                 $txt .= ' | '. tags_dropdown($this, $headers);
             }
@@ -410,19 +410,19 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
                     $sender_blocked = in_array($sender, $blocked_senders);
                     $domain_blocked = in_array($domain, $blocked_senders);
                     if(!in_array($sender, $existing_emails)){
-                        $txt .= ' | <div class="dropdown d-inline-block"><a class="block_sender_link hlink dropdown-toggle'.($domain_blocked || $sender_blocked ? '" id="unblock_sender" data-target="'.($domain_blocked? 'domain':'sender').'"' : '"').' href="#" aria-labelledby="dropdownMenuBlockSender" data-bs-toggle="dropdown"><i class="bi bi-lock-fill"></i> <span id="filter_block_txt">'.$this->trans($domain_blocked ? 'Unblock Domain' : ($sender_blocked ? 'Unblock Sender' : 'Block Sender')).'</span></a>';
+                        $txt .= ' | <li><div class="dropdown d-inline-block"><a class="block_sender_link hlink dropdown-toggle'.($domain_blocked || $sender_blocked ? '" id="unblock_sender" data-target="'.($domain_blocked? 'domain':'sender').'"' : '"').' href="#" aria-labelledby="dropdownMenuBlockSender" data-bs-toggle="dropdown"><i class="bi bi-lock-fill"></i> <span id="filter_block_txt">'.$this->trans($domain_blocked ? 'Unblock Domain' : ($sender_blocked ? 'Unblock Sender' : 'Block Sender')).'</span></a></li>';
                         $txt .= block_filter_dropdown($this);
                     }
                 } else {
-                    $txt .= ' | <span data-bs-toogle="tooltip" title="This functionality requires the email server support &quot;Sieve&quot; technology which is not provided. Contact your email provider to fix it or enable it if supported."><i class="bi bi-lock-fill"></i> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></span>';
+                    $txt .= ' | <li><span data-bs-toogle="tooltip" title="This functionality requires the email server support &quot;Sieve&quot; technology which is not provided. Contact your email provider to fix it or enable it if supported."><i class="bi bi-lock-fill"></i> <span id="filter_block_txt">'.$this->trans('Block Sender').'</span></span></li>';
                 }
             }
-            $txt .= ' | <a class="hlink" id="show_message_source" href="#">' . $this->trans('Show Source') . '</a>';
+            $txt .= ' | <li><a class="hlink" id="show_message_source" href="#">' . $this->trans('Show Source') . '</a></li>';
 
             if ($is_draft) {
-                $txt .= ' | <a class="edit_draft_link hlink" id="edit_draft" href="?page=compose'.$reply_args.'&imap_draft=1">'.$this->trans('Edit Draft').'</a>';
+                $txt .= ' | <li><a class="edit_draft_link hlink" id="edit_draft" href="?page=compose'.$reply_args.'&imap_draft=1">'.$this->trans('Edit Draft').'</a></li>';
             }
-            $txt .= '<div class="move_to_location"></div></div>';
+            $txt .= '</ul>';
             $txt .= '<input type="hidden" class="move_to_type" value="" />';
             $txt .= '<input type="hidden" class="move_to_string1" value="'.$this->trans('Move to ...').'" />';
             $txt .= '<input type="hidden" class="move_to_string2" value="'.$this->trans('Copy to ...').'" />';

--- a/modules/imap/site.css
+++ b/modules/imap/site.css
@@ -313,19 +313,46 @@
 }
 .msg_move_to .move_to_location {
   font-size: 100%;
-  left: auto;
   right: 0px;
-  top: 33px;
+  top: 40px;
   font-variant: normal;
 }
 .msg_move_to {
   width: auto !important;
   position: relative;
-  display: inline-block;
+  display: flex;
+  gap: 4px;
+  list-style: none;
+  flex-wrap: wrap;
 }
 .move_to_location .expand_link {
   float: left !important;
   width: auto !important;
+}
+.msg_move_to li {
+  display: flex;
+  position: relative;
+}
+.move_to_location {
+  display: none;
+  position: absolute;
+  left: -5%;
+  top: 40px;
+  right: 100%;
+  background-color: white;
+  border: 0.4px solid #8080807a;
+  border-radius: 4px;
+  z-index: 50;
+  min-width: 300px;
+  max-width: 400px;
+  min-height: 400px;
+  max-height: 400px;
+  overflow-y: auto;
+  box-shadow: 0px 5px 10px #8080804a;
+}
+.move_to_location .folders li {
+  display: flex;
+  flex-direction: column;
 }
 /* .imap_keyword, .imap_sort, .imap_filter { font-size: 75%; float: left; margin-top: 8px; } */
 .imap_keyword {
@@ -545,6 +572,13 @@
 .inner_list li[class^="imap_"]:hover .action-link {
     opacity: 1;
 }
+.inner_list li {
+  display: flex !important;
+  flex-direction: row !important;
+  gap: 2px;
+  align-items: center;
+}
+
 #loadingSpinner {
     position: absolute;
     left: 33.5%;

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -901,12 +901,14 @@ var unselect_non_imap_messages = function() {
 };
 
 var imap_move_copy = function(e, action, context) {
+    e.preventDefault()
     var move_to;
     if (!e.target || e.target.classList.contains('imap_move')) {
         move_to = $('.msg_controls .move_to_location');
     }
     else {
-        move_to = $('.msg_text .move_to_location');
+        var li = e.target.closest('li');
+        move_to = li.querySelector('.move_to_location');
     }
     unselect_non_imap_messages();
     var label;
@@ -923,7 +925,7 @@ var imap_move_copy = function(e, action, context) {
         label = $('.move_to_string2').val();
     }
     folders.prepend('<div class="move_to_title">'+label+'<a class="close_move_to close" href="#" aria-label="Close"><span aria-hidden="true">&times;</span></a></div>');
-    move_to.html(folders.html());
+    $(move_to).html(folders.html());
     $('.imap_move_folder_link', move_to).on("click", function() { return expand_imap_move_to_folders($(this).data('target'), context); });
     $('a', move_to).not('.imap_move_folder_link').not('.close_move_to').off('click');
     $('a', move_to).not('.imap_move_folder_link').not('.close_move_to').on("click", function() { imap_perform_move_copy($(this).data('id'), context); return false; });
@@ -933,7 +935,7 @@ var imap_move_copy = function(e, action, context) {
         $('.move_to_location').hide();
         return false;
     });
-    move_to.show();
+    $(move_to).show();
     return false;
 };
 


### PR DESCRIPTION
### ✨ UI Improvement: Move/Copy Email Actions

**Changes made:**

- Targeted the correct `.move_to_location` container based on the clicked element (`Move` or `Copy`)
- Applied CSS styles for better visual clarity and user experience
<img width="500" alt="Screenshot 2025-07-01 at 21 18 32" src="https://github.com/user-attachments/assets/45a2b181-e2bf-43a0-9ef7-be86f21a3b60" />

<img width="1101" alt="Screenshot 2025-07-01 at 22 03 01" src="https://github.com/user-attachments/assets/82d9b25d-e224-4936-a533-e07542f95ac8" />



