### PR TITLE
fix(frontend): resolve Cash.js SyntaxError by using .first() method

### DIFF
--- a/modules/core/js_modules/actions/pagination.js
+++ b/modules/core/js_modules/actions/pagination.js
@@ -1,5 +1,5 @@
 function refreshNextButton(current) {
-    const totalPages = $(".pagination .max:first").text();
+    const totalPages = $(".pagination .max").first().text();
     if (parseInt(current) >= parseInt(totalPages)) {
         $(".pagination .next").prop('disabled', true);
     } else {
@@ -16,7 +16,7 @@ function refreshPreviousButton(current) {
 }
 
 async function nextPage() {
-    const currentPage = $(".pagination .current:first").text();
+    const currentPage = $(".pagination .current").first().text();
 
     const nextPage = parseInt(currentPage) + 1;
 


### PR DESCRIPTION
## Description  
This PR fixes an error caused by the use of the unsupported `:first` selector in Cash.js. Unlike jQuery, Cash.js does not support positional pseudo-selectors such as `:first`, `:last`, etc. Using them throws a `SyntaxError: Failed to execute 'querySelectorAll'`.  

The code has been updated to use the `.first()` method instead of `:first`, which is the correct and supported way to select the first element in Cash.js.  

## Changes  
- Replaced `$(".pagination .max:first")` with `$(".pagination .max").first()` in `refreshNextButton()`.  
- Prevents runtime errors when initializing pagination.  

<img width="1207" height="193" alt="Screenshot 2025-09-06 at 22 33 58" src="https://github.com/user-attachments/assets/c263e454-5b97-427d-be69-82126959910b" />

