### PR TITLE
fix(other): stop building linux/arm/v6 which php:8.3-fpm-bookworm does not support

### DIFF
--- a/.github/workflows/Daily-Image.yml
+++ b/.github/workflows/Daily-Image.yml
@@ -11,28 +11,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
           push: true
           tags: cypht/cypht:daily
           cache-from: type=registry,ref=cypht/cypht:buildcache

--- a/.github/workflows/Release-Image.yml
+++ b/.github/workflows/Release-Image.yml
@@ -11,21 +11,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
-
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -38,16 +37,15 @@ jobs:
           echo "tags=$DOCKER_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
           file: ./docker/Dockerfile
           push: true
           tags: |
             cypht/cypht:${{ steps.tags.outputs.tags }}
             cypht/cypht:latest
-          debug: false
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker-push:  ## build, tag, and push image to dockerhub. presumes you are logge
 	@[ "$(tag)" = "" ] && (echo "Tag required. Example tag=1.2.3" ; exit 1)
 	@image=$(DOCKERHUB_REPO):$(tag)
 	@echo "Building image $${image}"
-	@docker buildx build . --platform linux/386,linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
+	@docker buildx build . --platform linux/386,linux/amd64,linux/arm64,linux/arm/v7 \
 		-t $${image} -f docker/Dockerfile --push
 
 .PHONY: dockerhub-push-readme


### PR DESCRIPTION
## Issue

* The daily Docker image job failed with `no match for platform in manifest` because the workflow builds `linux/arm/v6` and `php:8.3-fpm-bookworm` does not publish that platform.
* Bump image-workflow actions to Node 24 majors (`checkout@v5`, `setup-qemu-action@v4`, `setup-buildx-action@v4`, `login-action@v4`, `build-push-action@v7`) and remove the obsolete `debug` input from the release workflow.