### PR TITLE
fix(frontend): redirect to the login screen when the session has expired or has been invalidated

### DIFF
--- a/modules/core/js_modules/utils/logout.js
+++ b/modules/core/js_modules/utils/logout.js
@@ -1,0 +1,3 @@
+function logout() {
+    window.location.href = window.location.href;
+}

--- a/modules/core/navigation/navigation.js
+++ b/modules/core/navigation/navigation.js
@@ -102,6 +102,16 @@ async function navigate(url, loaderMessage) {
         if (!html || typeof html !== 'string') {
             throw new Error("Failed navigating to page, empty or invalid response body.");
         }
+
+        // load custom javascript
+        const scripts = extractCustomScripts($(html));
+        loadCustomScripts(scripts);
+
+        if (!hm_is_logged()) {
+            logout();
+            return;
+        }
+
         const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
         if (!titleMatch) {
             throw new Error("No <title> element found in response HTML");
@@ -127,10 +137,6 @@ async function navigate(url, loaderMessage) {
             cyphtMain = innerMain.prop('outerHTML');
         }
         document.title = title.replace(/<[^>]*>/g, '');
-        
-        // load custom javascript
-        const scripts = extractCustomScripts($(html));
-        loadCustomScripts(scripts);
 
         window.location.next = url;
 

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -277,8 +277,8 @@ var Hm_Ajax_Request = function() { return {
         return false;
     },
 
-    fail: function(xhr, not_callable, logout) {
-        if (logout) {
+    fail: function(xhr, not_callable, shouldLogout) {
+        if (shouldLogout) {
             logout();
             return;
         }

--- a/modules/core/site.js
+++ b/modules/core/site.js
@@ -245,8 +245,8 @@ var Hm_Ajax_Request = function() { return {
             if (hm_encrypt_ajax_requests()) {
                 res = Hm_Utils.json_decode(Hm_Crypt.decrypt(res.payload));
             }
-            if ((res.state && res.state == 'not callable') || !res.router_login_state) {
-                this.fail(xhr, true);
+            if ((res.status && res.status == 'not callable') || !res.router_login_state) {
+                this.fail(xhr, true, !res.router_login_state);
                 return;
             }
             if (Hm_Ajax.err_condition) {
@@ -277,7 +277,11 @@ var Hm_Ajax_Request = function() { return {
         return false;
     },
 
-    fail: function(xhr, not_callable) {
+    fail: function(xhr, not_callable, logout) {
+        if (logout) {
+            logout();
+            return;
+        }
         if (not_callable === true || (xhr.status && xhr.status == 500)) {
             Hm_Notices.show('Server Error', 'danger');
         }


### PR DESCRIPTION
This addresses an issue reported via email by @ulfgebhardt, in which he wrote:
> One thing I noticed: I switch User Agent every 10 Minutes, which seems to kick me off the platform (invalidate auth). I know that this is a feature of Cypht. But it does not send me to the login screen, just confronts me with a lot of Server errors. This could be a real bug, but needs further investigation whether my guess is correct.