### PR TITLE
fix(frontend): fully display the name of the filter in edit field (filter name)

### DIFF
--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -139,6 +139,12 @@ if (!hm_exists('get_mailbox_filters')) {
         foreach ($scripts_sorted as $script_name => $sc) {
             $exp_name = explode('-', $script_name);
             $parsed_name = str_replace('_', ' ', $exp_name[0]);
+
+            if (count($exp_name) > 3) {
+                $name_parts = array_slice($exp_name, 0, count($exp_name) - 2);
+                $parsed_name = str_replace('_', ' ', implode('-', $name_parts));
+            }
+
             $display_name = str_replace('_', ' ', implode('-', array_slice($exp_name, 0, count($exp_name) - 2)));
             $checked = ' checked';
             if (preg_match('/^s(en|dis)abled/', $display_name)) {


### PR DESCRIPTION
For a filter with a name containing dashes, when you click on edit, only the part of the name before the dash loads into the editing area, consequently, we were also editing the name of the filter without realizing it.

Example for the filter:
<img width="1059" height="131" alt="filter-01" src="https://github.com/user-attachments/assets/b4d033de-b286-4947-998a-75f801c02a2b" />

Before:
<img width="1025" height="389" alt="before-edit-filter" src="https://github.com/user-attachments/assets/2577c6f9-f557-4973-ae06-d9b21dbdc286" />


After:
<img width="1025" height="395" alt="after-edit-filter" src="https://github.com/user-attachments/assets/ee0732fe-e99b-4d15-b2f3-ce2e06b2fd4c" />

