### PR TITLE
fix(frontend): remove MIME boundaries and headers from body

### DIFF
--- a/modules/core/message_list_functions.php
+++ b/modules/core/message_list_functions.php
@@ -320,7 +320,17 @@ function subject_callback($vals, $style, $output_mod) {
     }
     $subject = $output_mod->html_safe($vals[0]);
     if (isset($vals[4]) && $vals[4]) {
-        $preview_msg = $output_mod->html_safe($vals[4]);
+        $lines = explode("\n", $vals[4]);
+        $clean = array_filter(array_map('trim', $lines), function ($line) {
+            return $line !== ''
+                && stripos($line, 'boundary=') === false
+                && !preg_match('/^-{2,}==/', $line)
+                && stripos($line, 'content-type:') !== 0
+                && stripos($line, 'charset=') === false
+                && stripos($line, 'content-transfer-encoding:') !== 0;
+        });
+        $clean_text = implode("\n", $clean);
+        $preview_msg = $output_mod->html_safe($clean_text);
     }
     
     $hl_subject = preg_replace("/^(\[[^\]]+\])/", '<span class="s_pre">$1</span>', $subject);


### PR DESCRIPTION
Remove MIME boundaries and headers from body

Clean the email body preview by filtering out multipart MIME boundaries
and header lines like Content-Type, charset, and Content-Transfer-Encoding.
This results in a clearer, more readable message preview.

Before
<img width="1117" alt="Screenshot 2025-07-07 at 19 38 58" src="https://github.com/user-attachments/assets/ddbdafe6-6755-4de9-a39a-635580a13712" />

After

![Screenshot 2025-07-01 at 22 33 00](https://github.com/user-attachments/assets/82557c5c-3d29-4057-880b-93c9a35bdb6b)


