### PR TITLE
feat(frontend): introduce NProgress and Cypht custom spinner using Bootstrap5

### DIFF
--- a/lib/js_libs.php
+++ b/lib/js_libs.php
@@ -8,6 +8,7 @@ define('JS_LIBS', [
     'jquery-are-you-sure' => 'third_party/jquery.are-you-sure.js',
     'sortable' => 'third_party/sortable.min.js',
     'kindeditor' => 'third_party/kindeditor/kindeditor-all-min.js',
+    'nprogress' => 'third_party/nprogress.js',
 ]);
 
 function get_js_libs($exclude_deps = []) {

--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -437,7 +437,6 @@ function setup_base_page($name, $source=false, $use_layout=true) {
         add_output($name, 'login_start', false, $source);
         add_output($name, 'login', false, $source);
         add_output($name, 'login_end', false, $source);
-        add_output($name, 'loading_icon', true, $source);
         add_output($name, 'date', true, $source);
         add_output($name, 'msgs', false, $source);
         add_output($name, 'folder_list_start', true, $source);

--- a/modules/core/js_modules/Hm_MessagesStore.js
+++ b/modules/core/js_modules/Hm_MessagesStore.js
@@ -220,6 +220,10 @@ class Hm_MessagesStore {
     }
 
     fetch(hideLoadingState = false) {
+        // show my custom cypht spinner(class = cypht-spinner)
+        const spinner = document.querySelector('.cypht-spinner');
+        if (spinner) spinner.style.display = 'block';
+
         let store = this;
         return this.getRequestConfigs().map((config) => {
             return new Promise((resolve, reject) => {
@@ -237,6 +241,9 @@ class Hm_MessagesStore {
                     reject,
                     this.abortController?.signal
                 );
+            }).finally(() => {
+                // Hide the spinner
+                if (spinner) spinner.style.display = 'none';
             });
         });
     }

--- a/modules/core/output_modules.php
+++ b/modules/core/output_modules.php
@@ -507,6 +507,7 @@ class Hm_Output_header_css extends Hm_Output_Module {
             if(count(array_intersect(['contacts','local_contacts','ldap_contacts','gmail_contacts'], $mods)) > 0){
                 $res .= '<link href="'.WEB_ROOT.'third_party/contact-group.css" media="all" rel="stylesheet" type="text/css" />';
             }
+            $res .= '<link href="'.WEB_ROOT.'third_party/nprogress.css" media="all" rel="stylesheet" type="text/css" />';
         }
         else {
             $res .= '<link href="'.WEB_ROOT.'site.css?v='.CACHE_ID.'" ';
@@ -661,18 +662,6 @@ class Hm_Output_js_data extends Hm_Output_Module {
     }
 }
 
-/**
- * Outputs a load icon
- * @subpackage core/output
- */
-class Hm_Output_loading_icon extends Hm_Output_Module {
-    /**
-     * Sort of ugly loading icon animated with js/css
-     */
-    protected function output() {
-        return '<div class="loading_icon"></div>';
-    }
-}
 
 /**
  * Start the main form on the settings page
@@ -1892,7 +1881,9 @@ class Hm_Output_message_list_start extends Hm_Output_Module {
                 $header_flds[] = '<th></th>';
             }
         }
-        $res = '<div class="p-3"><table class="message_table table">';
+        $res = '<div class="p-3">';
+        $res .= '<div class="cypht-spinner"><div class="spinner-border text-danger" role="status"><span class="visually-hidden">Loading...</span></div></div>';
+        $res .= '<table class="message_table table">';
         if (!$this->get('no_message_list_headers')) {
             if (!empty($col_flds)) {
                 $res .= '<colgroup>'.implode('', $col_flds).'</colgroup>';

--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -263,22 +263,21 @@ td {
 .placeholder {
   width: 100px !important;
 }
-.loading_icon {
-  background-position: 0px 0px;
-  background: transparent
-    url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAKCAYAAAD2Fg1xAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3gkbBRUr8yq4rwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACASURBVDjL7c/BCsQwCEXRm0STfm+/PjVVZ9XCrGc35MFDcSGccp5nrrVwd9ydiCAzeVJrpdZKaw0RQVVRVXrvjDE4juOdz/60946qIiKICK219x9AKYXMJDOJCCICd+e+b9ZamBlmxnVdb+eczDm/bmZG5U+yIRuyIRuyIRvySz7mT0d4m0OV2gAAAABJRU5ErkJggg==")
-    repeat-x top left;
-  background-size: cover;
-  opacity: 0.6;
-  text-align: center;
-  display: none;
-  position: fixed;
-  right: 0px;
-  top: 0px;
-  left: 0px;
-  height: 6px;
-  z-index: 1001;
+.cypht-spinner {
+    position: absolute;
+    inset-inline-start: 55%;
+    top: 50%;
+    --tw-translate-x: -50%;
+    display: none;
 }
+
+/* On small screens we don't have left menu, so there add 5% to inset-inline-start */
+@media screen and (max-width: 600px) {
+  .cypht-spinner {
+    inset-inline-start: 50%;
+  }
+}
+
 .logout {
   margin: 2px;
   margin-left: 5px;

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -99,19 +99,12 @@ var Hm_Ajax = {
         if (Hm_Ajax.icon_loading_id !== false) {
             return;
         }
-        var hm_loading_pos = $('.loading_icon').width()/40;
-        $('.loading_icon').show();
-        function move_background_image() {
-            hm_loading_pos = hm_loading_pos + 50;
-            $('.loading_icon').css('background-position', hm_loading_pos+'px 0');
-            Hm_Ajax.icon_loading_id = setTimeout(move_background_image, 100);
-        }
-        move_background_image();
+        NProgress.start()
     },
 
     stop_loading_icon : function(loading_id) {
         clearTimeout(loading_id);
-        $('.loading_icon').hide();
+        NProgress.done();
         Hm_Ajax.icon_loading_id = false;
     },
 

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -226,6 +226,7 @@ function get_module_assignments($settings) {
                 $css .= file_get_contents(sprintf("third_party/contact-group.css", 'third_party'));
             }
         }
+        $css .= file_get_contents(sprintf("third_party/nprogress.css", 'third_party'));
     }
     return array($js, $css, $filters, $assets);
 }

--- a/tests/phpunit/modules/core/functions.php
+++ b/tests/phpunit/modules/core/functions.php
@@ -170,7 +170,7 @@ class Hm_Test_Core_Functions extends TestCase {
         $res2 = Hm_Output_Modules::dump();
         $len2 = count($res2['foo']);
         $this->assertEquals(12, $len);
-        $this->assertEquals(20, $len2);
+        $this->assertEquals(19, $len2);
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/modules/core/output_modules.php
+++ b/tests/phpunit/modules/core/output_modules.php
@@ -441,15 +441,6 @@ class Hm_Test_Core_Output_Modules extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function test_loading_icon() {
-        $test = new Output_Test('loading_icon', 'core');
-        $res = $test->run();
-        $this->assertEquals(array('<div class="loading_icon"></div>'), $res->output_response);
-    }
-    /**
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
-     */
     public function test_start_settings_form() {
         $test = new Output_Test('start_settings_form', 'core');
         $res = $test->run();
@@ -1060,10 +1051,10 @@ class Hm_Test_Core_Output_Modules extends TestCase {
         $test = new Output_Test('message_list_start', 'core');
         $test->handler_response = array('message_list_fields' => array('foo', 'bar'));
         $res = $test->run();
-        $this->assertEquals(array('<div class="p-3"><table class="message_table table"><colgroup><col class="f"><col class="b"></colgroup><thead><tr><th class="o">o</th><th class="a">r</th></tr></thead><tbody class="message_table_body">'), $res->output_response);
+        $this->assertEquals(array('<div class="p-3"><div class="cypht-spinner"><div class="spinner-border text-danger" role="status"><span class="visually-hidden">Loading...</span></div></div><table class="message_table table"><colgroup><col class="f"><col class="b"></colgroup><thead><tr><th class="o">o</th><th class="a">r</th></tr></thead><tbody class="message_table_body">'), $res->output_response);
         $test->handler_response = array('message_list_fields' => array(array(false, true, false)));
         $res = $test->run();
-        $this->assertEquals(array('<div class="p-3"><table class="message_table table"><thead><tr><th></th></tr></thead><tbody class="message_table_body">'), $res->output_response);
+        $this->assertEquals(array('<div class="p-3"><div class="cypht-spinner"><div class="spinner-border text-danger" role="status"><span class="visually-hidden">Loading...</span></div></div><table class="message_table table"><thead><tr><th></th></tr></thead><tbody class="message_table_body">'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/modules/core/output_modules_debug.php
+++ b/tests/phpunit/modules/core/output_modules_debug.php
@@ -17,7 +17,7 @@ class Hm_Test_Core_Output_Modules_Debug extends TestCase {
         $test = new Output_Test('header_css', 'core');
         $test->handler_response = array('router_module_list' => array('core'));
         $res = $test->run();
-        $this->assertEquals(array('<link href="modules/themes/assets/default/css/default.css?v=asdf" media="all" rel="stylesheet" type="text/css" /><link href="vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" /><link href="modules/core/site.css" media="all" rel="stylesheet" type="text/css" /><style type="text/css">@font-face {font-family:"Behdad";src:url("modules/core/assets/fonts/Behdad/Behdad-Regular.woff2") format("woff2"),url("modules/core/assets/fonts/Behdad/Behdad-Regular.woff") format("woff");</style>'), $res->output_response);
+        $this->assertEquals(array('<link href="modules/themes/assets/default/css/default.css?v=asdf" media="all" rel="stylesheet" type="text/css" /><link href="vendor/twbs/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet" type="text/css" /><link href="modules/core/site.css" media="all" rel="stylesheet" type="text/css" /><link href="third_party/nprogress.css" media="all" rel="stylesheet" type="text/css" /><style type="text/css">@font-face {font-family:"Behdad";src:url("modules/core/assets/fonts/Behdad/Behdad-Regular.woff2") format("woff2"),url("modules/core/assets/fonts/Behdad/Behdad-Regular.woff") format("woff");</style>'), $res->output_response);
     }
     /**
      * @preserveGlobalState disabled
@@ -29,7 +29,7 @@ class Hm_Test_Core_Output_Modules_Debug extends TestCase {
         $test->handler_response = array('encrypt_ajax_requests' => true, 'router_module_list' => $given_router_module_list);
         $res = $test->run();
         $dependant_scripts = array('vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js');
-        $third_party_scripts = array('cash.min.js', 'resumable.min.js', 'ays-beforeunload-shim.js', 'jquery.are-you-sure.js', 'sortable.min.js', 'kindeditor/kindeditor-all-min.js', 'forge.min.js');
+        $third_party_scripts = array('cash.min.js', 'resumable.min.js', 'ays-beforeunload-shim.js', 'jquery.are-you-sure.js', 'sortable.min.js', 'kindeditor/kindeditor-all-min.js', 'nprogress.js', 'forge.min.js');
         $expected_scripts = array_merge($dependant_scripts, array_map(function($script) { return 'third_party/'.$script; }, $third_party_scripts));
         
         // The navigation utils and core's site.js should be included before any other module

--- a/third_party/nprogress.css
+++ b/third_party/nprogress.css
@@ -1,0 +1,85 @@
+/* NProgress.css
+ * https://github.com/rstacruz/nprogress
+ *
+ * MIT Licensed
+ * https://github.com/rstacruz/nprogress/blob/master/License.md
+ * Copyright (c) 2013, 2014 Rico Sta. Cruz - http://ricostacruz.com/nprogress
+ *
+ * Author:  Rico Sta. Cruz(@rstacruz@hachyderm.io)
+ * Version: 0.2.0
+ * Date:    13th May 2015
+ */
+
+/* Make clicks pass-through */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: #29d;
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  opacity: 1.0;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+          transform: rotate(3deg) translate(0px, -4px);
+}
+
+/* Remove these to get rid of the spinner */
+#nprogress .spinner {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 15px;
+  right: 15px;
+}
+
+#nprogress .spinner-icon {
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+
+  border: solid 2px transparent;
+  border-top-color: #29d;
+  border-left-color: #29d;
+  border-radius: 50%;
+
+  -webkit-animation: nprogress-spinner 400ms linear infinite;
+          animation: nprogress-spinner 400ms linear infinite;
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
+@-webkit-keyframes nprogress-spinner {
+  0%   { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+@keyframes nprogress-spinner {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/third_party/nprogress.js
+++ b/third_party/nprogress.js
@@ -1,0 +1,485 @@
+/* NProgress
+ * https://github.com/rstacruz/nprogress
+ *
+ * MIT Licensed
+ * https://github.com/rstacruz/nprogress/blob/master/License.md
+ * Copyright (c) 2013, 2014 Rico Sta. Cruz - http://ricostacruz.com/nprogress
+ *
+ * Author:  Rico Sta. Cruz(@rstacruz@hachyderm.io)
+ * Version: 0.2.0
+ * Date:    13th May 2015
+ */
+
+;(function(root, factory) {
+
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.NProgress = factory();
+  }
+
+})(this, function() {
+  var NProgress = {};
+
+  NProgress.version = '0.2.0';
+
+  var Settings = NProgress.settings = {
+    minimum: 0.08,
+    easing: 'ease',
+    positionUsing: '',
+    speed: 200,
+    trickle: true,
+    trickleRate: 0.02,
+    trickleSpeed: 800,
+    showSpinner: true,
+    barSelector: '[role="bar"]',
+    spinnerSelector: '[role="spinner"]',
+    parent: 'body',
+    template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
+  };
+
+  /**
+   * Updates configuration.
+   *
+   *     NProgress.configure({
+   *       minimum: 0.1
+   *     });
+   */
+  NProgress.configure = function(options) {
+    var key, value;
+    for (key in options) {
+      value = options[key];
+      if (value !== undefined && options.hasOwnProperty(key)) Settings[key] = value;
+    }
+
+    return this;
+  };
+
+  /**
+   * Last number.
+   */
+
+  NProgress.status = null;
+
+  /**
+   * Sets the progress bar status, where `n` is a number from `0.0` to `1.0`.
+   *
+   *     NProgress.set(0.4);
+   *     NProgress.set(1.0);
+   */
+
+  NProgress.set = function(n) {
+    var started = NProgress.isStarted();
+
+    n = clamp(n, Settings.minimum, 1);
+    NProgress.status = (n === 1 ? null : n);
+
+    var progress = NProgress.render(!started),
+        bar      = progress.querySelector(Settings.barSelector),
+        speed    = Settings.speed,
+        ease     = Settings.easing;
+
+    progress.offsetWidth; /* Repaint */
+
+    queue(function(next) {
+      // Set positionUsing if it hasn't already been set
+      if (Settings.positionUsing === '') Settings.positionUsing = NProgress.getPositioningCSS();
+
+      // Add transition
+      css(bar, barPositionCSS(n, speed, ease));
+
+      if (n === 1) {
+        // Fade out
+        css(progress, { 
+          transition: 'none', 
+          opacity: 1 
+        });
+        progress.offsetWidth; /* Repaint */
+
+        setTimeout(function() {
+          css(progress, { 
+            transition: 'all ' + speed + 'ms linear', 
+            opacity: 0 
+          });
+          setTimeout(function() {
+            NProgress.remove();
+            next();
+          }, speed);
+        }, speed);
+      } else {
+        setTimeout(next, speed);
+      }
+    });
+
+    return this;
+  };
+
+  NProgress.isStarted = function() {
+    return typeof NProgress.status === 'number';
+  };
+
+  /**
+   * Shows the progress bar.
+   * This is the same as setting the status to 0%, except that it doesn't go backwards.
+   *
+   *     NProgress.start();
+   *
+   */
+  NProgress.start = function() {
+    if (!NProgress.status) NProgress.set(0);
+
+    var work = function() {
+      setTimeout(function() {
+        if (!NProgress.status) return;
+        NProgress.trickle();
+        work();
+      }, Settings.trickleSpeed);
+    };
+
+    if (Settings.trickle) work();
+
+    return this;
+  };
+
+  /**
+   * Hides the progress bar.
+   * This is the *sort of* the same as setting the status to 100%, with the
+   * difference being `done()` makes some placebo effect of some realistic motion.
+   *
+   *     NProgress.done();
+   *
+   * If `true` is passed, it will show the progress bar even if its hidden.
+   *
+   *     NProgress.done(true);
+   */
+
+  NProgress.done = function(force) {
+    if (!force && !NProgress.status) return this;
+
+    return NProgress.inc(0.3 + 0.5 * Math.random()).set(1);
+  };
+
+  /**
+   * Increments by a random amount.
+   */
+
+  NProgress.inc = function(amount) {
+    var n = NProgress.status;
+
+    if (!n) {
+      return NProgress.start();
+    } else {
+      if (typeof amount !== 'number') {
+        amount = (1 - n) * clamp(Math.random() * n, 0.1, 0.95);
+      }
+
+      n = clamp(n + amount, 0, 0.994);
+      return NProgress.set(n);
+    }
+  };
+
+  NProgress.trickle = function() {
+    return NProgress.inc(Math.random() * Settings.trickleRate);
+  };
+
+  /**
+   * Waits for all supplied jQuery promises and
+   * increases the progress as the promises resolve.
+   *
+   * @param $promise jQUery Promise
+   */
+  (function() {
+    var initial = 0, current = 0;
+
+    NProgress.promise = function($promise) {
+      if (!$promise || $promise.state() === "resolved") {
+        return this;
+      }
+
+      if (current === 0) {
+        NProgress.start();
+      }
+
+      initial++;
+      current++;
+
+      $promise.always(function() {
+        current--;
+        if (current === 0) {
+            initial = 0;
+            NProgress.done();
+        } else {
+            NProgress.set((initial - current) / initial);
+        }
+      });
+
+      return this;
+    };
+
+  })();
+
+  /**
+   * (Internal) renders the progress bar markup based on the `template`
+   * setting.
+   */
+
+  NProgress.render = function(fromStart) {
+    if (NProgress.isRendered()) return document.getElementById('nprogress');
+
+    addClass(document.documentElement, 'nprogress-busy');
+    
+    var progress = document.createElement('div');
+    progress.id = 'nprogress';
+    progress.innerHTML = Settings.template;
+
+    var bar      = progress.querySelector(Settings.barSelector),
+        perc     = fromStart ? '-100' : toBarPerc(NProgress.status || 0),
+        parent   = document.querySelector(Settings.parent),
+        spinner;
+    
+    css(bar, {
+      transition: 'all 0 linear',
+      transform: 'translate3d(' + perc + '%,0,0)'
+    });
+
+    if (!Settings.showSpinner) {
+      spinner = progress.querySelector(Settings.spinnerSelector);
+      spinner && removeElement(spinner);
+    }
+
+    if (parent != document.body) {
+      addClass(parent, 'nprogress-custom-parent');
+    }
+
+    parent.appendChild(progress);
+    return progress;
+  };
+
+  /**
+   * Removes the element. Opposite of render().
+   */
+
+  NProgress.remove = function() {
+    removeClass(document.documentElement, 'nprogress-busy');
+    removeClass(document.querySelector(Settings.parent), 'nprogress-custom-parent');
+    var progress = document.getElementById('nprogress');
+    progress && removeElement(progress);
+  };
+
+  /**
+   * Checks if the progress bar is rendered.
+   */
+
+  NProgress.isRendered = function() {
+    return !!document.getElementById('nprogress');
+  };
+
+  /**
+   * Determine which positioning CSS rule to use.
+   */
+
+  NProgress.getPositioningCSS = function() {
+    // Sniff on document.body.style
+    var bodyStyle = document.body.style;
+
+    // Sniff prefixes
+    var vendorPrefix = ('WebkitTransform' in bodyStyle) ? 'Webkit' :
+                       ('MozTransform' in bodyStyle) ? 'Moz' :
+                       ('msTransform' in bodyStyle) ? 'ms' :
+                       ('OTransform' in bodyStyle) ? 'O' : '';
+
+    if (vendorPrefix + 'Perspective' in bodyStyle) {
+      // Modern browsers with 3D support, e.g. Webkit, IE10
+      return 'translate3d';
+    } else if (vendorPrefix + 'Transform' in bodyStyle) {
+      // Browsers without 3D support, e.g. IE9
+      return 'translate';
+    } else {
+      // Browsers without translate() support, e.g. IE7-8
+      return 'margin';
+    }
+  };
+
+  /**
+   * Helpers
+   */
+
+  function clamp(n, min, max) {
+    if (n < min) return min;
+    if (n > max) return max;
+    return n;
+  }
+
+  /**
+   * (Internal) converts a percentage (`0..1`) to a bar translateX
+   * percentage (`-100%..0%`).
+   */
+
+  function toBarPerc(n) {
+    return (-1 + n) * 100;
+  }
+
+
+  /**
+   * (Internal) returns the correct CSS for changing the bar's
+   * position given an n percentage, and speed and ease from Settings
+   */
+
+  function barPositionCSS(n, speed, ease) {
+    var barCSS;
+
+    if (Settings.positionUsing === 'translate3d') {
+      barCSS = { transform: 'translate3d('+toBarPerc(n)+'%,0,0)' };
+    } else if (Settings.positionUsing === 'translate') {
+      barCSS = { transform: 'translate('+toBarPerc(n)+'%,0)' };
+    } else {
+      barCSS = { 'margin-left': toBarPerc(n)+'%' };
+    }
+
+    barCSS.transition = 'all '+speed+'ms '+ease;
+
+    return barCSS;
+  }
+
+  /**
+   * (Internal) Queues a function to be executed.
+   */
+
+  var queue = (function() {
+    var pending = [];
+    
+    function next() {
+      var fn = pending.shift();
+      if (fn) {
+        fn(next);
+      }
+    }
+
+    return function(fn) {
+      pending.push(fn);
+      if (pending.length == 1) next();
+    };
+  })();
+
+  /**
+   * (Internal) Applies css properties to an element, similar to the jQuery 
+   * css method.
+   *
+   * While this helper does assist with vendor prefixed property names, it 
+   * does not perform any manipulation of values prior to setting styles.
+   */
+
+  var css = (function() {
+    var cssPrefixes = [ 'Webkit', 'O', 'Moz', 'ms' ],
+        cssProps    = {};
+
+    function camelCase(string) {
+      return string.replace(/^-ms-/, 'ms-').replace(/-([\da-z])/gi, function(match, letter) {
+        return letter.toUpperCase();
+      });
+    }
+
+    function getVendorProp(name) {
+      var style = document.body.style;
+      if (name in style) return name;
+
+      var i = cssPrefixes.length,
+          capName = name.charAt(0).toUpperCase() + name.slice(1),
+          vendorName;
+      while (i--) {
+        vendorName = cssPrefixes[i] + capName;
+        if (vendorName in style) return vendorName;
+      }
+
+      return name;
+    }
+
+    function getStyleProp(name) {
+      name = camelCase(name);
+      return cssProps[name] || (cssProps[name] = getVendorProp(name));
+    }
+
+    function applyCss(element, prop, value) {
+      prop = getStyleProp(prop);
+      element.style[prop] = value;
+    }
+
+    return function(element, properties) {
+      var args = arguments,
+          prop, 
+          value;
+
+      if (args.length == 2) {
+        for (prop in properties) {
+          value = properties[prop];
+          if (value !== undefined && properties.hasOwnProperty(prop)) applyCss(element, prop, value);
+        }
+      } else {
+        applyCss(element, args[1], args[2]);
+      }
+    }
+  })();
+
+  /**
+   * (Internal) Determines if an element or space separated list of class names contains a class name.
+   */
+
+  function hasClass(element, name) {
+    var list = typeof element == 'string' ? element : classList(element);
+    return list.indexOf(' ' + name + ' ') >= 0;
+  }
+
+  /**
+   * (Internal) Adds a class to an element.
+   */
+
+  function addClass(element, name) {
+    var oldList = classList(element),
+        newList = oldList + name;
+
+    if (hasClass(oldList, name)) return; 
+
+    // Trim the opening space.
+    element.className = newList.substring(1);
+  }
+
+  /**
+   * (Internal) Removes a class from an element.
+   */
+
+  function removeClass(element, name) {
+    var oldList = classList(element),
+        newList;
+
+    if (!hasClass(element, name)) return;
+
+    // Replace the class name.
+    newList = oldList.replace(' ' + name + ' ', ' ');
+
+    // Trim the opening and closing spaces.
+    element.className = newList.substring(1, newList.length - 1);
+  }
+
+  /**
+   * (Internal) Gets a space separated list of the class names on the element. 
+   * The list is wrapped with a single space on each end to facilitate finding 
+   * matches within the list.
+   */
+
+  function classList(element) {
+    return (' ' + (element.className || '') + ' ').replace(/\s+/gi, ' ');
+  }
+
+  /**
+   * (Internal) Removes an element from the DOM.
+   */
+
+  function removeElement(element) {
+    element && element.parentNode && element.parentNode.removeChild(element);
+  }
+
+  return NProgress;
+});
+


### PR DESCRIPTION
This PR introduces NProgress and a custom Cypht spinner for improved visual feedback during asynchronous operations. Integrated using Bootstrap 5 styling.
<img width="1917" height="952" alt="CleanShot 2025-08-01 at 03 25 05" src="https://github.com/user-attachments/assets/d018757d-23da-4fcd-a12c-d091d9450c74" />
