### PR TITLE
fix(module/smtp): prevent path traversal in chunked attachment upload

### DIFF
--- a/lib/module.php
+++ b/lib/module.php
@@ -479,7 +479,10 @@ abstract class Hm_Handler_Module {
     public function build_page_url($page, $params = []) {
         $url = '?'.$this->config->get('page_param_name').'='.$page;
         foreach ($params as $key => $value) {
-            $url .= '&'.urlencode($key).'='.urlencode($value);
+            if (!is_scalar($value)) {
+                continue;
+            }
+            $url .= '&'.urlencode((string) $key).'='.urlencode((string) $value);
         }
         return $url;
     }

--- a/modules/core/hm-mailbox.php
+++ b/modules/core/hm-mailbox.php
@@ -397,7 +397,10 @@ class Hm_Mailbox {
             return false;
         }
         if ($this->is_imap()) {
-            if ($this->connection->append_start($folder, mb_strlen($msg), $seen, $draft)) {
+            // IMAP APPEND literal size is in octets (bytes), not characters.
+            // mb_strlen() under-counts UTF-8 (e.g. attachment filenames with "é"),
+            // which makes APPEND fail and surfaces as "error occurred saving the sent message".
+            if ($this->connection->append_start($folder, strlen($msg), $seen, $draft)) {
                 $this->connection->append_feed($msg."\r\n");
                 return $this->connection->append_end();
             }
@@ -488,7 +491,7 @@ class Hm_Mailbox {
                 $attachment_id = get_attachment_id_for_mail_parser($struct, $part_id);
                 if ($attachment_id !== false) {
                     $msg = remove_attachment($attachment_id, $msg);
-                    if ($this->connection->append_start($folder, mb_strlen($msg))) {
+                    if ($this->connection->append_start($folder, strlen($msg))) {
                         $this->connection->append_feed($msg."\r\n");
                         if ($this->connection->append_end()) {
                             if ($this->connection->message_action('DELETE', array($uid))['status']) {

--- a/modules/imap/handler_modules.php
+++ b/modules/imap/handler_modules.php
@@ -351,7 +351,11 @@ class Hm_Handler_imap_save_sent extends Hm_Handler_Module {
                 $this->out('sent_msg_uid', $uid);
                 $this->out('sent_imap_id', $imap_id);
 
-                if ($this->user_config->get('review_sent_email_setting', false)) {
+                // Only redirect when we have a real message uid (APPENDUID). Some
+                // servers acknowledge APPEND without APPENDUID; store_message then
+                // returns true and urlencode() would fatal on a non-string value.
+                if ($this->user_config->get('review_sent_email_setting', false)
+                        && is_scalar($uid) && $uid !== true) {
                     $this->out('redirect_url', $this->build_page_url('message', array(
                         'uid' => $uid,
                         'list_path' => 'imap_'.$imap_id.'_'.bin2hex($sent_folder),

--- a/modules/imap/hm-imap.php
+++ b/modules/imap/hm-imap.php
@@ -2079,7 +2079,8 @@ if (!class_exists('Hm_IMAP')) {
 
         /**
          * finish an IMAP APPEND operation
-         * @return bool true on success
+         * @return int|string|bool message uid when APPENDUID is present, true on
+         *                         success without a uid, false on failure
          */
         public function append_end() {
             $result = $this->get_response(false, true);
@@ -2087,10 +2088,14 @@ if (!class_exists('Hm_IMAP')) {
                 $res = preg_grep('/APPENDUID/', array_map('json_encode', $result));
                 if ($res) {
                     $line = json_decode(reset($res), true);
-                    return $line[5];
+                    if (is_array($line) && isset($line[5]) && is_scalar($line[5])) {
+                        return $line[5];
+                    }
                 }
+                // APPEND succeeded but server did not return a usable APPENDUID
+                return true;
             }
-            return $result;
+            return false;
         }
 
         /* ------------------ HELPERS ------------------------------------------ */

--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -261,10 +261,13 @@ class Hm_Handler_process_enable_exclude_auto_bcc extends Hm_Handler_Module {
  */
 class Hm_Handler_get_test_chunk extends Hm_Handler_Module {
     public function process() {
-        $filepath = $this->config->get('attachment_dir');
-        $filepath = $filepath.'/chunks-'.$this->request->get['resumableIdentifier'];
-        $chunk_file = $filepath.'/'.$this->request->get['resumableFilename'].'.part'.$this->request->get['resumableChunkNumber'];
-        if (file_exists($chunk_file)) {
+        $resumable_identifier = trim(basename((string) ($this->request->get['resumableIdentifier'] ?? '')));
+        $resumable_filename = trim(basename((string) ($this->request->get['resumableFilename'] ?? '')));
+
+        $expected_dir = $this->config->get('attachment_dir').'/chunks-'.$resumable_identifier;
+        $chunk_file = $expected_dir.'/'.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'];
+        if ($resumable_identifier !== '' && $resumable_filename !== ''
+                && dirname($chunk_file) === $expected_dir && file_exists($chunk_file)) {
             header("HTTP/1.0 200 Ok");
         } else {
             header("HTTP/1.0 404 Not Found");
@@ -287,16 +290,23 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
             mkdir($filepath.'/'.$userpath, 0777, true);
         }
 
+        $resumable_identifier = trim(basename((string) ($this->request->get['resumableIdentifier'] ?? '')));
+        $resumable_filename = trim(basename((string) ($this->request->get['resumableFilename'] ?? '')));
+
         if (!empty($this->request->files)) foreach ($this->request->files as $file) {
             if ($file['error'] != 0) {
-                Hm_Msgs::add('Error '.$file['error'].' in file '.$this->request->get['resumableFilename'], 'danger');
+                Hm_Msgs::add('Error '.$file['error'].' in file '.$resumable_filename, 'danger');
                 continue;
             }
 
-            if(isset($this->request->get['resumableIdentifier']) && trim($this->request->get['resumableIdentifier'])!=''){
-                $temp_dir = $filepath.'/'.$userpath.'/chunks-'.$this->request->get['resumableIdentifier'];
+            $temp_dir = $filepath.'/'.$userpath.'/chunks-'.$resumable_identifier;
+            $dest_file = $temp_dir.'/'.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'];
+
+            if ($resumable_identifier === '' || $resumable_filename === ''
+                    || dirname($dest_file) !== $temp_dir) {
+                Hm_Msgs::add('Invalid upload request', 'danger');
+                continue;
             }
-            $dest_file = $temp_dir.'/'.$this->request->get['resumableFilename'].'.part'.$this->request->get['resumableChunkNumber'];
 
             // create the temporary directory
             if (!is_dir($temp_dir)) {
@@ -305,10 +315,10 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
 
             // move the temporary file
             if (!move_uploaded_file($file['tmp_name'], $dest_file)) {
-                Hm_Msgs::add('Error saving (move_uploaded_file) chunk '.$this->request->get['resumableChunkNumber'].' for file '.$this->request->get['resumableFilename'], 'danger');
+                Hm_Msgs::add('Error saving (move_uploaded_file) chunk '.$this->request->get['resumableChunkNumber'].' for file '.$resumable_filename, 'danger');
             } else {
                 // check if all the parts present, and create the final destination file
-                $result = createFileFromChunks($temp_dir, $this->request->get['resumableFilename'],
+                $result = createFileFromChunks($temp_dir, $resumable_filename,
                                 $this->request->get['resumableChunkSize'],
                                 $this->request->get['resumableTotalSize'],
                                 $this->request->get['resumableTotalChunks']);
@@ -344,7 +354,7 @@ class Hm_Handler_smtp_save_draft extends Hm_Handler_Module {
         $msg_attrs = array('draft_smtp' => $smtp, 'draft_to' => $to, 'draft_body' => $body,
         'draft_subject' => $subject, 'draft_cc' => $cc, 'draft_bcc' => $bcc,
         'draft_in_reply_to' => $inreplyto);
-        $uploaded_files = !$uploaded_files ? []: explode(',', $uploaded_files);
+        $uploaded_files = !$uploaded_files ? [] : parse_uploaded_files_list($uploaded_files);
         $profiles = $this->get('compose_profiles', array());
         $profile = profile_from_compose_smtp_id($profiles, $smtp);
 
@@ -358,9 +368,15 @@ class Hm_Handler_smtp_save_draft extends Hm_Handler_Module {
 
         if ($this->module_is_supported('imap')) {
             $userpath = md5($this->session->get('username', false));
-            foreach($uploaded_files as $key => $file) {
-                $uploaded_files[$key] = $this->config->get('attachment_dir').DIRECTORY_SEPARATOR.$userpath.DIRECTORY_SEPARATOR.$file;
+            $attachment_dir = $this->config->get('attachment_dir');
+            $resolved = [];
+            foreach ($uploaded_files as $file) {
+                $path = user_attachment_path($attachment_dir, $userpath, $file);
+                if ($path !== false) {
+                    $resolved[] = $path;
+                }
             }
+            $uploaded_files = $resolved;
             $new_draft_id = save_imap_draft(array('draft_smtp' => $smtp, 'draft_to' => $to, 'draft_body' => $body,
                     'draft_subject' => $subject, 'draft_cc' => $cc, 'draft_bcc' => $bcc,
                     'draft_in_reply_to' => $inreplyto, 'delivery_receipt' => $delivery_receipt, 'schedule' => $schedule,
@@ -714,9 +730,13 @@ class Hm_Handler_process_compose_form_submit extends Hm_Handler_Module {
         /* parse attachments */
         $uploaded_files = [];
         if (!empty($this->request->post['send_uploaded_files'])) {
-            $uploaded_files = explode(',', $this->request->post['send_uploaded_files']);
-            foreach($uploaded_files as $key => $file) {
-                $uploaded_files[$key] = $this->config->get('attachment_dir').'/'.md5($this->session->get('username', false)).'/'.$file;
+            $userpath = md5($this->session->get('username', false));
+            $attachment_dir = $this->config->get('attachment_dir');
+            foreach (parse_uploaded_files_list($this->request->post['send_uploaded_files']) as $file) {
+                $path = user_attachment_path($attachment_dir, $userpath, $file);
+                if ($path !== false) {
+                    $uploaded_files[] = $path;
+                }
             }
         }
 
@@ -1981,6 +2001,15 @@ if (!hm_exists('rrmdir')) {
  */
 if (!hm_exists('createFileFromChunks')) {
     function createFileFromChunks($temp_dir, $fileName, $chunkSize, $totalSize,$total_files) {
+        // defense in depth: strip directory components and verify the assembled
+        // file stays in the parent of $temp_dir (the per-user attachment dir).
+        $fileName = trim(basename((string) $fileName));
+        $expected_dir = dirname($temp_dir);
+        $dest_file = $expected_dir.'/'.$fileName;
+        if ($fileName === '' || $fileName === '.' || $fileName === '..'
+                || dirname($dest_file) !== $expected_dir) {
+            return false;
+        }
         // count all the parts of this file
         // $fileName = Hm_Crypt::ciphertext($fileName, Hm_Request_Key::generate());
         $total_files_on_server_size = 0;
@@ -1994,19 +2023,19 @@ if (!hm_exists('createFileFromChunks')) {
         // If the Size of all the chunks on the server is equal to the size of the file uploaded.
         if ($total_files_on_server_size >= $totalSize) {
         // create the final destination file
-            if (($fp = fopen($temp_dir.'/../'.$fileName, 'w')) !== false) {
+            if (($fp = fopen($dest_file, 'w')) !== false) {
                 for ($i=1; $i<=$total_files; $i++) {
                     fwrite($fp, file_get_contents($temp_dir.'/'.$fileName.'.part'.$i));
                 }
                 fclose($fp);
-                $hashed_content = Hm_Crypt::ciphertext(file_get_contents($temp_dir.'/../'.$fileName), Hm_Request_Key::generate());
-                file_put_contents($temp_dir.'/../'.$fileName, $hashed_content);
+                $hashed_content = Hm_Crypt::ciphertext(file_get_contents($dest_file), Hm_Request_Key::generate());
+                file_put_contents($dest_file, $hashed_content);
             } else {
                 return false;
             }
 
             // rename the temporary directory (to avoid access from other
-            // concurrent chunks uploads) and than delete it
+            // concurrent chunks uploads) and then delete it
             if (rename($temp_dir, $temp_dir.'_UNUSED')) {
                 rrmdir($temp_dir.'_UNUSED');
             } else {
@@ -2016,6 +2045,57 @@ if (!hm_exists('createFileFromChunks')) {
         return true;
     }
 }
+
+/**
+ * Parse a list of uploaded attachment filenames from a request value.
+ * Prefers JSON (handles commas/unicode in names); falls back to comma-split
+ * for older clients. Each name is reduced to a basename so "../" cannot escape
+ * the per-user attachment directory when paths are built later.
+ * @subpackage smtp/functions
+ */
+if (!hm_exists('parse_uploaded_files_list')) {
+function parse_uploaded_files_list($raw) {
+    if ($raw === false || $raw === null || $raw === '') {
+        return [];
+    }
+    if (is_array($raw)) {
+        $names = $raw;
+    } else {
+        $decoded = json_decode($raw, true);
+        $names = is_array($decoded) ? $decoded : explode(',', $raw);
+    }
+    $safe = [];
+    foreach ($names as $name) {
+        if (!is_string($name) && !is_numeric($name)) {
+            continue;
+        }
+        $name = trim(basename((string) $name));
+        if ($name === '' || $name === '.' || $name === '..') {
+            continue;
+        }
+        $safe[] = $name;
+    }
+    return $safe;
+}}
+
+/**
+ * Build a path under the current user's attachment directory.
+ * Returns false if the filename would escape that directory.
+ * @subpackage smtp/functions
+ */
+if (!hm_exists('user_attachment_path')) {
+function user_attachment_path($attachment_dir, $userpath, $filename) {
+    $filename = trim(basename((string) $filename));
+    if ($filename === '' || $filename === '.' || $filename === '..') {
+        return false;
+    }
+    $expected_dir = rtrim($attachment_dir, '/\\').DIRECTORY_SEPARATOR.$userpath;
+    $path = $expected_dir.DIRECTORY_SEPARATOR.$filename;
+    if (dirname($path) !== $expected_dir) {
+        return false;
+    }
+    return $path;
+}}
 
 /**
  * @subpackage smtp/functions

--- a/modules/smtp/setup.php
+++ b/modules/smtp/setup.php
@@ -152,10 +152,14 @@ return array(
         'resumableChunkSize' => FILTER_VALIDATE_INT,
         'resumableCurrentChunkSize' => FILTER_VALIDATE_INT,
         'resumableTotalSize' => FILTER_VALIDATE_INT,
-        'resumableType' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-        'resumableIdentifier' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-        'resumableFilename' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-        'resumableRelativePath' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+        'resumableType' => FILTER_UNSAFE_RAW,
+        // Keep raw values so the on-disk name matches the original filename from
+        // the browser (e.g. "café.txt"). FILTER_SANITIZE_FULL_SPECIAL_CHARS would
+        // HTML-entity-encode characters (é -> &eacute;), breaking send-time lookup.
+        // Path traversal is prevented in the upload handlers via basename()/dirname().
+        'resumableIdentifier' => FILTER_UNSAFE_RAW,
+        'resumableFilename' => FILTER_UNSAFE_RAW,
+        'resumableRelativePath' => FILTER_UNSAFE_RAW,
         'draft_smtp' => FILTER_SANITIZE_FULL_SPECIAL_CHARS
     ),
     'allowed_output' => array(

--- a/modules/smtp/site.js
+++ b/modules/smtp/site.js
@@ -110,7 +110,7 @@ var save_compose_state = function(no_files, notice, schedule, callback) {
         {'name': 'draft_in_reply_to', 'value': inreplyto},
         {'name': 'delete_uploaded_files', 'value': no_files},
         {'name': 'draft_to', 'value': to},
-        {'name': 'uploaded_files', 'value': uploaded_files},
+        {'name': 'uploaded_files', 'value': JSON.stringify(uploaded_files)},
         {'name': 'schedule', 'value': schedule ?? ''},
         {'name': 'compose_delivery_receipt', 'value': delivery_receipt ?? ''}],
         function(res) {
@@ -570,7 +570,7 @@ var process_compose_form = function(){
     }
 
     var uploaded_files = $("input[name='uploaded_files[]']").map(function () { return $(this).val(); }).get();
-    $('#send_uploaded_files').val(uploaded_files);
+    $('#send_uploaded_files').val(JSON.stringify(uploaded_files));
     Hm_Ajax.show_loading_icon();
     $('.smtp_send_placeholder').addClass('disabled_input');
     $('.smtp_send_archive').addClass('disabled_input');


### PR DESCRIPTION
Related to https://avan.tech/item167923

Other issues fixed in this pull request

- Compose/send behavior breaks for common real-world names: accented characters are HTML-entity-encoded before storage (so send-time lookup misses the file), 
- comma-separated attachment lists cannot represent names that contain commas, 
- saving a sent copy over IMAP can fail when the message contains multi-byte UTF-8 (APPEND size calculated in characters instead of bytes). 
- In some APPENDUID edge cases, the post-send “review sent message” redirect hits a fatal and leave a blank page.