### PR TITLE
fix(module/smtp): scope attachment chunks to the current user

### DIFF
--- a/modules/smtp/modules.php
+++ b/modules/smtp/modules.php
@@ -264,9 +264,10 @@ class Hm_Handler_get_test_chunk extends Hm_Handler_Module {
         $resumable_identifier = trim(basename((string) ($this->request->get['resumableIdentifier'] ?? '')));
         $resumable_filename = trim(basename((string) ($this->request->get['resumableFilename'] ?? '')));
 
-        $expected_dir = $this->config->get('attachment_dir').'/chunks-'.$resumable_identifier;
-        $chunk_file = $expected_dir.'/'.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'];
-        if ($resumable_identifier !== '' && $resumable_filename !== ''
+        $user_dir = user_attachment_dir($this->config->get('attachment_dir'), $this->session->get('username', false));
+        $expected_dir = $user_dir ? $user_dir.DIRECTORY_SEPARATOR.'chunks-'.$resumable_identifier : '';
+        $chunk_file = $expected_dir !== '' ? $expected_dir.DIRECTORY_SEPARATOR.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'] : '';
+        if ($user_dir && $resumable_identifier !== '' && $resumable_filename !== ''
                 && dirname($chunk_file) === $expected_dir && file_exists($chunk_file)) {
             header("HTTP/1.0 200 Ok");
         } else {
@@ -283,11 +284,14 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
         $from = $this->request->get['draft_smtp'];
         $filepath = $this->config->get('attachment_dir');
 
-        $userpath = md5($this->session->get('username', false));
+        $user_dir = user_attachment_dir($filepath, $this->session->get('username', false));
+        if (!$user_dir) {
+            Hm_Msgs::add('Invalid upload request', 'danger');
+            return;
+        }
 
-        // create the attachment folder for the profile to avoid
-        if (!is_dir($filepath.'/'.$userpath)) {
-            mkdir($filepath.'/'.$userpath, 0777, true);
+        if (!is_dir($user_dir)) {
+            mkdir($user_dir, 0700, true);
         }
 
         $resumable_identifier = trim(basename((string) ($this->request->get['resumableIdentifier'] ?? '')));
@@ -299,8 +303,8 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
                 continue;
             }
 
-            $temp_dir = $filepath.'/'.$userpath.'/chunks-'.$resumable_identifier;
-            $dest_file = $temp_dir.'/'.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'];
+            $temp_dir = $user_dir.DIRECTORY_SEPARATOR.'chunks-'.$resumable_identifier;
+            $dest_file = $temp_dir.DIRECTORY_SEPARATOR.$resumable_filename.'.part'.$this->request->get['resumableChunkNumber'];
 
             if ($resumable_identifier === '' || $resumable_filename === ''
                     || dirname($dest_file) !== $temp_dir) {
@@ -308,9 +312,8 @@ class Hm_Handler_upload_chunk extends Hm_Handler_Module {
                 continue;
             }
 
-            // create the temporary directory
             if (!is_dir($temp_dir)) {
-                mkdir($temp_dir, 0777, true);
+                mkdir($temp_dir, 0700, true);
             }
 
             // move the temporary file
@@ -904,7 +907,9 @@ class Hm_Handler_process_enable_attachment_reminder_setting extends Hm_Handler_M
  */
 class Hm_Handler_attachment_dir extends Hm_Handler_Module {
     public function process() {
-        $this->out('attachment_dir', $this->config->get('attachment_dir'));
+        $attachment_dir = $this->config->get('attachment_dir');
+        $this->out('attachment_dir', $attachment_dir);
+        $this->out('user_attachment_dir', user_attachment_dir($attachment_dir, $this->session->get('username', false)));
     }
 }
 
@@ -913,17 +918,9 @@ class Hm_Handler_attachment_dir extends Hm_Handler_Module {
  */
 class Hm_Handler_clear_attachment_chunks extends Hm_Handler_Module {
     public function process() {
-        $attachment_dir = $this->config->get('attachment_dir');
-        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($attachment_dir));
-        foreach ($rii as $file) {
-            if ($file->getFilename() == '.' || $file->getFilename() == '..') {
-                continue;
-            }
-            if (is_dir($file->getPath()) && $file->getPath() != $attachment_dir){
-                if (mb_strpos($file->getPath(), 'chunks-') !== False) {
-                    rrmdir($file->getPath());
-                }
-            }
+        $user_dir = user_attachment_dir($this->config->get('attachment_dir'), $this->session->get('username', false));
+        foreach (user_attachment_chunk_dirs($user_dir) as $chunk_dir) {
+            rrmdir($chunk_dir);
         }
         Hm_Msgs::add('Attachment chunks cleaned');
     }
@@ -961,27 +958,7 @@ class Hm_Output_enable_compose_delivery_receipt_setting extends Hm_Output_Module
  */
 class Hm_Output_attachment_setting extends Hm_Output_Module {
     protected function output() {
-        $size_in_kbs = 0;
-        $num_chunks = 0;
-        if (!is_dir($this->get('attachment_dir'))) {
-            return;
-        }
-        $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->get('attachment_dir')));
-        $files = array();
-
-        foreach ($rii as $file) {
-            if ($file->getFilename() == '.' || $file->getFilename() == '..') {
-                continue;
-            }
-            if ($file->isDir()){
-                continue;
-            }
-            if (mb_strpos($file->getPathname(), '.part') !== False) {
-                $num_chunks++;
-                $size_in_kbs += filesize($file->getPathname());
-                $files[] = $file->getPathname();
-            }
-        }
+        list($num_chunks, $size_in_kbs) = count_user_attachment_chunk_parts($this->get('user_attachment_dir'));
         if ($size_in_kbs > 0) {
             $size_in_kbs = round(($size_in_kbs / 1024), 2);
         }
@@ -2076,6 +2053,83 @@ function parse_uploaded_files_list($raw) {
         $safe[] = $name;
     }
     return $safe;
+}}
+
+/**
+ * Per-user attachment directory: attachment_dir/md5(username).
+ * Returns false if the username or base path is missing, or the path would escape the base.
+ * @subpackage smtp/functions
+ * @param string $attachment_dir
+ * @param mixed $username
+ * @return string|false
+ */
+if (!hm_exists('user_attachment_dir')) {
+function user_attachment_dir($attachment_dir, $username) {
+    if (!is_string($username) || $username === '' || !is_string($attachment_dir) || $attachment_dir === '') {
+        return false;
+    }
+    $base = rtrim($attachment_dir, '/\\');
+    if ($base === '') {
+        return false;
+    }
+    $dir = $base.DIRECTORY_SEPARATOR.md5($username);
+    if (dirname($dir) !== $base) {
+        return false;
+    }
+    return $dir;
+}}
+
+/**
+ * Immediate chunk directories under a per-user attachment folder.
+ * @subpackage smtp/functions
+ * @param string|false $user_dir
+ * @return array
+ */
+if (!hm_exists('user_attachment_chunk_dirs')) {
+function user_attachment_chunk_dirs($user_dir) {
+    $dirs = [];
+    if (!is_string($user_dir) || $user_dir === '' || !is_dir($user_dir)) {
+        return $dirs;
+    }
+    $user_dir = rtrim($user_dir, '/\\');
+    $entries = @scandir($user_dir);
+    if (!is_array($entries)) {
+        return $dirs;
+    }
+    foreach ($entries as $entry) {
+        if ($entry === '.' || $entry === '..' || !str_starts_with($entry, 'chunks-')) {
+            continue;
+        }
+        $path = $user_dir.DIRECTORY_SEPARATOR.$entry;
+        if (is_dir($path) && dirname($path) === $user_dir) {
+            $dirs[] = $path;
+        }
+    }
+    return $dirs;
+}}
+
+/**
+ * Count in-progress .part files for one user only.
+ * @subpackage smtp/functions
+ * @param string|false $user_dir
+ * @return array{0:int,1:int}
+ */
+if (!hm_exists('count_user_attachment_chunk_parts')) {
+function count_user_attachment_chunk_parts($user_dir) {
+    $num_chunks = 0;
+    $size_in_bytes = 0;
+    foreach (user_attachment_chunk_dirs($user_dir) as $chunk_dir) {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($chunk_dir, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $file) {
+            if ($file->isFile() && mb_strpos($file->getFilename(), '.part') !== false) {
+                $num_chunks++;
+                $size_in_bytes += $file->getSize();
+            }
+        }
+    }
+    return [$num_chunks, $size_in_bytes];
 }}
 
 /**

--- a/tests/phpunit/modules/smtp/attachment_chunks.php
+++ b/tests/phpunit/modules/smtp/attachment_chunks.php
@@ -1,0 +1,133 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Clear Chunks and the settings counter must stay inside the current
+ * user's attachment directory. Assembled files must not be deleted.
+ *
+ * These tests load modules/smtp/modules.php, which defines Hm_SMTP_List.
+ * Other suites already define a mock of that class via helpers.php in this
+ * process, so this class must run isolated with global state discarded.
+ *
+ * @runClassInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+class Hm_Test_Smtp_Attachment_Chunks extends TestCase {
+
+    private $attachment_dir;
+    private $alice_dir;
+    private $bob_dir;
+
+    public function setUp(): void {
+        require_once APP_PATH.'modules/smtp/modules.php';
+        $this->attachment_dir = sys_get_temp_dir().'/cypht-chunk-test-'.bin2hex(random_bytes(8));
+        mkdir($this->attachment_dir, 0700, true);
+        $this->alice_dir = user_attachment_dir($this->attachment_dir, 'alice');
+        $this->bob_dir = user_attachment_dir($this->attachment_dir, 'bob');
+        mkdir($this->alice_dir, 0700, true);
+        mkdir($this->bob_dir, 0700, true);
+    }
+
+    public function tearDown(): void {
+        if (is_dir($this->attachment_dir)) {
+            $this->rrmdir($this->attachment_dir);
+        }
+    }
+
+    public function test_user_attachment_dir_is_md5_child_of_base() {
+        $this->assertSame($this->attachment_dir.DIRECTORY_SEPARATOR.md5('alice'), $this->alice_dir);
+        $this->assertNotSame($this->alice_dir, $this->bob_dir);
+        $this->assertFalse(user_attachment_dir($this->attachment_dir, ''));
+        $this->assertFalse(user_attachment_dir($this->attachment_dir, false));
+        $this->assertFalse(user_attachment_dir('', 'alice'));
+    }
+
+    public function test_count_only_includes_current_user_part_files() {
+        $this->seedPausedUpload($this->alice_dir, 'chunks-alice-upload', 'big.bin', 2048);
+        $this->seedPausedUpload($this->bob_dir, 'chunks-bob-upload', 'other.bin', 4096);
+        file_put_contents($this->alice_dir.'/assembled.bin', str_repeat('A', 512));
+        file_put_contents($this->alice_dir.'/orphan.part1', 'should-not-count');
+        mkdir($this->attachment_dir.'/chunks-global', 0700, true);
+        file_put_contents($this->attachment_dir.'/chunks-global/leaked.part1', 'global');
+
+        list($alice_count, $alice_bytes) = count_user_attachment_chunk_parts($this->alice_dir);
+        list($bob_count, $bob_bytes) = count_user_attachment_chunk_parts($this->bob_dir);
+
+        $this->assertSame(1, $alice_count);
+        $this->assertSame(2048, $alice_bytes);
+        $this->assertSame(1, $bob_count);
+        $this->assertSame(4096, $bob_bytes);
+        $this->assertSame([0, 0], count_user_attachment_chunk_parts(false));
+        $this->assertSame([0, 0], count_user_attachment_chunk_parts($this->attachment_dir.'/missing'));
+    }
+
+    public function test_clear_only_removes_current_user_chunk_dirs() {
+        $this->seedPausedUpload($this->alice_dir, 'chunks-alice-upload', 'big.bin', 2048);
+        $this->seedPausedUpload($this->alice_dir, 'chunks-alice-upload_UNUSED', 'stale.bin', 128);
+        $this->seedPausedUpload($this->bob_dir, 'chunks-bob-upload', 'other.bin', 4096);
+        file_put_contents($this->alice_dir.'/assembled.bin', 'keep-me');
+        mkdir($this->attachment_dir.'/chunks-global', 0700, true);
+        file_put_contents($this->attachment_dir.'/chunks-global/leaked.part1', 'global');
+
+        foreach (user_attachment_chunk_dirs($this->alice_dir) as $chunk_dir) {
+            rrmdir($chunk_dir);
+        }
+
+        $this->assertDirectoryDoesNotExist($this->alice_dir.'/chunks-alice-upload');
+        $this->assertDirectoryDoesNotExist($this->alice_dir.'/chunks-alice-upload_UNUSED');
+        $this->assertFileExists($this->alice_dir.'/assembled.bin');
+        $this->assertSame('keep-me', file_get_contents($this->alice_dir.'/assembled.bin'));
+        $this->assertDirectoryExists($this->bob_dir.'/chunks-bob-upload');
+        $this->assertFileExists($this->bob_dir.'/chunks-bob-upload/other.bin.part1');
+        $this->assertDirectoryExists($this->attachment_dir.'/chunks-global');
+        $this->assertSame([0, 0], count_user_attachment_chunk_parts($this->alice_dir));
+        $this->assertSame(1, count_user_attachment_chunk_parts($this->bob_dir)[0]);
+    }
+
+    public function test_settings_output_counts_parts_without_bool_typecast() {
+        $this->seedPausedUpload($this->alice_dir, 'chunks-alice-upload', 'matt_test.pdf', 2048);
+        $mod = new Hm_Output_attachment_setting(array('user_attachment_dir' => $this->alice_dir), array());
+        $html = $mod->output_content('Hm_Format_HTML5', array());
+        $this->assertStringContainsString('(1 Chunks) 2 KB', $html);
+    }
+
+    public function test_chunk_dirs_are_immediate_children_named_chunks() {
+        mkdir($this->alice_dir.'/not-chunks', 0700, true);
+        file_put_contents($this->alice_dir.'/not-chunks/x.part1', 'nope');
+        mkdir($this->alice_dir.'/nested', 0700, true);
+        mkdir($this->alice_dir.'/nested/chunks-hidden', 0700, true);
+        file_put_contents($this->alice_dir.'/nested/chunks-hidden/y.part1', 'hidden');
+        $this->seedPausedUpload($this->alice_dir, 'chunks-real', 'z.bin', 16);
+
+        $dirs = user_attachment_chunk_dirs($this->alice_dir);
+        $this->assertCount(1, $dirs);
+        $this->assertSame($this->alice_dir.DIRECTORY_SEPARATOR.'chunks-real', $dirs[0]);
+        $this->assertSame(1, count_user_attachment_chunk_parts($this->alice_dir)[0]);
+    }
+
+    private function seedPausedUpload($user_dir, $chunk_dirname, $filename, $bytes) {
+        $dir = $user_dir.'/'.$chunk_dirname;
+        mkdir($dir, 0700, true);
+        file_put_contents($dir.'/'.$filename.'.part1', str_repeat('x', $bytes));
+    }
+
+    private function rrmdir($dir) {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir.'/'.$item;
+            if (is_dir($path)) {
+                $this->rrmdir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -175,6 +175,9 @@
     <testsuite name="modules_ldap_contacts">
       <file>./modules/ldap_contacts/ldap_contacts.php</file>
     </testsuite>
+    <testsuite name="modules_smtp">
+      <file>./modules/smtp/attachment_chunks.php</file>
+    </testsuite>
     <testsuite name="mta_sts">
       <file>./mta_sts.php</file>
     </testsuite>


### PR DESCRIPTION
## Issues

Clear Chunks and the Settings attachment counter operated on the whole ATTACHMENT_DIR. Any logged-in user could see other people's in-progress upload volume and wipe their paused chunks.

- **Clear Chunks deletes other users' uploads.** Settings → Clear Chunks  walked every `chunks-*` directory under ATTACHMENT_DIR. User B could  remove User A's paused resumable parts. Assembled files in the user  folder were not deleted; in-progress/paused chunks were.

- **Settings leaks other users' chunk volume.** The Attachment Chunks  row summed every `.part` file in ATTACHMENT_DIR. Filenames and  usernames were not shown, but any session could see `(N Chunks) X KB`  for the whole site.

- **Resume misses chunks written under the user directory.** Uploads go  to `attachment_dir/md5(username)/chunks-…`. The resume existence check  still looked at `attachment_dir/chunks-…`, so a paused attachment could  404 even though the parts were on disk.

- **Chunk directories were created world-readable.** New dirs used mode  `0777` (typically `0755` after umask), so other local Unix accounts  could enter a user's paused upload folder.
