### PR TITLE
fix(docker): fix MariaDB healthcheck auth warnings and remove obsolete version attribute

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,6 +82,7 @@ COPY index.php index.php
 # Entrypoint
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY .env.example .env
 
 # Healthcheck
 HEALTHCHECK CMD curl --fail http://localhost || exit 1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,5 @@
-version: '3.8'
+# this is a demo of using the production cypht image
+
 services:
   db:
     image: mariadb:10
@@ -12,7 +13,7 @@ services:
       - MYSQL_USER=cypht
       - MYSQL_PASSWORD=cypht_password
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ucypht", "-pcypht_password"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This PR addresses two warnings in the Docker Compose setup:

- Fixed MariaDB healthcheck authentication warnings - The healthcheck was attempting anonymous root access, causing repeated "[Warning] Access denied for user 'root'@'localhost' (using password: NO)" warnings in logs

- Removed obsolete version attribute - Eliminated the warning about the deprecated version attribute in docker-compose.yml

- Fix the error we are having when trying to login `.env file not found at: "/usr/local/share/cypht/.env"` (Was removed here https://github.com/cypht-org/cypht/pull/1575)