### PR TITLE
fix(frontend): tooltips appears behind content

### DIFF
--- a/modules/core/site.css
+++ b/modules/core/site.css
@@ -1261,7 +1261,6 @@ div.unseen,
 }
 [data-title] {
   position: relative;
-  z-index: 10 !important;
 }
 
 #list_controls_menu {


### PR DESCRIPTION
Sometimes tooltips would appear hidden behind the content