### PR TITLE
fix(module/tags): add-label dialog fails when no labels exist

### DIFF
--- a/modules/tags/output_modules.php
+++ b/modules/tags/output_modules.php
@@ -112,9 +112,9 @@ class Hm_Output_tags extends hm_output_module {
             $this->flatten_tags($folderTree, 0, $flat);
             $res .= '<script type="application/json" class="tags_json_data">'.
                 json_encode($flat, JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP).'</script>';
-            $res .= '<script type="application/json" class="tags_palette_data">'.
-                json_encode(Hm_Tags::colorPalette(), JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP).'</script>';
         }
+        $res .= '<script type="application/json" class="tags_palette_data">'.
+            json_encode(Hm_Tags::colorPalette(), JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP).'</script>';
         $res .= '<li class="tags_add_new"><a href="#" class="tag_add_new_btn">';
         if (!$this->get('hide_folder_icons')) {
             $res .= '<i class="bi bi-plus-square menu-icon"></i>';

--- a/modules/tags/site.js
+++ b/modules/tags/site.js
@@ -113,7 +113,7 @@ var show_tag_form_modal = function(tag) {
     var isEdit = !!tag.id;
     var parentTag = tag.parent ? get_tags_json_data().find(function(t) { return t.id === tag.parent; }) : null;
     var palette = get_tags_palette_data();
-    var currentColor = tag.color || palette[0];
+    var currentColor = tag.color || palette[0] || '#5f6368'; //same as Hm_Tags::defaultColor()
     var modal = new Hm_Modal({
         modalId: 'tagFormModal',
         title: tag_modal_icon('bi-tag-fill') + (isEdit ? hm_trans('Edit label') : hm_trans('Create new label'))

--- a/tests/phpunit/modules/tags/output_modules.php
+++ b/tests/phpunit/modules/tags/output_modules.php
@@ -25,6 +25,11 @@ class Hm_Test_Tags_Output_Modules extends TestCase {
         $this->assertEquals('tags_folders', $sources[0][0]);
         $this->assertStringContainsString('tag_add_new_btn', $sources[0][1]);
         $this->assertStringNotContainsString('tag_row', $sources[0][1]);
+        $this->assertStringContainsString('tags_palette_data', $sources[0][1]);
+        $this->assertStringNotContainsString('tags_json_data', $sources[0][1]);
+        foreach (Hm_Tags::colorPalette() as $color) {
+            $this->assertStringContainsString($color, $sources[0][1]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

When an account has no labels yet, clicking **Add label** does not open the create dialog. The console shows: `Uncaught TypeError: $(...).text(...).html is not a function` 

Related to this discussion https://matrix.to/#/!SeNiIGzqZwRjAclUCr:gitter.im/$JbSBNU2wBsTYgTmRQr-UPePxWc1CaXAYBVUNrSTgNZ0?via=gitter.im&via=matrix.org&via=thicket.au
