### PR TITLE
refactor(backend): resolve VENDOR_PATH dynamically based on installation layout

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,16 +21,14 @@ define('SITE_ID', '');
 define('JS_HASH', '');
 define('CSS_HASH', '');
 define('ASSETS_PATH', APP_PATH.'assets/');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* don't let anything output content until we are ready */
 ob_start();
 
 /* get includes */
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/index.php
+++ b/index.php
@@ -13,7 +13,6 @@
  * SITE_ID    random site id used for page keys
  */
 define('APP_PATH', '');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('CONFIG_PATH', APP_PATH.'config/');
 define('WEB_ROOT', '');
 define('ASSETS_THEMES_ROOT', '');
@@ -26,9 +25,13 @@ define('ASSETS_PATH', APP_PATH.'assets/');
 /* don't let anything output content until we are ready */
 ob_start();
 
-require VENDOR_PATH.'autoload.php';
 /* get includes */
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
+
 $environment = Hm_Environment::getInstance();
 $environment->load();
 

--- a/lib/define_vendor_path.php
+++ b/lib/define_vendor_path.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Define the vendor path for Cypht
+ * 
+ * This script must be included only after APP_PATH has been defined, and before any other scripts that require the vendor path.
+ * 
+ * @package framework
+ * @subpackage setup
+ */
+
+if (defined('VENDOR_PATH') && file_exists(VENDOR_PATH)) {
+    // The vendor path may have already been defined in third-party code that integrates Cypht.
+    // If so, we pass.
+} elseif (file_exists(APP_PATH.'vendor/')) {
+    define('VENDOR_PATH', APP_PATH.'vendor/');
+} else {
+    // When installed via composer, the vendor path is generally two levels up (jason-munro/cypht) from APP_PATH.
+    define('VENDOR_PATH', APP_PATH . '../../');
+}

--- a/lib/framework.php
+++ b/lib/framework.php
@@ -250,6 +250,15 @@ if (!class_exists('Hm_Functions')) {
         public static function stream_socket_enable_crypto($socket, $type) {
             return stream_socket_enable_crypto($socket, true, $type);
         }
+
+        public static function define_vendor_path() {
+            if (file_exists(APP_PATH.'vendor/')) {
+                define('VENDOR_PATH', APP_PATH.'vendor/');
+            } else {
+                // When installed via composer, the vendor path is generally two levels up (jason-munro/cypht) from APP_PATH.
+                define('VENDOR_PATH', APP_PATH . '../../');
+            }
+        }
     }
 }
 

--- a/lib/framework.php
+++ b/lib/framework.php
@@ -250,17 +250,6 @@ if (!class_exists('Hm_Functions')) {
         public static function stream_socket_enable_crypto($socket, $type) {
             return stream_socket_enable_crypto($socket, true, $type);
         }
-
-        public static function define_vendor_path() {
-            if (defined('VENDOR_PATH') && file_exists(VENDOR_PATH)) { // Could have already been defined in integrating app code.
-                return;
-            } elseif (file_exists(APP_PATH.'vendor/')) {
-                define('VENDOR_PATH', APP_PATH.'vendor/');
-            } else {
-                // When installed via composer, the vendor path is generally two levels up (jason-munro/cypht) from APP_PATH.
-                define('VENDOR_PATH', APP_PATH . '../../');
-            }
-        }
     }
 }
 

--- a/lib/framework.php
+++ b/lib/framework.php
@@ -252,7 +252,9 @@ if (!class_exists('Hm_Functions')) {
         }
 
         public static function define_vendor_path() {
-            if (file_exists(APP_PATH.'vendor/')) {
+            if (defined('VENDOR_PATH') && file_exists(VENDOR_PATH)) { // Could have already been defined in integrating app code.
+                return;
+            } elseif (file_exists(APP_PATH.'vendor/')) {
                 define('VENDOR_PATH', APP_PATH.'vendor/');
             } else {
                 // When installed via composer, the vendor path is generally two levels up (jason-munro/cypht) from APP_PATH.

--- a/modules/api_login/api.php
+++ b/modules/api_login/api.php
@@ -7,12 +7,14 @@
 
 /* Constants */
 define('APP_PATH', dirname(dirname(dirname(__FILE__))).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* Init the framework */
-require_once VENDOR_PATH.'autoload.php';
 require_once APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require_once VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/modules/api_login/api.php
+++ b/modules/api_login/api.php
@@ -8,11 +8,10 @@
 /* Constants */
 define('APP_PATH', dirname(dirname(dirname(__FILE__))).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* Init the framework */
 require_once APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
 
 require_once VENDOR_PATH.'autoload.php';
 

--- a/modules/api_login/api.php
+++ b/modules/api_login/api.php
@@ -11,9 +11,8 @@ define('WEB_ROOT', '');
 require APP_PATH.'lib/define_vendor_path.php';
 
 /* Init the framework */
-require_once APP_PATH.'lib/framework.php';
-
 require_once VENDOR_PATH.'autoload.php';
+require_once APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -10,13 +10,15 @@ if (strtolower(php_sapi_name()) !== 'cli') {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 chdir(APP_PATH);
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -16,9 +16,8 @@ require APP_PATH.'lib/define_vendor_path.php';
 chdir(APP_PATH);
 
 /* get the framework */
-require APP_PATH.'lib/framework.php';
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/config_gen.php
+++ b/scripts/config_gen.php
@@ -11,12 +11,12 @@ if (strtolower(php_sapi_name()) !== 'cli') {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
+
 chdir(APP_PATH);
 
 /* get the framework */
 require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
 
 require VENDOR_PATH.'autoload.php';
 

--- a/scripts/create_account.php
+++ b/scripts/create_account.php
@@ -17,12 +17,14 @@ else {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/create_account.php
+++ b/scripts/create_account.php
@@ -18,13 +18,11 @@ else {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* get the framework */
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/create_config.php
+++ b/scripts/create_config.php
@@ -6,12 +6,14 @@ if (mb_strtolower(php_sapi_name()) !== 'cli') {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/create_config.php
+++ b/scripts/create_config.php
@@ -7,13 +7,11 @@ if (mb_strtolower(php_sapi_name()) !== 'cli') {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* get the framework */
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/delete_account.php
+++ b/scripts/delete_account.php
@@ -16,12 +16,14 @@ else {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/delete_account.php
+++ b/scripts/delete_account.php
@@ -17,13 +17,11 @@ else {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* get the framework */
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -3,11 +3,13 @@
 <?php
 
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('MIGRATIONS_PATH', APP_PATH.'database/migrations');
 
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 // Allow specifying environment file via --env argument
 // Usage: php setup_database.php --env=.env.test

--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -4,12 +4,10 @@
 
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('MIGRATIONS_PATH', APP_PATH.'database/migrations');
-
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
+require APP_PATH.'lib/define_vendor_path.php';
 
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 // Allow specifying environment file via --env argument
 // Usage: php setup_database.php --env=.env.test

--- a/scripts/update_password.php
+++ b/scripts/update_password.php
@@ -38,12 +38,14 @@ if (is_array($argv)) {
 
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
-define('VENDOR_PATH', APP_PATH.'vendor/');
 define('WEB_ROOT', '');
 
 /* get the framework */
-require VENDOR_PATH.'autoload.php';
 require APP_PATH.'lib/framework.php';
+
+Hm_Functions::define_vendor_path();
+
+require VENDOR_PATH.'autoload.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();

--- a/scripts/update_password.php
+++ b/scripts/update_password.php
@@ -39,13 +39,11 @@ if (is_array($argv)) {
 /* determine current absolute path used for require statements */
 define('APP_PATH', dirname(dirname(__FILE__)).'/');
 define('WEB_ROOT', '');
+require APP_PATH.'lib/define_vendor_path.php';
 
 /* get the framework */
-require APP_PATH.'lib/framework.php';
-
-Hm_Functions::define_vendor_path();
-
 require VENDOR_PATH.'autoload.php';
+require APP_PATH.'lib/framework.php';
 
 $environment = Hm_Environment::getInstance();
 $environment->load();


### PR DESCRIPTION
Because `VENDOR_PATH` is always assumed at the APP_PATH level, integrating Cypht in other software often requires overwriting that constant definition with the real path.

This PR provides a way to dynamically resolve that path when Cypht is installed either as a standalone app or a package via Composer.

Related change in Tiki: https://gitlab.com/tikiwiki/tiki/-/merge_requests/10893.

Related issue: https://github.com/cypht-org/cypht/issues/1909