### PR TITLE
fix(other): remove mistaken lock column from hm_user_session schema

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -74,7 +74,10 @@ return [
     |  Postgresql:
     |   CREATE TABLE hm_user_session (hm_id varchar(250) primary key not null, data text, hm_version INTEGER DEFAULT 1, date timestamp);
     |
-    |  MySQL or SQLite:
+    |  MySQL:
+    |   CREATE TABLE hm_user_session (hm_id varchar(180), data longblob, hm_version INTEGER DEFAULT 1, date timestamp, primary key (hm_id));
+    |
+    |  SQLite:
     |   CREATE TABLE hm_user_session (hm_id varchar(180), data longblob, hm_version INTEGER DEFAULT 1, lock INTEGER DEFAULT 0, date timestamp, primary key (hm_id));
     |
     |


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

<!--
Validate your PR title - a quick Guide

A valid PR title contains a type (https://github.com/commitizen/conventional-commit-types/blob/master/index.json), a scope (https://github.com/cypht-org/cypht/blob/master/.github/workflows/test.lint.pr.yml#L31) and a title starting with a lower case letter.

Here are some valid examples:
- fix(frontend): my fix
- feat(backend): my feature
- docs(docker): my docs
- refactor(frontend/backend) : my refactor
- test(unit): my test
-->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #1658
- Remove the mistakenly added 'lock INTEGER DEFAULT 0' column from the MySQL/SQLite CREATE TABLE statement for hm_user_session table in the database configuration comments.
