### PR TITLE
fix(backend): Fix dkim body hash failure

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -268,9 +268,10 @@ class Hm_Handler_smtp_save_draft extends Hm_Handler_Module {
             delete_uploaded_files($this->session, $draft_id);
             return;
         }
-        
+
+        $uploaded_files = !$uploaded_files ? []: explode(',', $uploaded_files);
+
         if ($this->module_is_supported('imap')) {
-            $uploaded_files = explode(',', $uploaded_files);
             $userpath = md5($this->session->get('username', false));
             foreach($uploaded_files as $key => $file) {
                 $uploaded_files[$key] = $this->config->get('attachment_dir').DIRECTORY_SEPARATOR.$userpath.DIRECTORY_SEPARATOR.$file;
@@ -665,9 +666,12 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         );
 
         /* parse attachments */
-        $uploaded_files = explode(',', $this->request->post['send_uploaded_files']);
-        foreach($uploaded_files as $key => $file) {
-            $uploaded_files[$key] = $this->config->get('attachment_dir').'/'.md5($this->session->get('username', false)).'/'.$file;
+        $uploaded_files = [];
+        if (!empty($this->request->post['send_uploaded_files'])) {
+            $uploaded_files = explode(',', $this->request->post['send_uploaded_files']);
+            foreach($uploaded_files as $key => $file) {
+                $uploaded_files[$key] = $this->config->get('attachment_dir').'/'.md5($this->session->get('username', false)).'/'.$file;
+            }
         }
 
         $uploaded_files = get_uploaded_files_from_array(


### PR DESCRIPTION
This PR fixes a DKIM body hash failure caused by Cypht treating plain text as an attachment and adding an incomplete boundary (opening without closing).  

**Code reference:**  
`modules/smtp/hm-mime-message.php (Hm_MIME_Msg::prep_message_body)`

This issue has already been handled since Cypht 2.x

**Related Commits:**  
- https://github.com/cypht-org/cypht/commit/e3c5d583ce0ed322b216756d55cf518a6abb14d9
- https://github.com/cypht-org/cypht/commit/7bd295f020f1ebbefa7056367bb237e07863f77a

**Related issue:**  https://github.com/cypht-org/cypht/issues/796

