### PR TITLE
fix(frontend/backend): avoid recursive, exhausting calls to get_folder_list_by_level; limit children count computation to folders with existing kids, and only when needed

### DIFF
--- a/modules/core/hm-mailbox.php
+++ b/modules/core/hm-mailbox.php
@@ -240,12 +240,12 @@ class Hm_Mailbox {
         }
     }
 
-    public function get_subfolders($folder, $only_subscribed = false, $with_input = false) {
+    public function get_subfolders($folder, $only_subscribed = false, $with_input = false, $count_children = false) {
         if (! $this->authed()) {
             return;
         }
         if ($this->is_imap()) {
-            return $this->connection->get_folder_list_by_level($folder, $only_subscribed, $with_input);
+            return $this->connection->get_folder_list_by_level($folder, $only_subscribed, $with_input, $count_children);
         } else {
             return $this->connection->get_folders($folder, $only_subscribed, $this->user_config->get('unsubscribed_folders')[$this->server_id] ?? [], $with_input);
         }

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -664,7 +664,11 @@ class Hm_Handler_imap_folder_expand extends Hm_Handler_Module {
                 if ($with_subscription) {
                     $only_subscribed = false;
                 }
-                $msgs = $mailbox->get_subfolders(hex2bin($folder), $only_subscribed, $with_subscription);
+                $count_children = false;
+                if (isset($this->request->post['count_children'])){
+                    $count_children = $this->request->post['count_children'];
+                }
+                $msgs = $mailbox->get_subfolders(hex2bin($folder), $only_subscribed, $with_subscription, $count_children);
                 if (isset($msgs[$folder])) {
                     unset($msgs[$folder]);
                 }

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -2548,7 +2548,7 @@ if (!class_exists('Hm_IMAP')) {
          * @param string $level mailbox name or empty string for the top level
          * @return array list of matching folders
          */
-        public function get_folder_list_by_level($level='', $only_subscribed=false, $with_input = false, $is_delete_action = false) {
+        public function get_folder_list_by_level($level='', $only_subscribed=false, $with_input = false, $count_children = false) {
             $result = array();
             $folders = array();
             if ($this->server_support_children_capability()) {
@@ -2571,8 +2571,8 @@ if (!class_exists('Hm_IMAP')) {
                 if ($with_input) {
                     $result[$name]['special'] = $folder['special'];
                 }
-                if ($folder['can_have_kids'] && !$is_delete_action) {
-                    $result[$name]['number_of_children'] = count($this->get_folder_list_by_level($folder['name'], false, false, $is_delete_action));
+                if ($folder['has_kids'] && $count_children) {
+                    $result[$name]['number_of_children'] = count($this->get_folder_list_by_level($folder['name'], false, false));
                 }
             }
             if ($only_subscribed || $with_input) {

--- a/modules/imap/setup.php
+++ b/modules/imap/setup.php
@@ -429,5 +429,6 @@ return array(
         'filter_type' => FILTER_UNSAFE_RAW,
         'list_page' => FILTER_UNSAFE_RAW,
         'sort' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'count_children' => FILTER_VALIDATE_BOOL,
     )
 );

--- a/modules/imap_folders/site.js
+++ b/modules/imap_folders/site.js
@@ -51,7 +51,8 @@ var expand_folders_page_list = function(path, container, link_class, target, id_
                 [{'name': 'hm_ajax_hook', 'value': 'ajax_imap_folder_expand'},
                 {'name': 'imap_server_id', 'value': detail.server_id},
                 {'name': 'folder', 'value': detail.folder},
-                {'name': 'subscription_state', 'value': lsub}],
+                {'name': 'subscription_state', 'value': lsub},
+                {'name': 'count_children', 'value': id_dest === 'delete_source'}],
                 function(res) {
                     if (res.imap_expanded_folder_path) {
                         var folder_location = $('.'+container);


### PR DESCRIPTION
This addresses an issue reported via email by @ulfgebhardt, in which he wrote:
> - I am greeted with an `Server Error` Message when I try to login, sometimes the Everything Page is not even reachable.
> - Every few call I get `Server Error` displayed on the Top-Right.

The problem was mainly caused by folder list requests taking too long to complete, which in most cases resulted in timeout errors. In the less likely case of success, subsequent requests would still fail with timeouts.