### PR TITLE
ci(workflow): add PHP 8.3 to test matrix

### DIFF
--- a/.github/workflows/Test-Build.yml
+++ b/.github/workflows/Test-Build.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.1', '8.3']
         database: ['mysql', 'postgres', 'sqlite']
 
     env:
@@ -101,7 +101,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.1', '8.3']
         database: ['sqlite']
 
     env:


### PR DESCRIPTION
Edit .github/workflows/Test-Build.yml to add PHP 8.3 to the matrix for both phpunit and selenium test jobs.