### PR TITLE
fix(frontend): make profile_replyto optional

### DIFF
--- a/modules/profiles/modules.php
+++ b/modules/profiles/modules.php
@@ -377,7 +377,7 @@ function profile_form($form_vals, $id, $smtp_servers, $imap_servers, $out_mod) {
 
     // Reply-to
     $res .= '<div class="form-floating mb-3 form-check-create-profile">';
-    $res .= '<input type="email" required name="profile_replyto" class="form-control" value="'.$out_mod->html_safe($form_vals['replyto']).'" placeholder="'.$out_mod->trans('Reply-to').' *">';
+    $res .= '<input type="email" name="profile_replyto" class="form-control" value="'.$out_mod->html_safe($form_vals['replyto']).'" placeholder="'.$out_mod->trans('Reply-to').' *">';
     $res .= '<label>'.$out_mod->trans('Reply-to').' *</label></div>';
 
     // IMAP Server


### PR DESCRIPTION
As requested in the previous Cypht Test meeting, we are not obliged to put the profile_replyto, it's optional