### PR TITLE
chore(backend): allow isolated execution of handler and output modules

### DIFF
--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -165,8 +165,9 @@ class Hm_Dispatch {
     /**
      * Setup object needed to process a request
      * @param object $config site configuration
+     * @param bool $do_it set to false to not process the request immediately
      */
-    public function __construct($config) {
+    public function __construct($config, $do_it = true) {
 
         /* get the site config defined in the config/app.php file */
         $this->site_config = $config;
@@ -185,7 +186,9 @@ class Hm_Dispatch {
         $this->request = new Hm_Request($this->module_exec->filters, $config);
 
         /* do it */
-        $this->process_request();
+        if ($do_it) {
+            $this->process_request();
+        }
     }
 
     /**
@@ -344,6 +347,68 @@ class Hm_Dispatch {
         }
         $this->module_exec->page = $this->page;
         Hm_Debug::add('Page ID: '.$this->page, 'info');
+    }
+
+    /**
+     * Process a handler module in an isolated context
+     * @param string $module_name module name to process
+     * @param array $request_get GET request data to pass to the handler module
+     * @param array $request_post POST request data to pass to the handler module
+     * @return array output from the module
+     */
+    public function process_handler_module($module_name, $request_get = [], $request_post = []) {
+        $this->module_exec->load_module_set_files(['core', Hm_Handler_Modules::get_module_source($module_name)], $this->site_config->get_modules());
+
+        $this->request->post = $request_post;
+        $this->request->get = $request_get;
+
+        $res = $this->module_exec->run_handler_module([], [], $module_name, [], $this->session);
+
+        return $res[0];
+    }
+
+    /**
+     * Process an output module in an isolated context
+     * @param string $module_name module name to process
+     * @param array $input data to pass to the output module
+     * @return array output from the module
+     */
+    public function process_output_module($module_name, $input) {
+        $this->module_exec->load_module_set_files(
+            ['core', Hm_Output_Modules::get_module_source($module_name)],
+            $this->site_config->get_modules()
+        );
+
+        $res = $this->module_exec->run_output_module(
+            $input,
+            [],
+            $module_name,
+            [],
+            $this->session,
+            $this->request->format,
+            $this->module_exec->get_current_language()
+        );
+
+        return $res[0];
+    }
+
+    /**
+     * Process many output modules with the same handler module as data source in an isolated context
+     * @param array $output_modules list of output modules to process
+     * @param string $handler_module module name to process
+     * @param array $request_get GET request data to pass to the handler module
+     * @param array $request_post POST request data to pass to the handler module
+     * @return array output from the modules
+     */
+    public function process_output_modules_with_handler($output_modules, $handler_module, $request_get = [], $request_post = []) {
+        $handler_output = $this->process_handler_module($handler_module, $request_get, $request_post);
+
+        $output = [];
+        foreach ($output_modules as $output_module) {
+            $output[$output_module] = $this->process_output_module($output_module, $handler_output);
+        }
+
+        return $output;
     }
 
     /**

--- a/lib/dispatch.php
+++ b/lib/dispatch.php
@@ -357,10 +357,17 @@ class Hm_Dispatch {
      * @return array output from the module
      */
     public function process_handler_module($module_name, $request_get = [], $request_post = []) {
-        $this->module_exec->load_module_set_files(['core', Hm_Handler_Modules::get_module_source($module_name)], $this->site_config->get_modules());
+        // Define global constants if they are not already defined
+        Hm_Environment::getInstance()->define_default_constants($this->site_config);
+
+        $this->module_exec->load_module_set_files(['core', $this->get_module_source($module_name)], $this->site_config->get_modules());
 
         $this->request->post = $request_post;
         $this->request->get = $request_get;
+
+        $this->module_exec->request = $this->request;
+        $this->module_exec->session = $this->session;
+        $this->module_exec->cache = (new Hm_Cache_Setup($this->site_config, $this->session))->setup_cache();
 
         $res = $this->module_exec->run_handler_module([], [], $module_name, [], $this->session);
 
@@ -374,8 +381,11 @@ class Hm_Dispatch {
      * @return array output from the module
      */
     public function process_output_module($module_name, $input) {
+        // Define global constants if they are not already defined
+        Hm_Environment::getInstance()->define_default_constants($this->site_config);
+        
         $this->module_exec->load_module_set_files(
-            ['core', Hm_Output_Modules::get_module_source($module_name)],
+            ['core', $this->get_module_source($module_name)],
             $this->site_config->get_modules()
         );
 
@@ -390,6 +400,37 @@ class Hm_Dispatch {
         );
 
         return $res[0];
+    }
+
+    /**
+     * Get the source of a given module from the dynamically generated list through config/dynamic.php
+     * @param string $module_name module name to look up
+     * @return string|false module source or false if not found
+     */
+    private function get_module_source($module_name) {
+        $handlers = $this->site_config->get('handler_modules', []);
+        $outputs = $this->site_config->get('output_modules', []);
+        $all_modules = array_merge(array_merge(...array_values($handlers)), array_merge(...array_values($outputs)));
+
+        foreach ($all_modules as $module => $args) {
+            if ($module === $module_name) {
+                return $args[0];
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Load the required module sets files. Useful when processing modules in an isolated context.
+     * @param array $module_sets list of module sets to load
+     * @return void
+     */
+    public function load_required_module_sets($module_sets) {
+        // Define global constants if they are not already defined
+        Hm_Environment::getInstance()->define_default_constants($this->site_config);
+        
+        $this->module_exec->load_module_set_files(['core', ...$module_sets], $this->site_config->get_modules());
     }
 
     /**

--- a/lib/modules.php
+++ b/lib/modules.php
@@ -333,6 +333,15 @@ trait Hm_Modules {
     public static function dump() {
         return self::$module_list;
     }
+
+    public static function get_module_source($module) {
+        foreach (self::$module_list as $page => $modules) {
+            if (array_key_exists($module, $modules)) {
+                return $modules[$module][0];
+            }
+        }
+        return false;
+    }
 }
 
 /**

--- a/lib/modules.php
+++ b/lib/modules.php
@@ -333,15 +333,6 @@ trait Hm_Modules {
     public static function dump() {
         return self::$module_list;
     }
-
-    public static function get_module_source($module) {
-        foreach (self::$module_list as $page => $modules) {
-            if (array_key_exists($module, $modules)) {
-                return $modules[$module][0];
-            }
-        }
-        return false;
-    }
 }
 
 /**


### PR DESCRIPTION
This PR provides a simple way to run individual modules without necessarily running the entire app. An integration can simulate the necessary components of a module (configuration, request data, etc.), pass them to the caller, and receive real output.

This is leveraged by [Tiki](https://gitlab.com/tikiwiki/tiki/-/merge_requests/11072).