### PR TITLE
refactor(backend): revamp the site module for a better customization and extension of internal features and behaviours

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,10 @@ DB_USER=cypht_test
 DB_PASS=cypht_test
 DB_SOCKET=/var/lib/mysqld/mysqld.sock
 
-# Possible values 'DB', 'REDIS', 'MEM', and 'CUSTOM'. If set to 'CUSTOM', the 'SITE_MODULE_PATH' must be set and have the Hm_Custom_Session properly implemented. PHP session is the default if not set.
+# Possible values 'DB', 'REDIS', 'MEM', and 'custom'. If set to 'custom', the 'SITE_MODULE_PATH' must be set and have the Hm_Custom_Session properly implemented. PHP session is the default if not set.
 SESSION_TYPE=PHP
+
+# Possible values are `DB`, `LDAP`, `IMAP`, 'dynamic', and `custom`. If set to `custom`, the `SITE_MODULE_PATH` must be set and have the `Hm_Custom_Auth` properly implemented.
 AUTH_TYPE=DB
 
 IMAP_AUTH_NAME=localhost

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ DB_USER=cypht_test
 DB_PASS=cypht_test
 DB_SOCKET=/var/lib/mysqld/mysqld.sock
 
+# Possible values 'DB', 'REDIS', 'MEM', and 'CUSTOM'. If set to 'CUSTOM', the 'SITE_MODULE_PATH' must be set and have the Hm_Custom_Session properly implemented. PHP session is the default if not set.
 SESSION_TYPE=PHP
 AUTH_TYPE=DB
 

--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,8 @@ JS_COMPRESS=false
 CSS_COMPRESS=false
 
 ALLOW_SESSION_CACHE=false
-CACHE_CLASS=
+# If enabled, the 'SITE_MODULE_PATH' must be set and have the Hm_Custom_Cache properly implemented.
+ENABLE_CUSTOM_CACHE=false
 
 ENABLE_REDIS=true
 REDIS_SERVER='127.0.0.1'

--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,13 @@ DEFAULT_SMTP_PORT=
 DEFAULT_SMTP_TLS=
 DEFAULT_SMTP_NO_AUTH=
 
+# Possible values are 'file', 'db', and 'custom'. If set to 'custom', the 'SITE_MODULE_PATH' must be set.
 USER_CONFIG_TYPE=file
 USER_SETTINGS_DIR=/var/lib/hm3/users
 ATTACHMENT_DIR=/var/lib/hm3/attachments
+
+# Possible values are 'file' and 'custom'. If set to 'custom', the 'SITE_MODULE_PATH' must be set.
+SITE_CONFIG_TYPE=file
 
 ADMIN_USERS=
 
@@ -87,9 +91,6 @@ DISABLE_EMPTY_SUPERGLOBALS=false
 DISABLE_OPEN_BASE_DIR=false
 DISABLE_INI_SETTINGS=false
 DISABLE_FINGERPRINT=false
-
-AUTH_CLASS=
-SESSION_CLASS=
 
 API_LOGIN_KEY=
 
@@ -238,9 +239,13 @@ WORKER_CUSTOM_IMPORTS=
 GLITCHTIP_DSN=
 GLITCHTIP_TRACES_SAMPLE_RATE=0.01
 
-# Your router may be using the 'page' parameter for other purposes when loading Cypht, so this allows you to specify a different parameter name not conflicting with downstream implementations. If not set, it defaults to 'page'.
-PAGE_PARAM_NAME=page
-
 # To be able to view Microsoft TNEF decoded messages, you need to enable the following setting
 # and ensure that `tnef` and `unrtf` are installed on your system.
 ENABLE_MSTNEF_VIEWER=false
+
+# Your router may be using the 'page' parameter for other purposes when loading Cypht, so this allows you to specify a different parameter name not conflicting with downstream implementations. If not set, it defaults to 'page'.
+PAGE_PARAM_NAME=page
+
+# Specify where the module for customized behaviour is located on the web server.
+# See the built-in example at modules/site
+SITE_MODULE_PATH=

--- a/.env.example
+++ b/.env.example
@@ -253,3 +253,6 @@ PAGE_PARAM_NAME=page
 # Specify where the module for customized behaviour is located on the web server.
 # See the built-in example at modules/site
 SITE_MODULE_PATH=
+
+# Specify how the dispatch response should be handled. 'render' will render the response immediately, while 'store' will store the response to be retrieved later via the '$output' property of the '$dispatcher' object. This is useful for users who want to handle the response themselves. i.e. When using Cypht as a library.
+DISPATCH_RESPONSE_MODE=render

--- a/.env.example
+++ b/.env.example
@@ -256,3 +256,5 @@ SITE_MODULE_PATH=
 
 # Specify how the dispatch response should be handled. 'render' will render the response immediately, while 'store' will store the response to be retrieved later via the '$output' property of the '$dispatcher' object. This is useful for users who want to handle the response themselves. i.e. When using Cypht as a library.
 DISPATCH_RESPONSE_MODE=render
+
+WEB_ROOT=

--- a/.env.example
+++ b/.env.example
@@ -258,3 +258,6 @@ SITE_MODULE_PATH=
 DISPATCH_RESPONSE_MODE=render
 
 WEB_ROOT=
+
+# If enabled, the 'SITE_MODULE_PATH' must be set and have the Hm_Custom_Sieve_Client_Factory properly implemented.
+ENABLE_CUSTOM_SIEVE_FACTORY=false

--- a/config/app.php
+++ b/config/app.php
@@ -1408,4 +1408,6 @@ return [
     'site_module_path' => env('SITE_MODULE_PATH', ''),
 
     'dispatch_response_mode' => env('DISPATCH_RESPONSE_MODE', 'render'),
+
+    'web_root' => env('WEB_ROOT', ''),
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -441,12 +441,11 @@ return [
     |
     |
     | 'allow_session_cache' => env('ALLOW_SESSION_CACHE', false),
-    | 'cache_class' => env('CACHE_CLASS')
     */
 
     'allow_session_cache' => env('ALLOW_SESSION_CACHE', false),
 
-    'cache_class' => env('CACHE_CLASS'),
+    'enable_custom_cache' => env('ENABLE_CUSTOM_CACHE', false),
     /*
     | -------------
     | Redis Support

--- a/config/app.php
+++ b/config/app.php
@@ -1410,4 +1410,6 @@ return [
     'dispatch_response_mode' => env('DISPATCH_RESPONSE_MODE', 'render'),
 
     'web_root' => env('WEB_ROOT', ''),
+
+    'enable_custom_sieve_factory' => env('ENABLE_CUSTOM_SIEVE_FACTORY', false)
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -1406,4 +1406,6 @@ return [
     'page_param_name' => env('PAGE_PARAM_NAME', 'page'),
   
     'site_module_path' => env('SITE_MODULE_PATH', ''),
+
+    'dispatch_response_mode' => env('DISPATCH_RESPONSE_MODE', 'render'),
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -621,15 +621,6 @@ return [
     'disable_fingerprint' => env('DISABLE_FINGERPRINT', false),
 
     /*
-    | You can create your own custom authentication and session classes using the
-    | site module set, however you might want those classes located somewhere else
-    | outside of the Cypht code base. By setting session_type and auth_type to custom,
-    | you can control what class is used with the following settings
-    */
-    'auth_class' => env('AUTH_CLASS'),
-    'session_class' => env('SESSION_CLASS'),
-
-    /*
     | -----------------------------------------------------------------------------
     | Modules
     | -----------------------------------------------------------------------------
@@ -1411,7 +1402,9 @@ return [
 
     'js_exclude_deps' => env('JS_EXCLUDE_DEPS', ''),
 
-    'page_param_name' => env('PAGE_PARAM_NAME', 'page'),
-
     'enable_mstnef_viewer' => env('ENABLE_MSTNEF_VIEWER', false),
+
+    'page_param_name' => env('PAGE_PARAM_NAME', 'page'),
+  
+    'site_module_path' => env('SITE_MODULE_PATH', ''),
 ];

--- a/index.php
+++ b/index.php
@@ -15,7 +15,6 @@
 define('APP_PATH', dirname(__FILE__).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
 define('CONFIG_PATH', APP_PATH.'config/');
-define('WEB_ROOT', '');
 define('ASSETS_THEMES_ROOT', '');
 define('CACHE_ID', '');
 define('SITE_ID', '');
@@ -70,6 +69,8 @@ if (! isset($config)) {
 date_default_timezone_set($config->get('default_setting_timezone', 'UTC'));
 /* set the default since and per_source values */
 $environment->define_default_constants($config);
+
+define('WEB_ROOT', $config->get('web_root', ''));
 
 /* setup ini settings */
 if (!$config->get('disable_ini_settings')) {

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * CACHE_ID   unique string to bust js/css browser caching for a new build
  * SITE_ID    random site id used for page keys
  */
-define('APP_PATH', '');
+define('APP_PATH', dirname(__FILE__).'/');
 define('VENDOR_PATH', APP_PATH.'vendor/');
 define('CONFIG_PATH', APP_PATH.'config/');
 define('WEB_ROOT', '');
@@ -26,7 +26,11 @@ define('ASSETS_PATH', APP_PATH.'assets/');
 /* don't let anything output content until we are ready */
 ob_start();
 
-require VENDOR_PATH.'autoload.php';
+// Only require the autoloader if it exists, usually in cases where Cypht is not being used as a library.
+if (file_exists(VENDOR_PATH.'autoload.php')) {
+    require VENDOR_PATH.'autoload.php';
+}
+
 /* get includes */
 require APP_PATH.'lib/framework.php';
 $environment = Hm_Environment::getInstance();
@@ -78,7 +82,7 @@ if (DEBUG_MODE) {
 }
 
 /* process the request */
-new Hm_Dispatch($config);
+$dispatcher = new Hm_Dispatch($config);
 
 if (empty($config)) {
     $config = new Hm_Site_Config_File();

--- a/index.php
+++ b/index.php
@@ -82,8 +82,15 @@ if (DEBUG_MODE) {
     Hm_Debug::load_page_stats();
 }
 
-/* process the request */
-$dispatcher = new Hm_Dispatch($config);
+$dispatcher;
+$config->setInitCallback(function($config) {
+    // /* process the request */
+    $dispatcher = new Hm_Dispatch($config);
+});
+
+if (! is_a($config, 'Hm_Custom_Site_Config')) {
+    $config->triggerInit();
+} // Let custom site configs trigger their own init when ready
 
 if (empty($config)) {
     $config = new Hm_Site_Config_File();

--- a/index.php
+++ b/index.php
@@ -50,7 +50,17 @@ if (DEBUG_MODE) {
 }
 
 /* get configuration */
-$config = new Hm_Site_Config_File();
+if (env('CONFIG_TYPE') == 'custom') {
+    $site_module = basename(env('SITE_MODULE_PATH', ''));
+    if (is_readable(APP_PATH. "modules/$site_module/lib.php")) {
+        require_once APP_PATH . "modules/$site_module/lib.php";
+        $config = new Hm_Custom_Site_Config();
+    }
+}
+
+if (! isset($config)) {
+    $config = new Hm_Site_Config_File();
+}
 
 /* set default TZ */
 date_default_timezone_set($config->get('default_setting_timezone', 'UTC'));

--- a/index.php
+++ b/index.php
@@ -50,7 +50,7 @@ if (DEBUG_MODE) {
 }
 
 /* get configuration */
-if (env('CONFIG_TYPE') == 'custom') {
+if (env('SITE_CONFIG_TYPE') == 'custom') {
     $site_module = basename(env('SITE_MODULE_PATH', ''));
     if (is_readable(APP_PATH. "modules/$site_module/lib.php")) {
         require_once APP_PATH . "modules/$site_module/lib.php";

--- a/index.php
+++ b/index.php
@@ -82,10 +82,9 @@ if (DEBUG_MODE) {
     Hm_Debug::load_page_stats();
 }
 
-$dispatcher;
 $config->setInitCallback(function($config) {
     // /* process the request */
-    $dispatcher = new Hm_Dispatch($config);
+    return new Hm_Dispatch($config);
 });
 
 if (! is_a($config, 'Hm_Custom_Site_Config')) {

--- a/index.php
+++ b/index.php
@@ -13,7 +13,6 @@
  * SITE_ID    random site id used for page keys
  */
 define('APP_PATH', dirname(__FILE__).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('CONFIG_PATH', APP_PATH.'config/');
 define('ASSETS_THEMES_ROOT', '');
 define('CACHE_ID', '');
@@ -25,13 +24,13 @@ define('ASSETS_PATH', APP_PATH.'assets/');
 /* don't let anything output content until we are ready */
 ob_start();
 
-// Only require the autoloader if it exists, usually in cases where Cypht is not being used as a library.
-if (file_exists(VENDOR_PATH.'autoload.php')) {
-    require VENDOR_PATH.'autoload.php';
-}
-
 /* get includes */
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
+
 $environment = Hm_Environment::getInstance();
 $environment->load();
 
@@ -70,7 +69,7 @@ date_default_timezone_set($config->get('default_setting_timezone', 'UTC'));
 /* set the default since and per_source values */
 $environment->define_default_constants($config);
 
-define('WEB_ROOT', $config->get('web_root', ''));
+define('WEB_ROOT', $config->get('web_root'));
 
 /* setup ini settings */
 if (!$config->get('disable_ini_settings')) {

--- a/index.php
+++ b/index.php
@@ -19,7 +19,6 @@ define('CACHE_ID', '');
 define('SITE_ID', '');
 define('JS_HASH', '');
 define('CSS_HASH', '');
-define('ASSETS_PATH', APP_PATH.'assets/');
 
 /* don't let anything output content until we are ready */
 ob_start();
@@ -70,6 +69,7 @@ date_default_timezone_set($config->get('default_setting_timezone', 'UTC'));
 $environment->define_default_constants($config);
 
 define('WEB_ROOT', $config->get('web_root'));
+define('ASSETS_PATH', WEB_ROOT.'assets/');
 
 /* setup ini settings */
 if (!$config->get('disable_ini_settings')) {

--- a/lib/cache.php
+++ b/lib/cache.php
@@ -417,10 +417,19 @@ class Hm_Cache {
      */
     public function __construct($config, $session) {
         $this->session = $session;
-        if (!$this->check_redis($config) && !$this->check_memcache($config)) {
+        if (!$this->check_custom($config) && !$this->check_redis($config) && !$this->check_memcache($config)) {
             $this->check_session($config);
         }
         Hm_Debug::add(sprintf('CACHE backend using: %s', $this->type), 'info');
+    }
+
+    protected function check_custom($config) {
+        if ($config->get('enable_custom_cache', false)) {
+            $this->type = 'custom';
+            $this->backend = new Hm_Custom_Cache();
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -603,6 +612,10 @@ class Hm_Cache {
         return $default;
     }
 
+    protected function custom_get($key, $default) {
+        return $this->backend->get($this->key_hash($key), $default);
+    }
+
     /*
      * @param string $key key to make the hash unique
      * @return string
@@ -661,20 +674,6 @@ class Hm_Cache_Setup {
      * @return object
      */
     public function setup_cache() {
-        $cache_class = $this->get_cache_class();
-        Hm_Debug::add(sprintf('Using %s for cache', $cache_class), 'info');
-        return new $cache_class($this->config, $this->session);
-    }
-
-    /**
-     * @return string
-     */
-    private function get_cache_class() {
-        $custom_cache_class = $this->config->get('cache_class', 'Custom_Cache');
-        $cache_class = 'Hm_Cache';
-        if (class_exists($custom_cache_class)) {
-            $cache_class = $custom_cache_class;
-        }
-        return $cache_class;
+        return new Hm_Cache($this->config, $this->session);
     }
 }

--- a/lib/config.php
+++ b/lib/config.php
@@ -519,8 +519,8 @@ class Hm_Site_Config_File extends Hm_Config {
  */
 function load_user_config_object($config) {
     $type = $config->get('user_config_type', 'file');
-    switch ($type) {
-        case 'DB':
+    switch (strtolower($type)) {
+        case 'db':
             $user_config = new Hm_User_Config_DB($config);
             Hm_Debug::add("Using DB user configuration", 'info');
             break;

--- a/lib/config.php
+++ b/lib/config.php
@@ -484,7 +484,7 @@ class Hm_Site_Config_File extends Hm_Config {
      */
     public function triggerInit() {
         if (is_callable($this->initCallback)) {
-            call_user_func($this->initCallback, $this);
+            return call_user_func($this->initCallback, $this);
         }
     }
 

--- a/lib/config.php
+++ b/lib/config.php
@@ -470,11 +470,26 @@ class Hm_Site_Config_File extends Hm_Config {
 
     public $user_defaults = [];
 
+    protected $initCallback;
+
     /**
      * @param array $all_configs
      */
     public function __construct($all_configs = []) {
         $this->load(empty($all_configs) ? merge_config_files(APP_PATH.'config') : $all_configs, false);
+    }
+
+    /**
+     * Trigger the init callback if it exists. This is used to allow dynamic configuration of the site before any request handling occurs.
+     */
+    public function triggerInit() {
+        if (is_callable($this->initCallback)) {
+            call_user_func($this->initCallback, $this);
+        }
+    }
+
+    public function setInitCallback($callback) {
+        $this->initCallback = $callback;
     }
 
     /**

--- a/lib/config.php
+++ b/lib/config.php
@@ -519,21 +519,18 @@ class Hm_Site_Config_File extends Hm_Config {
  */
 function load_user_config_object($config) {
     $type = $config->get('user_config_type', 'file');
-    if (mb_strstr($type, ':')) {
-        list($type, $class) = explode(':', $type);
-    }
     switch ($type) {
         case 'DB':
             $user_config = new Hm_User_Config_DB($config);
             Hm_Debug::add("Using DB user configuration", 'info');
             break;
         case 'custom':
-            if (class_exists($class)) {
-                $user_config = new $class($config);
-                Hm_Debug::add("Using custom user configuration: {$class}", 'info');
+            if (class_exists('Hm_Custom_User_Config')) {
+                $user_config = new Hm_Custom_User_Config($config);
+                Hm_Debug::add("Using custom user configuration: Hm_Custom_User_Config", 'info');
                 break;
             } else {
-                Hm_Debug::add("User configuration class does not exist: {$class}");
+                Hm_Debug::add("User configuration class does not exist: Hm_Custom_User_Config");
             }
         default:
             $user_config = new Hm_User_Config_File($config);

--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -284,9 +284,14 @@ class Hm_Dispatch {
         $class = $this->site_config->get('output_class', 'Hm_Output_HTTP');
         $renderer = new $class;
         $content = $formatter->content($this->module_exec->output_response, $this->request->allowed_output);
-        /* TODO: might be a good idea to use a custom render class that can return
-         * the output on demand */
-        $this->output = $renderer->send_response($content, $this->module_exec->output_data);
+        $renderer = new Hm_Output_HTTP($content, $this->module_exec->output_data);
+
+        if ($this->site_config->get('dispatch_response_mode') == 'store') {
+            $this->output = $renderer->get_content();
+            return;
+        }
+
+        return $renderer->send_response();
     }
 
     /**

--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -197,6 +197,8 @@ class Hm_Dispatch {
         if (is_readable(APP_PATH. "modules/$site_module/lib.php")) {
             Hm_Debug::add('Including site module set lib.php', 'info');
             require_once APP_PATH . "modules/$site_module/lib.php";
+
+            $this->site_config->set('modules', array_merge($this->site_config->get('modules', []), [$site_module]));
         }
     }
 

--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -193,12 +193,10 @@ class Hm_Dispatch {
      * @return void
      */
     private function load_site_lib() {
-        if (!is_array($this->site_config->get_modules()) || !in_array('site', $this->site_config->get_modules(), true)) {
-            return;
-        }
-        if (is_readable(APP_PATH.'modules/site/lib.php')) {
+        $site_module = basename($this->site_config->get('site_module_path'));
+        if (is_readable(APP_PATH. "modules/$site_module/lib.php")) {
             Hm_Debug::add('Including site module set lib.php', 'info');
-            require APP_PATH.'modules/site/lib.php';
+            require_once APP_PATH . "modules/$site_module/lib.php";
         }
     }
 

--- a/lib/framework.php
+++ b/lib/framework.php
@@ -250,6 +250,15 @@ if (!class_exists('Hm_Functions')) {
         public static function stream_socket_enable_crypto($socket, $type) {
             return stream_socket_enable_crypto($socket, true, $type);
         }
+
+        public static function define_vendor_path() {
+            if (file_exists(APP_PATH.'vendor/')) {
+                define('VENDOR_PATH', APP_PATH.'vendor/');
+            } else {
+                // When installed via composer, the vendor path is generally two levels up from APP_PATH.
+                define('VENDOR_PATH', APP_PATH . '../../');
+            }
+        }
     }
 }
 

--- a/lib/ini_set.php
+++ b/lib/ini_set.php
@@ -70,6 +70,10 @@ foreach (array('user_settings_dir', 'attachment_dir') as $dir) {
     }
 }
 
+if ($config->get('site_module_path', false)) {
+    $base .= PATH_SEPARATOR . $config->get('site_module_path');
+}
+
 if (!$disabled) {
     ini_set('open_basedir', $base);
 }

--- a/lib/output.php
+++ b/lib/output.php
@@ -46,10 +46,10 @@ class Hm_Output_HTTP extends Hm_Output {
 
     /**
      * Send HTTP headers
-     * @param array $headers headers to send
      * @return void
      */
-    protected function output_headers($headers) {
+    protected function output_headers() {
+        $headers = $this->data['http_headers'] ?? [];
         foreach ($headers as $name => $value) {
             Hm_Functions::header($name.': '.$value);
         }
@@ -57,18 +57,18 @@ class Hm_Output_HTTP extends Hm_Output {
 
     /**
      * Send response content to the browser
-     * @param mixed $content data to send
-     * @param array $headers HTTP headers to set
      * @return void
      */
     protected function output_content() {
-        $this->output_headers($this->data['headers'] ?? []);
+        $this->output_headers();
         ob_end_clean();
 
         echo $this->get_content($this->content);
     }
 
     public function get_content() {
+        $this->output_headers();
+        
         // Append debug panel if DEBUG_MODE is enabled and it's an HTML response
         if (DEBUG_MODE && is_string($this->content) && stripos($this->content, '</body>') !== false) {
             $debug_panel = $this->get_debug_panel_html();

--- a/lib/output.php
+++ b/lib/output.php
@@ -12,13 +12,21 @@
  */
 abstract class Hm_Output {
 
+    protected $content;
+    protected $data;
+
+    public function __construct($content = null, $data = []) {
+        $this->content = $content;
+        $this->data = $data;
+    }
+
     /**
      * Extended classes must override this method to output content
      * @param mixed $content data to output
      * @param array $headers headers to send
      * @return void
      */
-    abstract protected function output_content($content, $headers);
+    abstract protected function output_content();
 
     /**
      * Wrapper around extended class output_content() calls
@@ -26,8 +34,8 @@ abstract class Hm_Output {
      * @param array $input raw module data
      * @return void
      */
-    public function send_response($response, $input = []) {
-        $this->output_content($response, $input['http_headers'] ?? []);
+    public function send_response() {
+        $this->output_content();
     }
 }
 
@@ -53,17 +61,20 @@ class Hm_Output_HTTP extends Hm_Output {
      * @param array $headers HTTP headers to set
      * @return void
      */
-    protected function output_content($content, $headers = []) {
-        $this->output_headers($headers);
+    protected function output_content() {
+        $this->output_headers($this->data['headers'] ?? []);
         ob_end_clean();
 
-        // Append debug panel if DEBUG_MODE is enabled and it's an HTML response
-        if (DEBUG_MODE && is_string($content) && stripos($content, '</body>') !== false) {
-            $debug_panel = $this->get_debug_panel_html();
-            $content = str_replace('</body>', $debug_panel.'</body>', $content);
-        }
+        echo $this->get_content($this->content);
+    }
 
-        echo $content;
+    public function get_content() {
+        // Append debug panel if DEBUG_MODE is enabled and it's an HTML response
+        if (DEBUG_MODE && is_string($this->content) && stripos($this->content, '</body>') !== false) {
+            $debug_panel = $this->get_debug_panel_html();
+            return str_replace('</body>', $debug_panel.'</body>', $this->content);
+        }
+        return $this->content;
     }
 
     /**

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -417,7 +417,7 @@ class Hm_Session_Setup {
      * @return string
      */
     private function get_session_class() {
-        switch ($this->session_type) {
+        switch (strtoupper($this->session_type)) {
             case 'DB':
                 $session_class = 'Hm_DB_Session';
                 break;
@@ -478,7 +478,7 @@ class Hm_Session_Setup {
      * @return string|false
      */
     private function custom_auth() {
-        if ($this->auth_type == 'custom') {
+        if (strtolower($this->auth_type) == 'custom') {
             return 'Hm_Custom_Auth';
         }
         return false;

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -428,7 +428,7 @@ class Hm_Session_Setup {
                 $session_class = 'Hm_Redis_Session';
                 break;
             case 'custom':
-                $session_class = $this->config->get('session_class', 'Custom_Session');
+                $session_class = 'Hm_Custom_Session';
                 break;
         }
         return (isset($session_class) && class_exists($session_class))
@@ -478,9 +478,8 @@ class Hm_Session_Setup {
      * @return string|false
      */
     private function custom_auth() {
-        $custom_auth_class = $this->config->get('auth_class', 'Custom_Auth');
-        if ($this->auth_type == 'custom' && Hm_Functions::class_exists($custom_auth_class)) {
-            return $custom_auth_class;
+        if ($this->auth_type == 'custom') {
+            return 'Hm_Custom_Auth';
         }
         return false;
     }

--- a/lib/session_base.php
+++ b/lib/session_base.php
@@ -427,7 +427,7 @@ class Hm_Session_Setup {
             case 'REDIS':
                 $session_class = 'Hm_Redis_Session';
                 break;
-            case 'custom':
+            case 'CUSTOM':
                 $session_class = 'Hm_Custom_Session';
                 break;
         }

--- a/modules/api_login/api.php
+++ b/modules/api_login/api.php
@@ -7,12 +7,14 @@
 
 /* Constants */
 define('APP_PATH', dirname(dirname(dirname(__FILE__))).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* Init the framework */
-require_once VENDOR_PATH.'autoload.php';
 require_once APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require_once VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/modules/sievefilters/functions.php
+++ b/modules/sievefilters/functions.php
@@ -290,8 +290,8 @@ if (!hm_exists('generate_filter_name')) {
 if (!hm_exists('get_sieve_client_factory')) {
     function get_sieve_client_factory($site_config)
     {
-        if (!is_null($site_config) && isset($site_config) && $factory_class = $site_config->get('sieve_client_factory')) {
-            return new $factory_class;
+        if (!is_null($site_config) && isset($site_config) && $site_config->get('enable_custom_sieve_factory')) {
+            return new Hm_Custom_Sieve_Client_Factory;
         } else {
             return new Hm_Sieve_Client_Factory;
         }

--- a/modules/sievefilters/modules.php
+++ b/modules/sievefilters/modules.php
@@ -1629,7 +1629,7 @@ class Hm_Handler_load_account_sieve_filters extends Hm_Handler_Module
         $accounts = $this->get('imap_accounts');
         if (isset($accounts[$form['imap_server_id']])) {
             $account = $accounts[$form['imap_server_id']];
-            $client = initialize_sieve_client_factory($this->config, null, $account);
+            $client = initialize_sieve_client_factory($this->config, $this->user_config, $account);
             $account['sieve_extensions'] = [];
 
             if ($client) {

--- a/modules/site/README.md
+++ b/modules/site/README.md
@@ -1,4 +1,5 @@
 ## Site
 
-This module set provides sites a way to add features to Cypht, or to override
-existing behavior without modifying any Cypht code. 
+This is an exemplary module set that provides a way to add features to Cypht or override existing behavior without modifying any Cypht code.
+
+If you decide to use this module, you must specify the location of your implemented module via the `SITE_MODULE_PATH` environment variable. The path should be outside the Cypht source code.

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -10,7 +10,7 @@ require_once 'lib/config.php';
 require_once 'lib/environment.php';
 
 /**
- * Custom session class. To use this, you must set the SESSION_TYPE environment variable to 'CUSTOM'.
+ * Custom session class. To use this, you must set the SESSION_TYPE environment variable to 'custom'.
  */
 class Hm_Custom_Session extends Hm_Session {
 

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -125,6 +125,15 @@ class Hm_Custom_User_Config extends Hm_Config {
 }
 
 /**
+ * =======
+ * 
+ * Just skip this part if sieve filters module is not enabled
+ * 
+ * =======
+ */
+
+include_once APP_PATH . 'modules/sievefilters/hm-sieve.php';
+/**
  * Custom sieve client factory class. To use this, you must set the ENABLE_CUSTOM_SIEVE_FACTORY environment variable to true.
  */
 class Hm_Custom_Sieve_Client_Factory extends Hm_Sieve_Client_Factory {

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -123,3 +123,13 @@ class Hm_Custom_User_Config extends Hm_Config {
         throw new \Exception('Not implemented');
     }
 }
+
+/**
+ * Custom sieve client factory class. To use this, you must set the ENABLE_CUSTOM_SIEVE_FACTORY environment variable to true.
+ */
+class Hm_Custom_Sieve_Client_Factory extends Hm_Sieve_Client_Factory {
+    public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
+    {
+        return parent::init($user_config, $imap_account, $is_nux_supported);
+    }
+}

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -63,21 +63,24 @@ class Hm_Custom_Auth extends Hm_Auth {
     }
 }
 
-class Hm_Custom_Cache extends Hm_Cache {
+/**
+ * Custom cache class. To use this, you must set the ENABLE_CUSTOM_CACHE environment variable to true.
+ */
+class Hm_Custom_Cache extends Hm_Noop_Cache {
 
-    public function get($key, $default = false, $session = false)
+    public function get($key, $default = false)
     {
-        return parent::get($key, $default, $session);
+        return $default;
     }
 
-    public function set($key, $val, $lifetime = 600, $session = false)
+    public function set($key, $val, $lifetime, $crypt_key)
     {
-        return parent::set($key, $val, $lifetime, $session);
+        return parent::set($key, $val, $lifetime, $crypt_key);
     }
 
-    public function del($key, $session = false)
+    public function del($key)
     {
-        return parent::del($key, $session);
+        return parent::del($key);
     }
 }
 
@@ -101,6 +104,9 @@ class Hm_Custom_Site_Config extends Hm_Config {
     }
 }
 
+/**
+ * Custom user configuration class. To use this, you must set the USER_CONFIG_TYPE environment variable to 'custom'.
+ */
 class Hm_Custom_User_Config extends Hm_Config {
     private $site_config;
 

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -9,7 +9,10 @@ require_once 'lib/cache.php';
 require_once 'lib/config.php';
 require_once 'lib/environment.php';
 
-class Hm_Custom_Session extends Hm_PHP_Session {
+/**
+ * Custom session class. To use this, you must set the SESSION_TYPE environment variable to 'CUSTOM'.
+ */
+class Hm_Custom_Session extends Hm_Session {
 
     public function check($request, $user = false, $pass = false, $fingerprint = true)
     {

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -80,7 +80,7 @@ class Hm_Custom_Cache extends Hm_Noop_Cache {
 /**
  * Custom site configuration class. To use this, you must set the SITE_CONFIG_TYPE environment variable to 'custom'.
  */
-class Hm_Custom_Site_Config extends Hm_Config {
+class Hm_Custom_Site_Config extends Hm_Site_Config_File {
     public function get($name, $default = false)
     {
         return parent::get($name, $default);
@@ -91,9 +91,9 @@ class Hm_Custom_Site_Config extends Hm_Config {
         return parent::set($name, $value);
     }
 
-    public function load($source, $key)
+    public function load($all_configs, $key)
     {
-        throw new \Exception('Not implemented');
+        return parent::load($all_configs, $key);
     }
 }
 

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -1,14 +1,4 @@
 <?php
-
-/** 
- * Overwrite these paths to the Cypht lib location in your setup.
- */
-require_once 'lib/session_php.php';
-require_once 'lib/auth.php';
-require_once 'lib/cache.php';
-require_once 'lib/config.php';
-require_once 'lib/environment.php';
-
 /**
  * Custom session class. To use this, you must set the SESSION_TYPE environment variable to 'custom'.
  */

--- a/modules/site/lib.php
+++ b/modules/site/lib.php
@@ -1,132 +1,126 @@
 <?php
 
-/**
- * To use these overrides, you must first enable the "site" module in your
- * config/app.php file to activate the module.
+/** 
+ * Overwrite these paths to the Cypht lib location in your setup.
  */
+require_once 'lib/session_php.php';
+require_once 'lib/auth.php';
+require_once 'lib/cache.php';
+require_once 'lib/config.php';
+require_once 'lib/environment.php';
 
-/**
- * Override the session class. These are the methods that must be overriden to
- * create a new session backend. The "session_type" value in your config/app.php must
- * be set to "custom" to activate this class. There are several other
- * properties and methods that can be modified to create custom sessions:
- *
- *  https://cypht.org/docs/code_docs/class-Hm_Session.html
- *
- * This example extends the standard PHP session class. You can also extend the
- * DB or Memcached classes, or the base session class. In this example we just
- * defer to the PHP session class methods.
- *
- * @package modules
- * @subpackage site
- */
-class Custom_Session extends Hm_PHP_Session {
+class Hm_Custom_Session extends Hm_PHP_Session {
 
-    /**
-     * check for an active session or an attempt to start one
-     * @param object $request request object
-     * @return bool
-     */
-    public function check($request, $user=false, $pass=false, $fingerprint=true) {
+    public function check($request, $user = false, $pass = false, $fingerprint = true)
+    {
         return parent::check($request, $user, $pass, $fingerprint);
     }
 
-    /**
-     * Start the session. This could be an existing session or a new login
-     * @param object $request request details
-     * @return void
-     */
-    public function start($request, $existing_session=false) {
-        return parent::start($request, $existing_session);
+    public function start($request)
+    {
+        return parent::start($request);
     }
 
-    /**
-     * Call the configured authentication method to check user credentials
-     * @param string $user username
-     * @param string $pass password
-     * @return bool true if the authentication was successful
-     */
-    public function auth($user, $pass) {
+    public function auth($user, $pass)
+    {
         return parent::auth($user, $pass);
     }
 
-    /**
-     * Return a session value, or a user settings value stored in the session
-     * @param string $name session value name to return
-     * @param mixed $default value to return if $name is not found
-     * @return mixed the value if found, otherwise $defaultHm_Auth
-     */
-    public function get($name, $default=false, $user=false) {
+    public function get($name, $default = false, $user = false)
+    {
         return parent::get($name, $default, $user);
     }
 
-    /**
-     * Save a value in the session
-     * @param string $name the name to save
-     * @param string $value the value to save
-     * @return void
-     */
-    public function set($name, $value, $user=false) {
-        return parent::set($name, $value);
+    public function set($name, $value, $user = false)
+    {
+        return parent::set($name, $value, $user);
     }
 
-    /**
-     * Delete a value from the session
-     * @param string $name name of value to deleteHm_Auth
-     * @return void
-     */
-    public function del($name) {
+    public function del($name)
+    {
         return parent::del($name);
     }
 
-    /**
-     * End a session after a page request is complete. This only closes the session and
-     * does not destroy it
-     * @return void
-     */
-    public function end() {
+    public function end()
+    {
         return parent::end();
     }
 
-    /**
-     * Destroy a session for good
-     * @param object $request request details
-     * @return void
-     */
-    public function destroy($request) {
+    public function destroy($request)
+    {
         return parent::destroy($request);
     }
-
 }
 
 /**
- * Override the authentication class. This method needs to be overriden to
- * create a custom authentication backend. You must set the "auth_type" setting
- * in your config/app.php file to "custom" to activate this class. More information
- * about the base class for authentication is located here:
- *
- * https://cypht.org/docs/code_docs/class-Hm_Auth.html
- *
- * This example extends the auth DB class, and simply defers the parent class
- * method
- * @package modules
- * @subpackage site
+ * Custom auth class. To use this, you must set the AUTH_TYPE environment variable to 'custom'.
  */
-class Custom_Auth extends Hm_Auth_DB {
+class Hm_Custom_Auth extends Hm_Auth {
 
-    /**
-     * This is the method new auth mechs need to override.
-     * @param string $user username
-     * @param string $pass password
-     * @return bool true if the user is authenticated, false otherwise
-     */
-    public function check_credentials($user, $pass) {
-        return parent::check_credentials($user, $pass);
+    public function check_credentials($user, $pass)
+    {
+        throw new \Exception('Not implemented');
     }
 }
 
-/*
-function format_msg_html($str, $images=false) {
-    return '';
+class Hm_Custom_Cache extends Hm_Cache {
+
+    public function get($key, $default = false, $session = false)
+    {
+        return parent::get($key, $default, $session);
+    }
+
+    public function set($key, $val, $lifetime = 600, $session = false)
+    {
+        return parent::set($key, $val, $lifetime, $session);
+    }
+
+    public function del($key, $session = false)
+    {
+        return parent::del($key, $session);
+    }
 }
-*/
+
+/**
+ * Custom site configuration class. To use this, you must set the SITE_CONFIG_TYPE environment variable to 'custom'.
+ */
+class Hm_Custom_Site_Config extends Hm_Config {
+    public function get($name, $default = false)
+    {
+        return parent::get($name, $default);
+    }
+
+    public function set($name, $value)
+    {
+        return parent::set($name, $value);
+    }
+
+    public function load($source, $key)
+    {
+        throw new \Exception('Not implemented');
+    }
+}
+
+class Hm_Custom_User_Config extends Hm_Config {
+    private $site_config;
+
+    public function __construct($site_config)
+    {
+        $this->site_config = $site_config;
+    }
+
+    public function get($name, $default = false)
+    {
+        return parent::get($name, $default);
+    }
+
+    public function set($name, $value)
+    {
+        return parent::set($name, $value);
+    }
+
+    public function load($source, $key)
+    {
+        throw new \Exception('Not implemented');
+    }
+}

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -96,6 +96,11 @@ function process_site_module(&$settings) {
                 unlink($link_path);
             }
 
+            // ensure it's absolute path
+            if ($site_module_path[0] !== '/') {
+                $site_module_path = realpath(APP_PATH . $site_module_path);
+            }
+
             symlink($site_module_path, $link_path);
 
             if (file_exists($link_path)) {

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -53,6 +53,8 @@ function build_config() {
     if (is_array($settings) && !empty($settings)) {
         $settings['version'] = VERSION;
 
+        process_site_module($settings);
+        
         /* check all PHP dependencies (fatal framework deps + module/settings-specific) */
         check_dependencies($settings);
 
@@ -80,6 +82,27 @@ function build_config() {
     }
     else {
         printf("\nNo settings found in ini file\n");
+    }
+}
+
+function process_site_module(&$settings) {
+    $site_module_path = $settings['site_module_path'];
+    if ($site_module_path) {
+        $site_module_name = basename($site_module_path);
+        if (file_exists($site_module_path)) {
+            $link_path = APP_PATH . 'modules/' . $site_module_name;
+            
+            if (file_exists($link_path)) {
+                unlink($link_path);
+            }
+
+            symlink($site_module_path, $link_path);
+
+            if (file_exists($link_path)) {
+                $settings['modules'][] = $site_module_name;
+                printf("Site module '%s' found at %s and added to module list\n", $site_module_name, $link_path);
+            }
+        }
     }
 }
 
@@ -405,6 +428,7 @@ function get_module_assignments($settings) {
         'allowed_post' => array(), 'allowed_server' => array(), 'allowed_pages' => array());
 
     if (isset($settings['modules'])) {
+        echo "modules found in settings: " . implode(', ', $settings['modules']) . "\n";
         $mods = get_modules($settings);
         foreach ($mods as $mod) {
             printf("scanning module %s ...\n", $mod);

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -10,13 +10,15 @@ if (strtolower(php_sapi_name()) !== 'cli') {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 chdir(APP_PATH);
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -686,7 +686,11 @@ function create_production_site($assets, $settings, $hashes) {
     }
 
     $index_file = file_get_contents('index.php');
-    $index_file = preg_replace("/APP_PATH', ''/", "APP_PATH', '".APP_PATH."'", $index_file);
+    $index_file = preg_replace(
+        "/^define\('APP_PATH',.*\);$/m",
+        "define('APP_PATH', '".APP_PATH."');",
+        $index_file
+    );
     $index_file = preg_replace("/ASSETS_PATH', APP_PATH\.'assets\/'/", "ASSETS_PATH', WEB_ROOT.'assets/'", $index_file);
     $index_file = preg_replace("/CACHE_ID', ''/", "CACHE_ID', '".urlencode(Hm_Crypt::unique_id(32))."'", $index_file);
     $index_file = preg_replace("/SITE_ID', ''/", "SITE_ID', '".urlencode(Hm_Crypt::unique_id(64))."'", $index_file);

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -691,7 +691,6 @@ function create_production_site($assets, $settings, $hashes) {
         "define('APP_PATH', '".APP_PATH."');",
         $index_file
     );
-    $index_file = preg_replace("/ASSETS_PATH', APP_PATH\.'assets\/'/", "ASSETS_PATH', WEB_ROOT.'assets/'", $index_file);
     $index_file = preg_replace("/CACHE_ID', ''/", "CACHE_ID', '".urlencode(Hm_Crypt::unique_id(32))."'", $index_file);
     $index_file = preg_replace("/SITE_ID', ''/", "SITE_ID', '".urlencode(Hm_Crypt::unique_id(64))."'", $index_file);
     $index_file = preg_replace("/JS_HASH', ''/", "JS_HASH', '".$hashes['js']."'", $index_file);

--- a/scripts/create_account.php
+++ b/scripts/create_account.php
@@ -17,12 +17,14 @@ else {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/create_config.php
+++ b/scripts/create_config.php
@@ -6,12 +6,14 @@ if (mb_strtolower(php_sapi_name()) !== 'cli') {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/delete_account.php
+++ b/scripts/delete_account.php
@@ -16,12 +16,14 @@ else {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -3,11 +3,13 @@
 <?php
 
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('MIGRATIONS_PATH', APP_PATH.'database/migrations');
 
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 // Allow specifying environment file via --env argument
 // Usage: php setup_database.php --env=.env.test

--- a/scripts/update_password.php
+++ b/scripts/update_password.php
@@ -38,12 +38,14 @@ if (is_array($argv)) {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/tests/phpunit/lib/output_debug.php
+++ b/tests/phpunit/lib/output_debug.php
@@ -24,10 +24,10 @@ class Hm_Test_Output_Debug extends TestCase {
      */
     public function test_send_response_injects_debug_panel_when_body_tag_present_and_debug_messages_exist() {
         Hm_Debug::add('Debug entry for panel', 'info');
-        $http = new Hm_Output_HTTP();
+        $http = new Hm_Output_HTTP('<html><body>Page Content</body></html>');
         ob_start();
         ob_start();
-        $http->send_response('<html><body>Page Content</body></html>');
+        $http->send_response();
         $output = ob_get_clean();
         $this->assertStringContainsString('cypht-debug-panel', $output);
         $this->assertStringContainsString('Debug Panel', $output);
@@ -38,10 +38,10 @@ class Hm_Test_Output_Debug extends TestCase {
      * @runInSeparateProcess
      */
     public function test_send_response_skips_panel_when_no_debug_messages() {
-        $http = new Hm_Output_HTTP();
+        $http = new Hm_Output_HTTP('<html><body>Page Content</body></html>');
         ob_start();
         ob_start();
-        $http->send_response('<html><body>Page Content</body></html>');
+        $http->send_response();
         $output = ob_get_clean();
         $this->assertStringNotContainsString('cypht-debug-panel', $output);
     }
@@ -71,10 +71,10 @@ class Hm_Test_Output_Debug extends TestCase {
         Hm_Debug::add('Low priority debug', 'debug');
         Hm_Debug::add('High priority error', 'danger');
         putenv('LOG_LEVEL=ERROR');
-        $http = new Hm_Output_HTTP();
+        $http = new Hm_Output_HTTP('<html><body>Content</body></html>');
         ob_start();
         ob_start();
-        $http->send_response('<html><body>Content</body></html>');
+        $http->send_response();
         $output = ob_get_clean();
         putenv('LOG_LEVEL=WARNING');
         $this->assertStringContainsString('cypht-debug-panel', $output);

--- a/tests/phpunit/modules/sievefilters/functions.php
+++ b/tests/phpunit/modules/sievefilters/functions.php
@@ -55,19 +55,21 @@ class MockSieveClientStorage {
 /**
  * Mock factory for testing that returns a mock client with predefined scripts
  */
-class Hm_Test_Mock_Sieve_Client_Factory {
-    private static $mockCreator;
-    
-    public static function setMockCreator($creator) {
-        self::$mockCreator = $creator;
-    }
-    
-    public function init($user_config = null, $imap_account = null, $is_nux_supported = false) {
-        if (!self::$mockCreator) {
-            throw new Exception('Mock creator not set');
+if (!class_exists('Hm_Custom_Sieve_Client_Factory')) {
+    class Hm_Custom_Sieve_Client_Factory {
+        private static $mockCreator;
+
+        public static function setMockCreator($creator) {
+            self::$mockCreator = $creator;
         }
+
+        public function init($user_config = null, $imap_account = null, $is_nux_supported = false) {
+            if (!self::$mockCreator) {
+                throw new Exception('Mock creator not set');
+            }
         
-        return call_user_func(self::$mockCreator);
+            return call_user_func(self::$mockCreator);
+        }
     }
 }
 
@@ -76,8 +78,8 @@ class Hm_Test_Mock_Sieve_Client_Factory {
  */
 class Hm_Test_Mock_Sieve_Site_Config {
     public function get($name) {
-        if ($name === 'sieve_client_factory') {
-            return 'Hm_Test_Mock_Sieve_Client_Factory';
+        if ($name === 'enable_custom_sieve_factory') {
+            return true;
         }
         return null;
     }
@@ -657,7 +659,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
             return $client;
         };
         
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator($mockCreator);
+        Hm_Custom_Sieve_Client_Factory::setMockCreator($mockCreator);
 
         $mailbox = array(
             'name' => 'Primary Account',

--- a/tests/phpunit/modules/sievefilters/functions.php
+++ b/tests/phpunit/modules/sievefilters/functions.php
@@ -2,21 +2,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-class Hm_Test_Sieve_Failing_Factory {
-    public function init($user_config = null, $imap_account = null, $is_nux_supported = false) {
-        throw new Exception('Connection refused');
-    }
-}
-
-class Hm_Test_Failing_Sieve_Site_Config {
-    public function get($name) {
-        return 'Hm_Test_Sieve_Failing_Factory';
-    }
-    public function get_modules($include_setup = false) {
-        return array();
-    }
-}
-
 class Hm_Test_Mock_Sieve_Module {
     public $config;
     public $user_config;
@@ -371,9 +356,9 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function test_get_sieve_client_factory_uses_class_from_site_config() {
+    public function test_get_sieve_client_factory_uses_custom_class_as_configured() {
         $factory = get_sieve_client_factory(new Hm_Test_Mock_Sieve_Site_Config());
-        $this->assertInstanceOf('Hm_Test_Mock_Sieve_Client_Factory', $factory);
+        $this->assertInstanceOf('Hm_Custom_Sieve_Client_Factory', $factory);
     }
 
     /**
@@ -382,8 +367,13 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
      */
     public function test_initialize_sieve_client_factory_returns_null_and_adds_message_on_exception() {
         require_once APP_PATH.'modules/sievefilters/hm-sieve.php';
+
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
+            throw new Exception('Connection refused');
+        });
+
         $result = initialize_sieve_client_factory(
-            new Hm_Test_Failing_Sieve_Site_Config(),
+            new Hm_Test_Mock_Sieve_Site_Config(),
             new Hm_Mock_Config(),
             array('sieve_config_host' => 'sieve.example.com')
         );
@@ -399,7 +389,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
      */
     public function test_get_blocked_senders_array_returns_empty_when_no_blocked_senders_script() {
         MockSieveClientStorage::setScripts(array('other_script' => 'discard;'));
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $result = get_blocked_senders_array(
@@ -424,7 +414,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
                 'discard; stop;',
             )),
         ));
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $result = get_blocked_senders_array(
@@ -442,7 +432,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
      * @runInSeparateProcess
      */
     public function test_get_blocked_senders_array_returns_empty_and_adds_message_on_exception() {
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             throw new Exception('Client connection failed');
         });
         $result = get_blocked_senders_array(
@@ -460,7 +450,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
      */
     public function test_get_blocked_senders_returns_empty_string_when_script_not_present() {
         MockSieveClientStorage::setScripts(array());
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $mod = new Hm_Output_Test(array(), array());
@@ -488,7 +478,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
                 'discard; stop;',
             )),
         ));
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $mod = new Hm_Output_Test(array(), array());
@@ -522,7 +512,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
                 '}',
             )),
         ));
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $user_config = new Hm_Mock_Config();
@@ -565,7 +555,7 @@ class Hm_Test_Sievefilters_Functions extends TestCase {
                 'fileinto "Archive";',
             )),
         ));
-        Hm_Test_Mock_Sieve_Client_Factory::setMockCreator(function () {
+        Hm_Custom_Sieve_Client_Factory::setMockCreator(function () {
             return $this->makeMockSieveClient();
         });
         $user_config = new Hm_Mock_Config();

--- a/tests/phpunit/modules/sievefilters/handler_modules.php
+++ b/tests/phpunit/modules/sievefilters/handler_modules.php
@@ -654,7 +654,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
             'blocked_senders' => $this->blockedSendersScript(array('spam@example.com')),
         );
         $test = new Sieve_Handler_Test('sieve_unblock_sender', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array('imap_server_id' => 'serverA', 'sender' => 'spam@example.com');
         $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
         $test->run();
@@ -669,7 +669,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
     public function test_sieve_block_domain_blocks_wildcard_domain_and_sets_reload_page() {
         Hm_Test_Sieve_Client::$scripts = array('main_script' => 'require ["include"];');
         $test = new Sieve_Handler_Test('sieve_block_domain_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array('imap_server_id' => 'serverA', 'sender' => 'spam@example.com');
         $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
         $res = $test->run();
@@ -685,7 +685,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
     public function test_sieve_block_unblock_script_blocks_new_sender_with_discard_action() {
         Hm_Test_Sieve_Client::$scripts = array();
         $test = new Sieve_Handler_Test('sieve_block_unblock_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_server_id' => 'serverA',
             'block_action' => 'discard',
@@ -711,7 +711,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
             'blocked_senders' => $this->blockedSendersScript($senders, $actions),
         );
         $test = new Sieve_Handler_Test('sieve_block_unblock_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_server_id' => 'serverA',
             'block_action' => 'discard',
@@ -743,7 +743,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
             'id' => 0,
         ));
         $test = new Sieve_Handler_Test('list_block_sieve_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array('imap_server_id' => 0);
         $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
         $res = $test->run();
@@ -757,7 +757,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
     public function test_load_account_sieve_filters_outputs_mailbox_with_extensions() {
         Hm_Test_Sieve_Client::$scripts = array();
         $test = new Sieve_Handler_Test('load_account_sieve_filters', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array('imap_server_id' => 'serverA');
         $test->input = array('imap_accounts' => $this->imapServersConfig());
         $test->user_config = array('imap_servers' => $this->imapServersConfig(), 'enable_sieve_filter_setting' => true);
@@ -785,7 +785,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
             'id' => 0,
         ));
         $test = new Sieve_Handler_Test('sieve_toggle_script_state', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 0,
             'script_state' => 1,

--- a/tests/phpunit/modules/sievefilters/handler_modules.php
+++ b/tests/phpunit/modules/sievefilters/handler_modules.php
@@ -107,17 +107,15 @@ class Hm_Test_Sieve_Client {
     }
 }
 
-class Hm_Test_Sieve_Client_Factory {
-    public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
-    {
-        return new Hm_Test_Sieve_Client();
-    }
-}
-
-class Hm_Test_Sieve_Client_Failing_Factory {
-    public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
-    {
-        throw new Exception('Test failure');
+if (! class_exists('Hm_Custom_Sieve_Client_Factory')) {
+    class Hm_Custom_Sieve_Client_Factory {
+        public function init($user_config = null, $imap_account = null, $is_nux_supported = false)
+        {
+            if (! $user_config || ! $imap_account) {
+                throw new Exception('Test failure');
+            }
+            return new Hm_Test_Sieve_Client();
+        }
     }
 }
 
@@ -239,7 +237,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         );
 
         $test = new Sieve_Handler_Test('load_custom_actions', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->get = array('list_path' => 'imap_serverA_INBOX');
         $test->user_config = array(
             'imap_servers' => $this->imapServersConfig(),
@@ -264,7 +262,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         );
 
         $test = new Sieve_Handler_Test('sieve_edit_filter', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_script_name' => 'important_sender-10-cyphtfilter',
@@ -291,7 +289,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         );
 
         $test = new Sieve_Handler_Test('sieve_edit_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_script_name' => 'manual_script-15-cypht',
@@ -318,7 +316,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         );
 
         $test = new Sieve_Handler_Test('sieve_delete_filter', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_script_name' => 'important_sender-10-cyphtfilter',
@@ -349,7 +347,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         );
 
         $test = new Sieve_Handler_Test('sieve_delete_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_script_name' => 'manual_script-15-cypht',
@@ -374,7 +372,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_filters_enabled_message_content_outputs_client_when_configured() {
         $test = new Sieve_Handler_Test('sieve_filters_enabled_message_content', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array('imap_server_id' => 'serverA');
         $test->user_config = array(
             'imap_servers' => $this->imapServersConfig(),
@@ -393,7 +391,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_save_filter_adds_success_message() {
         $test = new Sieve_Handler_Test('sieve_save_filter', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_filter_name' => 'Important Sender',
@@ -430,7 +428,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_save_filter_gen_script_returns_script_details_without_persisting_script() {
         $test = new Sieve_Handler_Test('sieve_save_filter', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_filter_name' => 'Important Sender',
@@ -471,7 +469,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_save_script_adds_success_message() {
         $test = new Sieve_Handler_Test('sieve_save_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 'Primary Account',
             'sieve_script_name' => 'Manual Script',
@@ -510,7 +508,7 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
         ));
 
         $test = new Sieve_Handler_Test('sieve_toggle_script_state', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
             'imap_account' => 0,
             'script_state' => 0,
@@ -535,9 +533,9 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_save_filter_adds_error_message_when_factory_fails() {
         $test = new Sieve_Handler_Test('sieve_save_filter', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Failing_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
-            'imap_account' => 'Primary Account',
+            'imap_account' => null, // Simulate failure by not providing a valid imap account
             'sieve_filter_name' => 'Important Sender',
             'sieve_filter_priority' => '10',
             'current_editing_filter_name' => '',
@@ -806,9 +804,9 @@ class Hm_Test_Sievefilters_Handler_Modules extends TestCase {
      */
     public function test_sieve_save_script_adds_error_message_when_factory_fails() {
         $test = new Sieve_Handler_Test('sieve_save_script', 'sievefilters');
-        $test->config = array('sieve_client_factory' => 'Hm_Test_Sieve_Client_Failing_Factory');
+        $test->config = array('enable_custom_sieve_factory' => true);
         $test->post = array(
-            'imap_account' => 'Primary Account',
+            'imap_account' => null, // Simulate failure by not providing a valid imap account
             'sieve_script_name' => 'Manual Script',
             'sieve_script_priority' => '15',
             'current_editing_script' => '',

--- a/tests/phpunit/output.php
+++ b/tests/phpunit/output.php
@@ -7,9 +7,7 @@ use PHPUnit\Framework\TestCase;
  */
 class Hm_Test_Output extends TestCase {
 
-    public $http;
     public function setUp(): void {
-        $this->http = new Hm_Output_HTTP();
         Hm_Msgs::flush();
         Hm_Debug::flush();
     }
@@ -20,19 +18,26 @@ class Hm_Test_Output extends TestCase {
     public function test_send_response() {
         ob_start();
         ob_start();
-        $this->http->send_response('test', array('http_headers' => array('test')));
+
+        $http = new Hm_Output_HTTP('test', array('http_headers' => array('test')));
+
+        $http->send_response();
         $output = ob_get_contents();
         ob_end_clean();
         $this->assertEquals('test', $output);
+
         ob_start();
         ob_start();
-        $this->http->send_response('test', array());
+
+        $http = new Hm_Output_HTTP('test', array());
+
+        $http->send_response();
         $output = ob_get_contents();
         ob_end_clean();
         $this->assertEquals('test', $output);
     }
+    
     public function tearDown(): void {
-        unset($this->http);
         Hm_Msgs::flush();
         Hm_Debug::flush();
     }

--- a/tests/phpunit/session_functions.php
+++ b/tests/phpunit/session_functions.php
@@ -35,7 +35,7 @@ class Hm_Test_Session_Functions extends TestCase {
         $this->config->set('session_type', 'custom');
         $this->config->set('auth_type', 'custom');
         $setup = new Hm_Session_Setup($this->config);
-        $this->assertEquals('Custom_Session', get_class(($setup->setup_session())));
+        $this->assertEquals('Hm_Custom_Session', get_class(($setup->setup_session())));
 
         $this->config->set('session_type', 'REDIS');
         $setup = new Hm_Session_Setup($this->config);

--- a/tests/phpunit/user_config_functions.php
+++ b/tests/phpunit/user_config_functions.php
@@ -23,8 +23,11 @@ class Hm_Test_User_Config_Functions extends TestCase {
         $this->assertEquals('Hm_User_Config_File', get_class(load_user_config_object($mock_config)));
         $mock_config->set('user_config_type', 'DB');
         $this->assertEquals('Hm_User_Config_DB', get_class(load_user_config_object($mock_config)));
-        $mock_config->set('user_config_type', 'custom:Hm_Mock_Config');
-        $this->assertEquals('Hm_Mock_Config', get_class(load_user_config_object($mock_config)));
+        $mock_config->set('user_config_type', 'custom');
+        $this->assertEquals('Hm_User_Config_File', get_class(load_user_config_object($mock_config)), 'default to file config if custom config class does not exist');
+
+        require_once 'modules/site/lib.php';
+        $this->assertEquals('Hm_Custom_User_Config', get_class(load_user_config_object($mock_config)), 'use custom config class if it exists');
     }
     /**
      * @preserveGlobalState disabled


### PR DESCRIPTION
Related: #1909 

Cypht already supports integration through the site module, but in practice some integrations (for example Tiki: https://doc.tiki.org/Webmail) still patch Cypht core code directly.

A likely reason is that site-level customization has not been flexible or explicit enough for key concerns such as authentication, sessions, cache, and configuration.

This PR improves and clarifies the customization model:

* Custom integration code can live in any accessible directory, configured through `SITE_MODULE_PATH`.
* Code in that path is automatically bound to Cypht internal modules (following the `modules/site` pattern).
* Core customization points now use predictable custom classes based on config type flags, without requiring extra class-name settings.

### Customization Points

* **Authentication**: If `AUTH_TYPE` is set to `custom`, Cypht uses `Hm_Custom_Auth` (no `AUTH_CLASS` needed).
* **Session handling**: If `SESSION_TYPE` is set to `custom`, Cypht uses `Hm_Custom_Session` (no `SESSION_CLASS` needed).
* **Configuration**: If `SITE_CONFIG_TYPE` is set to `custom`, Cypht uses `Hm_Custom_Site_Config`. If `USER_CONFIG_TYPE` is set to `custom`, Cypht uses `Hm_Custom_User_Config`.
* **Cache**: If `ENABLE_CUSTOM_CACHE` is enabled, Cypht uses `Hm_Custom_Cache` (no `CACHE_CLASS` needed).
* **Sieve client factory**: if `ENABLE_CUSTOM_SIEVE_FACTORY` is enabled, Cypht uses `Hm_Custom_Sieve_Client_Factory` (no `sieve_client_factory` setting needed).
* **Response handling**: Use `DISPATCH_RESPONSE_MODE` to specify behavior: `render` renders immediately, `store` stores for later retrieval via the dispatcher's `$output` property.
* **Routing**: Use `PAGE_PARAM_NAME` to specify custom page query parameter name. See: #1919.

### Integration Requirements

When using custom site configuration, you must explicitly call `$config->triggerInit()`, which returns the `$dispatcher` object.

Overall, this reduces the need for downstream core patches and makes supported integration points clearer.