### PR TITLE
fix(frontend): information about the event no longer appears in tiki-webmail

### DIFF
--- a/modules/imap/output_modules.php
+++ b/modules/imap/output_modules.php
@@ -352,6 +352,7 @@ class Hm_Output_filter_message_headers extends Hm_Output_Module {
             }
 
             // Action links section
+            $txt .= '<div class="event_calendar_section"></div>';
             $txt .= '<div class="row g-0 py-3">';
             $txt .= '<div class="col-12 msg_actions">';
             $txt .= '<div class="d-flex flex-wrap gap-2 mb-3">';


### PR DESCRIPTION
Before:
<img width="1002" height="533" alt="before" src="https://github.com/user-attachments/assets/d23a8b9b-b18a-4aa6-bb3d-68d936d1e91d" />

After:
<img width="543" height="267" alt="after" src="https://github.com/user-attachments/assets/d5e3f7cc-d6ab-42ec-ac75-1aa387d0e625" />

