### PR TITLE
fix(backend): guard undefined $latestVersion in upgrade checker

### DIFF
--- a/modules/core/handler_modules.php
+++ b/modules/core/handler_modules.php
@@ -1271,9 +1271,8 @@ class Hm_Handler_version_upgrade_checker extends Hm_Handler_Module {
 
     public function process()
     {
-        if ($this->session->get('latest_version')) {
-            $latestVersion = $this->session->get('latest_version');
-        } else {
+        $latestVersion = $this->session->get('latest_version') ?: null;
+        if (! $latestVersion) {
             $api = new Hm_API_Curl();
             $data = $api->command('https://api.github.com/repos/cypht-org/cypht/releases');
 
@@ -1285,7 +1284,7 @@ class Hm_Handler_version_upgrade_checker extends Hm_Handler_Module {
             }
         }
 
-        if (version_compare(CYPHT_VERSION, $latestVersion, '<')) {
+        if ($latestVersion && version_compare(CYPHT_VERSION, $latestVersion, '<')) {
             $needUpgrade = true;
         } else {
             $needUpgrade = false;


### PR DESCRIPTION
## Issue
`Hm_Handler_version_upgrade_checker` only assigned `$latestVersion` when the session already had a cached value, or when `https://api.github.com/repos/cypht-org/cypht/releases` returned HTTP 200.

If that request failed (timeout, rate limit, no outbound HTTPS, DNS, proxy, etc.), `$latestVersion` was never set. PHP 8 then raised `E_WARNING: Undefined variable $latestVersion` on `version_compare()` and on `$this->out('latest_version', $latestVersion)`.