### PR TITLE
fix(module/account): restyle accounts page and confirm before deleting users

### DIFF
--- a/language/en.php
+++ b/language/en.php
@@ -437,6 +437,7 @@ return array(
     'Added repository' => false,
     'Added server!' => false,
     'Are you sure you want to delete this server?' => false,
+    'Are you sure you want to delete the account "%s"? This cannot be undone.' => false,
     'Could not find that repository/owner combination at github.com' => false,
     'Disable prompts when deleting' => false,
     'Enable keyboard shortcuts' => false,

--- a/modules/account/js_modules/route_handlers.js
+++ b/modules/account/js_modules/route_handlers.js
@@ -1,0 +1,40 @@
+function applyAccountsPageHandlers() {
+    var pendingForm = null;
+    var modalEl = document.getElementById('confirmDeleteAccountModal');
+
+    if (!modalEl || typeof bootstrap === 'undefined') {
+        return;
+    }
+
+    var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+    $('.delete_user_form').on('submit', function(e) {
+        e.preventDefault();
+        pendingForm = this;
+        var username = $(this).find('[name="delete_username"]').val();
+        $('#confirmDeleteAccountMessage').text(
+            hm_trans('Are you sure you want to delete the account "%s"? This cannot be undone.').replace('%s', username)
+        );
+        modal.show();
+    });
+
+    $('#confirmDeleteAccountBtn').on('click', function() {
+        if (!pendingForm) {
+            return;
+        }
+        var form = pendingForm;
+        pendingForm = null;
+        modal.hide();
+        form.submit();
+    });
+
+    $(modalEl).on('hidden.bs.modal', function() {
+        if (pendingForm) {
+            pendingForm = null;
+        }
+    });
+
+    return function() {
+        pendingForm = null;
+    };
+}

--- a/modules/account/modules.php
+++ b/modules/account/modules.php
@@ -59,6 +59,10 @@ class Hm_Handler_process_delete_account extends Hm_Handler_Module {
         if (!$success) {
             return;
         }
+        if ($form['delete_username'] === $this->session->get('username')) {
+            Hm_Msgs::add('You cannot delete your own account', 'warning');
+            return;
+        }
         $dbh = Hm_DB::connect($this->config);
         if (Hm_DB::execute($dbh, 'delete from hm_user where username=?', array($form['delete_username']))) {
             Hm_Msgs::add('User account deleted');
@@ -154,51 +158,99 @@ class Hm_Output_create_form extends Hm_Output_Module {
         if (!$this->get('internal_users') || !$this->get('is_admin', false)) {
             Hm_Dispatch::page_redirect($this->build_page_url('home'));
         }
-        return '<div class="content_title">'.$this->trans('Accounts').'</div>'.
-            '<div class="settings_subtitle">'.$this->trans('Create Account').'</div>'.
-            '<div class="create_user">'.
-            '<form method="POST" autocomplete="off" >'.
-            '<input type="hidden" name="hm_page_key" value="'.Hm_Request_Key::generate().'" />'.
-            '<input style="display:none" type="text" name="fake_username" />'.
-            '<input style="display:none" type="password" name="fake_password" />'.
-            ' <input required type="text" placeholder="'.$this->trans('Username').'" name="create_username" value="">'.
-            ' <input type="password" required placeholder="'.$this->trans('Password').'" name="create_password">'.
-            ' <input type="password" required placeholder="'.$this->trans('Password Again').'" name="create_password_again">'.
-            ' <input type="submit" name="create_hm_user" value="'.$this->trans('Create').'" />'.
-            '</form></div>';
+        return '<div class="accounts_page px-0">'.
+            '<div class="content_title px-3">'.$this->trans('Accounts').'</div>'.
+            '<div class="settings_subtitle p-3 border-bottom">'.$this->trans('Create Account').'</div>'.
+            '<div class="create_user row px-3 mt-3">'.
+                '<div class="col-lg-4 col-sm-12">'.
+                    '<form method="POST" autocomplete="off">'.
+                        '<input type="hidden" name="hm_page_key" value="'.Hm_Request_Key::generate().'" />'.
+                        '<input style="display:none" type="text" name="fake_username" />'.
+                        '<input style="display:none" type="password" name="fake_password" />'.
+                        '<div class="form-floating mb-3">'.
+                            '<input required type="text" id="create_username" name="create_username" class="form-control" placeholder="'.$this->trans('Username').'" value="">'.
+                            '<label for="create_username">'.$this->trans('Username').'</label>'.
+                        '</div>'.
+                        '<div class="form-floating mb-3">'.
+                            '<input required type="password" id="create_password" name="create_password" class="form-control" placeholder="'.$this->trans('Password').'">'.
+                            '<label for="create_password">'.$this->trans('Password').'</label>'.
+                        '</div>'.
+                        '<div class="form-floating mb-3">'.
+                            '<input required type="password" id="create_password_again" name="create_password_again" class="form-control" placeholder="'.$this->trans('Password Again').'">'.
+                            '<label for="create_password_again">'.$this->trans('Password Again').'</label>'.
+                        '</div>'.
+                        '<input type="submit" name="create_hm_user" class="btn btn-primary" value="'.$this->trans('Create').'" />'.
+                    '</form>'.
+                '</div>'.
+            '</div>';
     }
 }
+
+/**
+ * @subpackage account/output
+ */
 class Hm_Output_user_list extends Hm_Output_Module {
     protected function output() {
-        $res = '<br /><div class="settings_subtitle">'.$this->trans('Existing Accounts').'</div>';
-        $res .= '<table class="user_list"><thead></thead><tbody>';
-        if ($this->get('is_mobile')) {
-            $width = 2;
+        $current_user = $this->get('username', '');
+        $users = $this->get('user_list', array());
+        $res = '<div class="settings_subtitle p-3 border-bottom mt-3">'.$this->trans('Existing Accounts').'</div>';
+        $res .= '<div class="row px-3 pb-3"><div class="col-lg-8 col-xl-6">';
+        $res .= '<div class="table-responsive">';
+        if (!$users) {
+            $res .= '<div class="d-flex flex-column align-items-center justify-content-center p-5">'.
+                '<i class="bi bi-people fs-4"></i>'.
+                '<span>'.$this->trans('No accounts found').'</span>'.
+                '</div>';
         }
         else {
-            $width = 6;
-        }
-        $count = 0;
-        foreach ($this->get('user_list', array()) as $user) {
-            if ($count == 0) {
-                $res .= '<tr>';
+            $res .= '<table class="table table-striped user_list">'.
+                '<thead><tr>'.
+                '<th>'.$this->trans('Username').'</th>'.
+                '<th class="text-end"></th>'.
+                '</tr></thead><tbody>';
+            foreach ($users as $user) {
+                $username = $user['username'];
+                $is_current = ($username === $current_user);
+                $res .= '<tr><td>'.$this->html_safe($username);
+                if ($is_current) {
+                    $res .= ' <span class="badge text-bg-secondary">'.$this->trans('You').'</span>';
+                }
+                $res .= '</td><td class="text-end">';
+                if ($is_current) {
+                    $res .= '<button type="button" class="btn btn-link p-0 text-muted border-0" disabled '.
+                        'title="'.$this->trans('You cannot delete your own account').'">'.
+                        '<i class="bi bi-trash-fill"></i></button>';
+                }
+                else {
+                    $confirm_msg = sprintf($this->trans('Are you sure you want to delete the account "%s"? This cannot be undone.'), $username);
+                    $res .= '<form class="delete_user_form d-inline" action="'.$this->build_page_url('accounts').'" method="POST">'.
+                        '<input type="hidden" name="hm_page_key" value="'.Hm_Request_Key::generate().'" />'.
+                        '<input name="delete_username" type="hidden" value="'.$this->html_safe($username).'" />'.
+                        '<button type="submit" class="btn btn-link p-0 text-danger border-0 user_delete" '.
+                        'title="'.$this->trans('Delete').'" aria-label="'.$this->trans('Delete').'" '.
+                        'onclick="if (typeof applyAccountsPageHandlers === \'function\') { return true; } return confirm('.htmlspecialchars(json_encode($confirm_msg), ENT_QUOTES, 'UTF-8').');">'.
+                        '<i class="bi bi-trash-fill"></i></button></form>';
+                }
+                $res .= '</td></tr>';
             }
-            $res .= '<td><form class="delete_user_form" action="'.$this->build_page_url('accounts').'" method="POST">'.
-                '<input type="hidden" name="hm_page_key" value="'.Hm_Request_Key::generate().'" />'.
-                '<input name="delete_username" type="hidden" value="'.
-                $this->html_safe($user['username']).'" /><input class="user_delete" type="submit" '.
-                'value=" X " /></form>';
-            $res .= ' '.$this->html_safe($user['username']).'</td>';
-            $count++;
-            if ($count == $width) {
-                $res .= '</tr>';
-                $count = 0;
-            }
+            $res .= '</tbody></table>';
         }
-        if ($count != $width) {
-            $res .= '</tr>';
-        }
-        $res .= '</table>';
+        $res .= '</div></div></div>';
+        $res .= '<div class="modal fade" id="confirmDeleteAccountModal" tabindex="-1" aria-labelledby="confirmDeleteAccountModalLabel" aria-hidden="true">'.
+            '<div class="modal-dialog">'.
+            '<div class="modal-content">'.
+            '<div class="modal-header">'.
+            '<h5 class="modal-title" id="confirmDeleteAccountModalLabel">'.$this->trans('Delete account').'</h5>'.
+            '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="'.$this->trans('Close').'"></button>'.
+            '</div>'.
+            '<div class="modal-body">'.
+            '<p class="mb-0" id="confirmDeleteAccountMessage"></p>'.
+            '</div>'.
+            '<div class="modal-footer">'.
+            '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'.$this->trans('Cancel').'</button>'.
+            '<button type="button" class="btn btn-danger" id="confirmDeleteAccountBtn">'.$this->trans('Delete').'</button>'.
+            '</div></div></div></div>';
+        $res .= '</div>';
         return $res;
     }
 }

--- a/modules/account/site.css
+++ b/modules/account/site.css
@@ -1,6 +1,3 @@
-.create_user { margin-top: 20px; margin-left: 10px; }
-.create_user input { clear: both; float: left; padding: 4px; margin-left: 20px; margin-top: 10px; margin-bottom: 10px; }
-.create_account_link { margin-left: 120px; float: left; clear: left; font-size: 115%; padding: 5px; }
-.user_list { padding-left: 40px; padding-top: 20px; }
-.user_list td {padding-bottom: 10px; }
-.user_list .user_delete { cursor: pointer; margin-right: 10px; }
+.accounts_page .user_list td {
+    vertical-align: middle;
+}

--- a/modules/account/site.js
+++ b/modules/account/site.js
@@ -1,5 +1,0 @@
-$(function() {
-    $('.delete_user_form').on('submit', function() {
-        return hm_delete_prompt();
-    });
-});

--- a/modules/core/navigation/routes.js
+++ b/modules/core/navigation/routes.js
@@ -89,6 +89,10 @@ const routes = [
         page: 'change_password'
     },
     {
+        page: 'accounts',
+        handler: 'applyAccountsPageHandlers'
+    },
+    {
         page: 'highlights',
         handler: 'applyHighlightsPageHandlers'
     },


### PR DESCRIPTION
## Summary
- The accounts page did not keep the side menu after SPA navigation.
- Create account and the existing-user list still used the old unstyled markup, so the page looked out of place next to the rest of the UI.
- Clicking the X next to a user deleted that account immediately, with no warning and no way to cancel.

Related issue: https://github.com/cypht-org/cypht/issues/2077