### PR TITLE
fix(frontend): make server status list responsive with loading indicators a…

### DIFF
--- a/lib/request.php
+++ b/lib/request.php
@@ -175,6 +175,12 @@ class Hm_Request {
             $this->mobile = true;
             return;
         }
+
+        if (!empty($_COOKIE['is_mobile_screen']) && $_COOKIE['is_mobile_screen'] == '1') {
+            $this->mobile = true;
+            return;
+        }
+
         if (!empty($this->server['HTTP_USER_AGENT'])) {
             if (preg_match("/(iphone|ipod|ipad|android|blackberry|webos|opera mini)/i", $this->server['HTTP_USER_AGENT'])) {
                 $this->mobile = true;

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -9,6 +9,13 @@ $.fn.fadeOutAndRemove = function(timeout = 600) {
     return this;
 };
 
+if (window.innerWidth <= 768) {
+    document.documentElement.classList.add('mobile');
+    document.cookie = "is_mobile_screen=1; path=/; SameSite=Lax";
+} else {
+    document.cookie = "is_mobile_screen=0; path=/; SameSite=Lax";
+}
+
 /* swipe event handler */
 var swipe_event = function(el, callback, direction) {
     var start_x, start_y, dist_x, dist_y, threshold = 150, restraint = 100,

--- a/modules/developer/modules.php
+++ b/modules/developer/modules.php
@@ -275,26 +275,58 @@ class Hm_Output_server_status_start extends Hm_Output_Module {
     protected function output() {
         $settings = $this->get('user_settings', array());
         $enable_sieve = $settings['enable_sieve_filter_setting'] ?? DEFAULT_ENABLE_SIEVE_FILTER;
-        $res = '<div class="content_title px-3">'.$this->trans('Status').'</div><div class="p-3"><table class="table table-borderless"><thead><tr><th class="text-secondary fw-light">'.$this->trans('Type').'</th><th class="text-secondary fw-light">'.$this->trans('Name').'</th><th class="text-secondary fw-light">'.
-                $this->trans('Status').'</th>';
-        if ($enable_sieve) {
-            $res .= '<th class="text-secondary fw-light">'.$this->trans('Sieve server capabilities').'</th>';
+        $res = '<div class="content_title_info px-4">'.$this->trans('Status & Sieve Capabilities').'</div><div class="server_status_info p-3">';
+        if (!$this->get('is_mobile')) {
+            $res .= '<table class="table table-borderless"><thead><tr><th class="text-secondary fw-light">'.$this->trans('Type').'</th><th class="text-secondary fw-light">'.$this->trans('Name').'</th><th class="text-secondary fw-light">'.
+                    $this->trans('Status').'</th>';
+            if ($enable_sieve) {
+                $res .= '<th class="text-secondary fw-light">'.$this->trans('Sieve server capabilities').'</th>';
+            }
+            $res .= '</tr></thead><tbody>';
+        }else {
+            $imap_servers = $this->get('imap_servers', array());
+            // Helper function to render label/value pairs
+            $row = function($label, $value) {
+                return '<li><div class="server_status_label">'.$label.'</div><div>'.$value.'</div></li>';
+            };
+            $last_key = end(array_keys($imap_servers));
+            foreach($imap_servers as $index => $imap_server) {
+                $res .= "<ul class='server_status_parent_list'>";
+                $res .= $row($this->trans('Type'), strtoupper($imap_server['type'] ?? 'IMAP'));
+                $res .= $row($this->trans('Name'), $imap_server['name']);
+                $res .= $row(
+                    $this->trans('Status'),
+                    '<div class="imap_status_'.$imap_server['id'].' imap_status" data-id="'.$imap_server['id'].'"></div>'
+                );
+                if ($enable_sieve) {
+                    $res .= $row(
+                        $this->trans('Sieve server capabilities'),
+                        '<div class="imap_detail_'.$imap_server['id'].'"></div>'
+                    );
+                }
+                $res .= "</ul>";
+                if ($index !== $last_key) {
+                    $res .= '<hr class="my-4 border-top border-secondary opacity-50">';
+                }
+            }
         }
-        $res .= '</tr></thead><tbody>';
         return $res;
     }
 }
 
+
 /**
  * Close the status table used on the info page
- * @subpackage developer/output
- */
+ * @subpackage developer/output */
 class Hm_Output_server_status_end extends Hm_Output_Module {
     /**
      * Close the table opened in Hm_Output_server_status_start
      */
     protected function output() {
-        return '</tbody></table></div></div>';
+        if (!$this->get('is_mobile')) {
+            return '</tbody></table></div></div>';
+        }
+        return '</div>';
     }
 }
 
@@ -307,8 +339,33 @@ class Hm_Output_server_capabilities_start extends Hm_Output_Module {
      * Modules populate this table to run a status check from the info page
      */
     protected function output() {
-        $res = '<div class="content_title px-3">'.$this->trans('Capabilities').'</div><div class="p-3"><table class="table table-borderless"><thead><tr><th class="text-secondary fw-light">'.$this->trans('Type').'</th><th class="text-secondary fw-light">'.$this->trans('Name').'</th><th class="text-secondary fw-light">'.
+        $res = '<div class="content_title_info px-4">'.$this->trans('Capabilities').'</div><div class="p-3">';
+        if(!$this->get('is_mobile')) {
+            $res .= '<table class="table table-borderless"><thead><tr><th class="text-secondary fw-light">'.$this->trans('Type').'</th><th class="text-secondary fw-light">'.$this->trans('Name').'</th><th class="text-secondary fw-light">'.
                 $this->trans('Server capabilities').'</th></tr></thead><tbody>';
+        }else {
+            $imap_servers = $this->get('imap_servers', array());
+
+            // Helper function to render label/value pairs
+            $row = function($label, $value) {
+                return '<li><div class="server_status_label">'.$label.'</div><div>'.$value.'</div></li>';
+            };
+            $last_key = end(array_keys($imap_servers));
+            foreach($imap_servers as $imap_server) {
+                $res .= "<ul class='server_status_parent_list'>";
+                $res .= $row($this->trans('Type'), strtoupper($imap_server['type'] ?? 'IMAP'));
+                $res .= $row($this->trans('Name'), $imap_server['name']);
+                
+                $res .= $row(
+                    $this->trans('Server capabilities'),
+                    '<div class="imap_capabilities_'.$imap_server['id'].'"></div>'
+                );
+                $res .= "</ul>";
+                if ($imap_server['id'] !== $last_key) {
+                    $res .= '<hr class="my-4 border-top border-secondary opacity-50">';
+                }
+            }
+        }
         return $res;
     }
 }
@@ -322,6 +379,9 @@ class Hm_Output_server_capabilities_end extends Hm_Output_Module {
      * Close the table opened in Hm_Output_server_capabilities_start
      */
     protected function output() {
-        return '</tbody></table></div></div>';
+        if(!$this->get('is_mobile')) {
+            return '</tbody></table></div></div>';
+        }
+        return '</div>';
     }
 }

--- a/modules/developer/site.css
+++ b/modules/developer/site.css
@@ -1,6 +1,27 @@
 .hmod_val, .omod_val, .hmod, .omod { color: #666; display: none; padding: 4px; padding-left: 60px; }
 .config_map_page { color: #666; font-size: 110%; cursor: pointer; padding-top: 20px; padding-left: 40px; }
-.config_map { margin-left: 40px; min-width: 400px; }
+.config_map { margin-left: 25px; min-width: 400px; }
 .config_map th {border-bottom: solid 1px #eee; padding-left: 20px;  display: none; padding-top: 10px; color: #666; font-size: 90%; text-align: left; }
 .config_map th { padding-left: 60px; }
 .config_map img { width: 16px; height: 16px; opacity: .6 }
+
+
+.server_status_parent_list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-left: 1.6rem;
+}
+
+.server_status_parent_list li {
+    list-style: none;
+    gap: 4px;
+}
+
+.server_status_parent_list .server_status_label {
+    opacity: .6;
+}
+
+@media screen and (max-width: 768px) {
+    .server_info table tr { display: flex; flex-direction: column;}
+}

--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -737,13 +737,15 @@ class Hm_Output_display_imap_status extends Hm_Output_Module {
         $settings = $this->get('user_settings', array());
         $enable_sieve = $settings['enable_sieve_filter_setting'] ?? DEFAULT_ENABLE_SIEVE_FILTER;
         $res = '';
-        foreach ($this->get('imap_servers', array()) as $index => $vals) {
-            $res .= '<tr><td>'.(strtoupper($vals['type'] ?? 'IMAP')).'</td><td>'.$vals['name'].'</td><td class="imap_status_'.$vals['id'].' imap_status" data-id="'.$vals['id'].'"></td>';
-            if ($enable_sieve) {
-                $res .= '<td class="imap_detail_'.$vals['id'].'"></td>';
+        if(!$this->get('is_mobile')) {
+            foreach ($this->get('imap_servers', array()) as $index => $vals) {
+                $res .= '<tr><td>'.(strtoupper($vals['type'] ?? 'IMAP')).'</td><td>'.$vals['name'].'</td><td class="imap_status_'.$vals['id'].' imap_status" data-id="'.$vals['id'].'"></td>';
+                if ($enable_sieve) {
+                    $res .= '<td class="imap_detail_'.$vals['id'].'"></td>';
+                }
+                $res .= '</tr>';
             }
-            $res .= '</tr>';
-        }
+        }   
         return $res;
     }
 }
@@ -758,9 +760,11 @@ class Hm_Output_display_imap_capability extends Hm_Output_Module {
      */
     protected function output() {
         $res = '';
-        foreach ($this->get('imap_servers', array()) as $index => $vals) {
-            $res .= '<tr><td>IMAP</td><td>'.$vals['name'].'</td>'.
-                '<td class="imap_capabilities_'.$vals['id'].'"></td></tr>';
+        if(!$this->get('is_mobile')) {
+            foreach ($this->get('imap_servers', array()) as $index => $vals) {
+                $res .= '<tr><td>IMAP</td><td>'.$vals['name'].'</td>'.
+                    '<td class="imap_capabilities_'.$vals['id'].'"></td></tr>';
+            }
         }
         return $res;
     }

--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -240,6 +240,23 @@ var imap_flag_message = function(state, supplied_uid, supplied_detail) {
 
 var imap_status_update = function() {
     $('.imap_status').each(function(i, el) {
+        const serverId = $(el).data('id');
+        $('.imap_detail_' + serverId).html(`
+            <div class="d-flex align-items-center">
+                <div class="spinner-border text-primary me-2" role="status" style="width: 1rem; height: 1rem;">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <span>Loading sieve capabilities...</span>
+            </div>
+        `);
+        $('.imap_capabilities_' + serverId).html(`
+            <div class="d-flex align-items-center">
+                <div class="spinner-border text-primary me-2" role="status" style="width: 1rem; height: 1rem;">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <span>Loading server capabilities...</span>
+            </div>
+        `);
         Hm_Ajax.request(
             [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_status'},
             {'name': 'imap_server_ids', 'value': $(el).data('id')}],


### PR DESCRIPTION
## ✨ Summary

This PR improves the server status module with a responsive design and enhanced user feedback during async status checks.

---

## ✅ Changes Included

- **Responsive layout**: Replaced table structure with a `<ul>`-based layout for better support on **mobile and desktop** views  
- **Loader preview**: Added a Bootstrap spinner to display while IMAP/Sieve status is being fetched asynchronously  
- **Visual separation**: Dynamically inserted `<hr>` elements between server blocks, excluding after the last item  

---

<img width="621" height="1072" alt="CleanShot 2025-07-12 at 22 32 33" src="https://github.com/user-attachments/assets/1ab61107-dd7c-47cb-997b-0b505c45d174" />

