### PR TITLE
fix(backend): max per source setting not persisting after save

### DIFF
--- a/modules/core/functions.php
+++ b/modules/core/functions.php
@@ -418,6 +418,7 @@ function process_site_setting($type, $handler, $callback=false, $default=false, 
             $result = $default;
         }
         $new_settings[$type.'_setting'] = $result;
+        $settings[$type] = $result;
     }
     else {
         $settings[$type] = $handler->user_config->get($type.'_setting', $default);

--- a/modules/core/setup.php
+++ b/modules/core/setup.php
@@ -66,6 +66,7 @@ add_handler('settings', 'process_mailto_handler_setting', true, 'core', 'date', 
 add_handler('settings', 'process_show_list_icons', true, 'core', 'date', 'after');
 add_handler('settings', 'reset_factory', true, 'core', 'save_user_data', 'before');
 add_handler('settings', 'save_user_settings', true, 'core', 'save_user_data', 'before');
+add_handler('settings', 'save_user_data', true, 'core', 'save_user_settings', 'after');
 add_handler('settings', 'reload_folder_cookie', true, 'core', 'save_user_settings', 'after');
 add_handler('settings', 'privacy_settings', true, 'core', 'date', 'after');
 add_handler('settings', 'process_search_all_folders_setting', true, 'core', 'save_user_settings', 'before');


### PR DESCRIPTION
---
🍰 Pullrequest

fix(backend): max per source setting not persisting after save

Problem

Two bugs prevented the "Max messages per source" setting from working correctly in the settings UI:

1. Setting not persisted across requests — save_user_data was listed as a positioning anchor in the settings page handler chain (setup.php) but never registered as an actual handler. As a result, save_user_settings updated the in-memory user_config but the change was never flushed to the session. On the next request, load_user_data reloaded stale session data and the new value was lost.
2. Form showing default value after save — process_site_setting() only populated $settings[$type] in the else branch (page load), not in the success branch (form submitted). Output modules read from user_settings[$type] to render the form field, so after a successful save the form snapped back to the default value on the same response, making it appear the save had no effect.

Fix

- modules/core/setup.php — register save_user_data as an actual handler on the settings page, after save_user_settings
- modules/core/functions.php — populate $settings[$type] = $result in the success path of process_site_setting() so the form immediately reflects the saved value

Issues

- None

Todo

- [x] None