### PR TITLE
fix(frontend): Prevent the duplication of footer buttons when reopening the modal

### DIFF
--- a/modules/imap/site.js
+++ b/modules/imap/site.js
@@ -1413,7 +1413,7 @@ $('.screen-email-like').on("click", function() {
         });
         list_html += "</ol>";
         const modal = new Hm_Modal({
-            modalId: 'emptySubjectBodyModal',
+            modalId: 'confirmaAddToTrustContact',
             title: 'Warning',
             btnSize: 'sm'
         });


### PR DESCRIPTION
**Problem:**
During the repeated opening of the Hm_Modal modal, the custom button (Add Emails to Trust contact) was duplicated each time, creating multiple instances of the same button.

**Cause:** 
The addFooterBtn method systematically added a new button without removing the previous ones, leading to duplication with each call.

<img width="464" height="310" alt="add-to-trust-contact-modal" src="https://github.com/user-attachments/assets/9843c948-0f1f-437c-82f7-7c8900b5699e" />
