### PR TITLE
chore(docs): track policies that the source code is based on in a machine-readable format

### DIFF
--- a/.github/workflows/policy-cases.yml
+++ b/.github/workflows/policy-cases.yml
@@ -1,0 +1,31 @@
+name: Validate policy cases
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Policy cases
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Validate policy cases
+        run: php scripts/validate_policy_cases.php

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,12 @@ Example:
 
 **Write Automated tests (for the new feature... if possible)**
 
+When an automated test protects an externally observable, security, privacy,
+data-protection, or project-process requirement, record its normalized cases in
+[docs/policy-cases.json](docs/policy-cases.json). See
+[docs/policy-cases.md](docs/policy-cases.md) for the decision rule and the
+required case format. Internal implementation tests do not need a policy entry.
+
 6. Run automated tests (if possible)
 
  - Unit Tests and integration tests with PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "zbateson/mail-mime-parser": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5.62"
+        "phpunit/phpunit": "^10.5.62",
+        "opis/json-schema": "^2.4"
     },
     "suggest": {
         "ext-pdo": "To use database features, this needs to be installed",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e46b68e16ee25231ea6c65e7a0b33ef2",
+    "content-hash": "c208df0cb8889dccd04d662f09ecd3f1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3222,6 +3222,196 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -4775,7 +4965,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4789,9 +4979,9 @@
         "ext-session": "*",
         "php": ">=8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docs/policy-cases.json
+++ b/docs/policy-cases.json
@@ -4,6 +4,9 @@
       "id": "user-settings-persistence",
       "title": "User settings persistence",
       "description": "Saving settings without permanently persisting them, permanently saving them, and saving them while logging out.",
+      "tests": [
+        "Hm_Test_Core_Handler_Modules::test_process_save_form"
+      ],
       "cases": [
         {
           "id": "session-only-save",
@@ -56,6 +59,9 @@
       "id": "message-external-resource-blocking",
       "title": "Message external-resource blocking",
       "description": "Remote resources in message HTML are not loaded or retained as active resources.",
+      "tests": [
+        "Hm_Test_Core_Message_Functions::test_sanitize_email_html_blocks_css_tracking"
+      ],
       "cases": [
         {
           "id": "block-css-tracking-resource",
@@ -84,6 +90,9 @@
       "id": "http-security-headers",
       "title": "Restrictive HTTP security headers",
       "description": "Secure response headers are emitted by default and external images remain blocked unless explicitly enabled.",
+      "tests": [
+        "Hm_Test_Core_Handler_Modules::test_http_headers"
+      ],
       "cases": [
         {
           "id": "tls-ajax-default-image-policy",
@@ -129,6 +138,9 @@
       "id": "brute-force-protection",
       "title": "Brute-force protection",
       "description": "Failed-login tracking uses non-reversible identifiers and locks an identifier after the configured threshold.",
+      "tests": [
+        "Hm_Test_Brute_Force_Handler_Modules::test_make_key_returns_consistent_hash"
+      ],
       "cases": [
         {
           "id": "hash-login-attempt-identifier",

--- a/docs/policy-cases.json
+++ b/docs/policy-cases.json
@@ -47,7 +47,6 @@
           },
           "expected": {
             "messages": [
-              "Settings saved",
               "Saved user data on logout",
               "Session destroyed on logout"
             ]

--- a/docs/policy-cases.json
+++ b/docs/policy-cases.json
@@ -1,0 +1,150 @@
+{
+  "policies": [
+    {
+      "id": "user-settings-persistence",
+      "title": "User settings persistence",
+      "description": "Saving settings without permanently persisting them, permanently saving them, and saving them while logging out.",
+      "cases": [
+        {
+          "id": "session-only-save",
+          "description": "A normal settings save does not report permanent persistence.",
+          "input": {
+            "post": {
+              "save_settings": true,
+              "password": "foo"
+            }
+          },
+          "expected": {
+            "messages": []
+          }
+        },
+        {
+          "id": "permanent-save",
+          "description": "A permanent settings save reports that settings were saved.",
+          "input": {
+            "post": {
+              "save_settings_permanently": 1,
+              "save_settings": true,
+              "password": "foo"
+            }
+          },
+          "expected": {
+            "messages": ["Settings saved"]
+          }
+        },
+        {
+          "id": "permanent-save-and-logout",
+          "description": "A permanent settings save followed by logout reports both operations.",
+          "input": {
+            "post": {
+              "save_settings_permanently_then_logout": 1,
+              "save_settings": true,
+              "password": "foo"
+            }
+          },
+          "expected": {
+            "messages": [
+              "Settings saved",
+              "Saved user data on logout",
+              "Session destroyed on logout"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "message-external-resource-blocking",
+      "title": "Message external-resource blocking",
+      "description": "Remote resources in message HTML are not loaded or retained as active resources.",
+      "cases": [
+        {
+          "id": "block-css-tracking-resource",
+          "description": "A remote CSS tracking resource is removed before rendering.",
+          "input": {
+            "html": "<ul style=\"list-style-image: url(https://tracker.example.com/test)\"><li>x</li></ul>"
+          },
+          "expected": {
+            "blocked_count": 1,
+            "must_not_contain": "tracker.example.com"
+          }
+        },
+        {
+          "id": "block-background-tracking-resource",
+          "description": "A remote background tracking resource is removed before rendering.",
+          "input": {
+            "html": "<div style=\"background: url(https://tracker.example.com/bg)\">x</div>"
+          },
+          "expected": {
+            "must_not_contain": "tracker.example.com"
+          }
+        }
+      ]
+    },
+    {
+      "id": "http-security-headers",
+      "title": "Restrictive HTTP security headers",
+      "description": "Secure response headers are emitted by default and external images remain blocked unless explicitly enabled.",
+      "cases": [
+        {
+          "id": "tls-ajax-default-image-policy",
+          "description": "TLS AJAX responses include HSTS, JSON content type, and a same-origin image policy.",
+          "input": {
+            "tls": true,
+            "request_type": "AJAX",
+            "language": "English",
+            "config": {}
+          },
+          "expected": {
+            "headers": {
+              "Content-Language": "En",
+              "Strict-Transport-Security": "max-age=31536000",
+              "X-Frame-Options": "SAMEORIGIN",
+              "X-XSS-Protection": "1; mode=block",
+              "X-Content-Type-Options": "nosniff",
+              "Content-Security-Policy": "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;",
+              "Content-Type": "application/json"
+            }
+          }
+        },
+        {
+          "id": "explicit-external-image-policy",
+          "description": "External image sources are allowed only when the administrator enables the setting.",
+          "input": {
+            "tls": true,
+            "request_type": "AJAX",
+            "language": "English",
+            "config": {
+              "allow_external_image_sources": true
+            }
+          },
+          "expected": {
+            "headers": {
+              "Content-Security-Policy": "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src * data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "brute-force-protection",
+      "title": "Brute-force protection",
+      "description": "Failed-login tracking uses non-reversible identifiers and locks an identifier after the configured threshold.",
+      "cases": [
+        {
+          "id": "hash-login-attempt-identifier",
+          "description": "The tracker namespaces and hashes identifiers instead of storing the raw value.",
+          "input": {
+            "prefix": "ip",
+            "value": "127.0.0.1",
+            "different_value": "10.0.0.1"
+          },
+          "expected": {
+            "same_value_same_key": true,
+            "different_value_different_key": true,
+            "key_must_not_contain": "127.0.0.1"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/policy-cases.md
+++ b/docs/policy-cases.md
@@ -32,9 +32,19 @@ remain ordinary tests unless the project has adopted them as requirements.
 6. Run the focused PHPUnit test and validate the JSON against
    [policy-cases.schema.json](policy-cases.schema.json).
 
-A case should describe the behavior in domain terms where possible. Test
-adapters may translate the normalized `input` and `expected` objects into
-HTTP requests, handler inputs, or other framework-specific values.
+Run the repository validator with:
+
+```bash
+php scripts/validate_policy_cases.php
+```
+
+The validator checks the JSON Schema, duplicate policy and case IDs, and that
+each test reference declared by a policy points to a PHPUnit class and method
+under `tests/`.
+
+A case should describe the behavior in domain terms where possible. The
+PHPUnit test translates the normalized `input` and `expected` objects into the
+framework-specific values needed by the test.
 
 ## Example
 
@@ -62,6 +72,5 @@ HTTP requests, handler inputs, or other framework-specific values.
 }
 ```
 
-The `tests` metadata makes ownership explicit. It is deliberately separate
-from the test adapter so a policy can later be covered by PHPUnit, Selenium,
-or another executable test without changing the policy vocabulary.
+The `tests` metadata makes PHPUnit ownership explicit. Each entry must name a
+PHPUnit class and method under `tests/`.

--- a/docs/policy-cases.md
+++ b/docs/policy-cases.md
@@ -1,0 +1,67 @@
+# Policy cases
+
+[policy-cases.json](policy-cases.json) is the machine-readable collection of
+Cypht behaviors that are treated as policies and verified by tests.
+
+## When to add a policy case
+
+Add a policy entry when a test protects a requirement that users, operators,
+mail recipients, or security reviewers should be able to rely on. In practice,
+the behavior should be at least one of these:
+
+- externally observable application behavior;
+- a security, privacy, or data-protection invariant;
+- a user or administrator control with a defined safety guarantee; or
+- a project process requirement that is explicitly adopted by Cypht.
+
+Do not add an entry for every PHPUnit test. Repository helpers, internal data
+structures, mock behavior, parser mechanics, and other implementation details
+remain ordinary tests unless the project has adopted them as requirements.
+
+## Adding an entry
+
+1. Decide whether the behavior is a policy rather than an implementation detail.
+2. Add or update a policy object in [policy-cases.json](policy-cases.json).
+3. Give the policy a unique kebab-case `id`, a `title`, a concise
+   `description`, and a `tests` array naming the PHPUnit test methods that
+   execute it.
+4. Add cases with unique kebab-case `id` values, a description, an `input`
+   object, and an `expected` object.
+5. Change the relevant test to obtain its cases through
+   `PolicyCases::forPolicy()`.
+6. Run the focused PHPUnit test and validate the JSON against
+   [policy-cases.schema.json](policy-cases.schema.json).
+
+A case should describe the behavior in domain terms where possible. Test
+adapters may translate the normalized `input` and `expected` objects into
+HTTP requests, handler inputs, or other framework-specific values.
+
+## Example
+
+```json
+{
+  "id": "message-external-resource-blocking",
+  "title": "Message external-resource blocking",
+  "description": "Remote resources in message HTML are not loaded automatically.",
+  "tests": [
+    "Hm_Test_Core_Message_Functions::test_sanitize_email_html_blocks_css_tracking"
+  ],
+  "cases": [
+    {
+      "id": "block-css-tracking-resource",
+      "description": "A remote CSS tracking resource is removed before rendering.",
+      "input": {
+        "html": "<ul style=\"list-style-image: url(https://tracker.example/test)\"><li>x</li></ul>"
+      },
+      "expected": {
+        "blocked_count": 1,
+        "must_not_contain": "tracker.example"
+      }
+    }
+  ]
+}
+```
+
+The `tests` metadata makes ownership explicit. It is deliberately separate
+from the test adapter so a policy can later be covered by PHPUnit, Selenium,
+or another executable test without changing the policy vocabulary.

--- a/docs/policy-cases.schema.json
+++ b/docs/policy-cases.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Cypht policy cases",
+  "type": "object",
+  "required": ["policies"],
+  "properties": {
+    "policies": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/policy" },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "policy": {
+      "type": "object",
+      "required": ["id", "title", "description", "tests", "cases"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "tests": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "cases": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/case" },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "case": {
+      "type": "object",
+      "required": ["id", "description", "input", "expected"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "description": { "type": "string", "minLength": 1 },
+        "input": { "type": "object" },
+        "expected": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    }
+  }
+}

--- a/scripts/validate_policy_cases.php
+++ b/scripts/validate_policy_cases.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * CLI script to validate policy cases against the schema and test references
+ */
+
+use Opis\JsonSchema\Validator;
+
+if (mb_strtolower(php_sapi_name()) !== 'cli') {
+    die("Must be run from the command line\n");
+}
+
+define('APP_PATH', dirname(dirname(__FILE__)).'/');
+require APP_PATH.'lib/define_vendor_path.php';
+
+$policy_path = APP_PATH.'/docs/policy-cases.json';
+$schema_path = APP_PATH.'/docs/policy-cases.schema.json';
+
+require_once VENDOR_PATH.'/autoload.php';
+
+function load_json_file($path) {
+    if (!is_readable($path)) {
+        throw new RuntimeException('File is not readable: '.$path);
+    }
+    return json_decode(file_get_contents($path), false, 512, JSON_THROW_ON_ERROR);
+}
+
+function policy_test_exists($test_reference) {
+    if (!preg_match('/^([A-Za-z0-9_]+)::([A-Za-z0-9_]+)$/', $test_reference, $matches)) {
+        return false;
+    }
+    $needle = 'class '.$matches[1];
+    $method = 'function '.$matches[2];
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(APP_PATH.'/tests'));
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+        $contents = file_get_contents($file->getPathname());
+        if (strpos($contents, $needle) !== false && strpos($contents, $method) !== false) {
+            return true;
+        }
+    }
+    return false;
+}
+
+try {
+    $policy_data = load_json_file($policy_path);
+    $schema = load_json_file($schema_path);
+    $validator = new Validator(null, 20, false);
+    $result = $validator->validate($policy_data, $schema);
+
+    if (!$result->isValid()) {
+        throw new RuntimeException('Schema validation failed: '.$result);
+    }
+
+    $policy_ids = array();
+    foreach ($policy_data->policies as $policy) {
+        if (isset($policy_ids[$policy->id])) {
+            throw new RuntimeException('Duplicate policy ID: '.$policy->id);
+        }
+        $policy_ids[$policy->id] = true;
+
+        $case_ids = array();
+        foreach ($policy->cases as $case) {
+            if (isset($case_ids[$case->id])) {
+                throw new RuntimeException('Duplicate case ID in '.$policy->id.': '.$case->id);
+            }
+            $case_ids[$case->id] = true;
+        }
+
+        foreach ($policy->tests as $test_reference) {
+            if (!policy_test_exists($test_reference)) {
+                throw new RuntimeException('Policy test reference not found: '.$test_reference);
+            }
+        }
+    }
+
+    echo 'Policy cases are valid: '.count($policy_data->policies).' policies.'.PHP_EOL;
+    exit(0);
+} catch (Throwable $error) {
+    fwrite(STDERR, 'Policy cases are invalid: '.$error->getMessage().PHP_EOL);
+    exit(1);
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -32,6 +32,7 @@ require_once APP_PATH.'vendor/autoload.php';
 
 /* get mock objects */
 require_once APP_PATH.'tests/phpunit/mocks.php';
+require_once APP_PATH.'tests/phpunit/policy_cases.php';
 
 /* get the framework */
 require_once APP_PATH.'lib/framework.php';

--- a/tests/phpunit/modules/brute_force/handler_modules.php
+++ b/tests/phpunit/modules/brute_force/handler_modules.php
@@ -46,8 +46,8 @@ class Hm_Test_Brute_Force_Handler_Modules extends TestCase {
     // Hm_Brute_Force_Tracker unit tests
     // -------------------------------------------------------------------------
 
-    /** @runInSeparateProcess */
     /**
+     * @runInSeparateProcess
      * @dataProvider brute_force_policy_cases
      */
     public function test_make_key_returns_consistent_hash($case) {

--- a/tests/phpunit/modules/brute_force/handler_modules.php
+++ b/tests/phpunit/modules/brute_force/handler_modules.php
@@ -129,13 +129,7 @@ class Hm_Test_Brute_Force_Handler_Modules extends TestCase {
     }
 
     public static function brute_force_policy_cases() {
-        $policy = json_decode(file_get_contents(APP_PATH.'docs/policy-cases.json'), true, 512, JSON_THROW_ON_ERROR);
-        foreach ($policy['policies'] as $policy_case) {
-            if ($policy_case['id'] === 'brute-force-protection') {
-                return array($policy_case['cases'][0]['id'] => array($policy_case['cases'][0]));
-            }
-        }
-        return array();
+        return PolicyCases::forPolicy('brute-force-protection');
     }
 
     /** @runInSeparateProcess */

--- a/tests/phpunit/modules/brute_force/handler_modules.php
+++ b/tests/phpunit/modules/brute_force/handler_modules.php
@@ -47,15 +47,17 @@ class Hm_Test_Brute_Force_Handler_Modules extends TestCase {
     // -------------------------------------------------------------------------
 
     /** @runInSeparateProcess */
-    public function test_make_key_returns_consistent_hash() {
-        $key1 = $this->tracker->make_key('ip', '127.0.0.1');
-        $key2 = $this->tracker->make_key('ip', '127.0.0.1');
-        $key3 = $this->tracker->make_key('ip', '10.0.0.1');
+    /**
+     * @dataProvider brute_force_policy_cases
+     */
+    public function test_make_key_returns_consistent_hash($case) {
+        $key1 = $this->tracker->make_key($case['input']['prefix'], $case['input']['value']);
+        $key2 = $this->tracker->make_key($case['input']['prefix'], $case['input']['value']);
+        $key3 = $this->tracker->make_key($case['input']['prefix'], $case['input']['different_value']);
 
-        $this->assertSame($key1, $key2);
-        $this->assertNotSame($key1, $key3);
-        // Must not expose the raw value
-        $this->assertStringNotContainsString('127.0.0.1', $key1);
+        $this->assertSame($case['expected']['same_value_same_key'], $key1 === $key2);
+        $this->assertSame($case['expected']['different_value_different_key'], $key1 !== $key3);
+        $this->assertStringNotContainsString($case['expected']['key_must_not_contain'], $key1);
     }
 
     /** @runInSeparateProcess */
@@ -124,6 +126,16 @@ class Hm_Test_Brute_Force_Handler_Modules extends TestCase {
         $data = $this->tracker->load();
         $this->assertGreaterThan(time(), $entry['locked_until']);
         $this->assertGreaterThan(time(), $data[$key]['locked_until']);
+    }
+
+    public static function brute_force_policy_cases() {
+        $policy = json_decode(file_get_contents(APP_PATH.'docs/policy-cases.json'), true, 512, JSON_THROW_ON_ERROR);
+        foreach ($policy['policies'] as $policy_case) {
+            if ($policy_case['id'] === 'brute-force-protection') {
+                return array($policy_case['cases'][0]['id'] => array($policy_case['cases'][0]));
+            }
+        }
+        return array();
     }
 
     /** @runInSeparateProcess */

--- a/tests/phpunit/modules/core/handler_modules.php
+++ b/tests/phpunit/modules/core/handler_modules.php
@@ -101,17 +101,7 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
     }
 
     public static function http_security_header_cases() {
-        $policy = json_decode(file_get_contents(APP_PATH.'docs/policy-cases.json'), true, 512, JSON_THROW_ON_ERROR);
-        foreach ($policy['policies'] as $policy_case) {
-            if ($policy_case['id'] === 'http-security-headers') {
-                $cases = array();
-                foreach ($policy_case['cases'] as $case) {
-                    $cases[$case['id']] = array($case);
-                }
-                return $cases;
-            }
-        }
-        return array();
+        return PolicyCases::forPolicy('http-security-headers');
     }
     /**
      * @preserveGlobalState disabled
@@ -339,24 +329,7 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
     }
 
     public static function settings_persistence_cases() {
-        $policy = json_decode(
-            file_get_contents(APP_PATH.'docs/policy-cases.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-
-        foreach ($policy['policies'] as $policy_case) {
-            if ($policy_case['id'] === 'user-settings-persistence') {
-                $cases = array();
-                foreach ($policy_case['cases'] as $case) {
-                    $cases[$case['id']] = array($case);
-                }
-                return $cases;
-            }
-        }
-
-        return array();
+        return PolicyCases::forPolicy('user-settings-persistence');
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/modules/core/handler_modules.php
+++ b/tests/phpunit/modules/core/handler_modules.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 class Hm_Test_Core_Handler_Modules extends TestCase {
 
     public function setUp(): void {
-        require __DIR__.'/../../helpers.php';
+        require_once __DIR__.'/../../helpers.php';
     }
     /**
      * @preserveGlobalState disabled
@@ -85,42 +85,33 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function test_http_headers() {
+    /**
+     * @dataProvider http_security_header_cases
+     */
+    public function test_http_headers($case) {
         $test = new Handler_Test('http_headers', 'core');
-        $test->tls = true;
-        $test->rtype = 'AJAX';
-        $test->input = array('language' => 'English');
+        $test->tls = $case['input']['tls'];
+        $test->rtype = $case['input']['request_type'];
+        $test->input = array('language' => $case['input']['language']);
+        $test->config = $case['input']['config'];
         $res = $test->run();
-		$out = array(
-			'Content-Language' => 'En',
-            'Strict-Transport-Security' => 'max-age=31536000',
-            'X-Frame-Options' => 'SAMEORIGIN',
-            'X-XSS-Protection' => '1; mode=block',
-            'X-Content-Type-Options' => 'nosniff',
-            'Content-Security-Policy' => "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;",
-            'Content-Type' => 'application/json',
-		);
-        foreach ($out as $key => $val) {
-            $this->assertEquals($out[$key], $res->handler_response['http_headers'][$key]);
+		foreach ($case['expected']['headers'] as $key => $value) {
+            $this->assertEquals($value, $res->handler_response['http_headers'][$key]);
         }
     }
-    /**
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
-     */
-    public function test_http_headers_allow_images() {
-        $test = new Handler_Test('http_headers', 'core');
-        $test->tls = true;
-        $test->rtype = 'AJAX';
-        $test->input = array('language' => 'English');
-        $test->config['allow_external_image_sources'] = true;
-        $res = $test->run();
-		$out = array(
-            'Content-Security-Policy' => "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src * data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;",
-		);
-        foreach ($out as $key => $val) {
-            $this->assertEquals($out[$key], $res->handler_response['http_headers'][$key]);
+
+    public static function http_security_header_cases() {
+        $policy = json_decode(file_get_contents(APP_PATH.'docs/policy-cases.json'), true, 512, JSON_THROW_ON_ERROR);
+        foreach ($policy['policies'] as $policy_case) {
+            if ($policy_case['id'] === 'http-security-headers') {
+                $cases = array();
+                foreach ($policy_case['cases'] as $case) {
+                    $cases[$case['id']] = array($case);
+                }
+                return $cases;
+            }
         }
+        return array();
     }
     /**
      * @preserveGlobalState disabled
@@ -336,20 +327,36 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function test_process_save_form() {
+    /**
+     * @dataProvider settings_persistence_cases
+     */
+    public function test_process_save_form($case) {
         $test = new Handler_Test('process_save_form', 'core');
         $test->session = array('username' => 'foo');
+        $test->post = $case['input']['post'];
         $test->run();
-        $test->post = array('save_settings' => true, 'password' => 'foo');
-        $this->assertEquals(array(), Hm_Msgs::get());
-        $test->run();
-        $test->post = array('save_settings_permanently' => 1, 'save_settings' => true, 'password' => 'foo');
-        $test->run();
-        $this->assertEquals(array('Settings saved'), Hm_Msgs::get());
-        Hm_Msgs::flush();
-        $test->post = array('save_settings_permanently_then_logout' => 1, 'save_settings' => true, 'password' => 'foo');
-        $test->run();
-        $this->assertEquals(array('Saved user data on logout', 'Session destroyed on logout'), Hm_Msgs::get());
+        $this->assertEquals($case['expected']['messages'], Hm_Msgs::get());
+    }
+
+    public static function settings_persistence_cases() {
+        $policy = json_decode(
+            file_get_contents(APP_PATH.'docs/policy-cases.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        foreach ($policy['policies'] as $policy_case) {
+            if ($policy_case['id'] === 'user-settings-persistence') {
+                $cases = array();
+                foreach ($policy_case['cases'] as $case) {
+                    $cases[$case['id']] = array($case);
+                }
+                return $cases;
+            }
+        }
+
+        return array();
     }
     /**
      * @preserveGlobalState disabled

--- a/tests/phpunit/modules/core/handler_modules.php
+++ b/tests/phpunit/modules/core/handler_modules.php
@@ -84,8 +84,6 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
     /**
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     */
-    /**
      * @dataProvider http_security_header_cases
      */
     public function test_http_headers($case) {
@@ -316,8 +314,6 @@ class Hm_Test_Core_Handler_Modules extends TestCase {
     /**
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     */
-    /**
      * @dataProvider settings_persistence_cases
      */
     public function test_process_save_form($case) {

--- a/tests/phpunit/modules/core/message_functions.php
+++ b/tests/phpunit/modules/core/message_functions.php
@@ -19,13 +19,41 @@ class Hm_Test_Core_Message_Functions extends TestCase {
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function test_sanitize_email_html_blocks_css_tracking() {
-        $test = '<ul style="list-style-image: url(https://tracker.example.com/test)"><li>x</li></ul>';
-        $this->assertEquals(1, count_blocked_remote_email_css_resources($test));
-        $this->assertStringNotContainsString('tracker.example.com', sanitize_email_html($test));
+    /**
+     * @dataProvider external_resource_cases
+     */
+    public function test_sanitize_email_html_blocks_css_tracking($case) {
+        $html = $case['input']['html'];
+        $this->assertStringNotContainsString($case['expected']['must_not_contain'], sanitize_email_html($html));
+        if (array_key_exists('blocked_count', $case['expected'])) {
+            $this->assertEquals($case['expected']['blocked_count'], count_blocked_remote_email_css_resources($html));
+        }
+    }
 
-        $test = '<div style="background: url(https://tracker.example.com/bg)">x</div>';
-        $this->assertStringNotContainsString('tracker.example.com', sanitize_email_html($test));
+    public static function external_resource_cases() {
+        $policy = json_decode(
+            file_get_contents(APP_PATH.'docs/policy-cases.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        foreach ($policy['policies'] as $policy_case) {
+            if ($policy_case['id'] === 'message-external-resource-blocking') {
+                $cases = array();
+                foreach ($policy_case['cases'] as $case) {
+                    $cases[$case['id']] = array($case);
+                }
+                return $cases;
+            }
+        }
+
+        return array();
+    }
+
+    public function test_format_msg_html_keeps_images_non_loading_by_default() {
+        $test = '<img src="https://tracker.example.com/pixel.gif">';
+        $this->assertStringNotContainsString('src="https://tracker.example.com/pixel.gif"', format_msg_html($test));
 
         $allowed = true;
         $msgText = '<img src="https://tracker.example.com/pixel.gif"><ul style="list-style-image: url(https://tracker.example.com/list)"><li>x</li></ul>';

--- a/tests/phpunit/modules/core/message_functions.php
+++ b/tests/phpunit/modules/core/message_functions.php
@@ -18,8 +18,6 @@ class Hm_Test_Core_Message_Functions extends TestCase {
     /**
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     */
-    /**
      * @dataProvider external_resource_cases
      */
     public function test_sanitize_email_html_blocks_css_tracking($case) {

--- a/tests/phpunit/modules/core/message_functions.php
+++ b/tests/phpunit/modules/core/message_functions.php
@@ -31,24 +31,7 @@ class Hm_Test_Core_Message_Functions extends TestCase {
     }
 
     public static function external_resource_cases() {
-        $policy = json_decode(
-            file_get_contents(APP_PATH.'docs/policy-cases.json'),
-            true,
-            512,
-            JSON_THROW_ON_ERROR
-        );
-
-        foreach ($policy['policies'] as $policy_case) {
-            if ($policy_case['id'] === 'message-external-resource-blocking') {
-                $cases = array();
-                foreach ($policy_case['cases'] as $case) {
-                    $cases[$case['id']] = array($case);
-                }
-                return $cases;
-            }
-        }
-
-        return array();
+        return PolicyCases::forPolicy('message-external-resource-blocking');
     }
 
     public function test_format_msg_html_keeps_images_non_loading_by_default() {

--- a/tests/phpunit/policy_cases.php
+++ b/tests/phpunit/policy_cases.php
@@ -1,0 +1,35 @@
+<?php
+
+class PolicyCases {
+    private static $data;
+
+    public static function forPolicy($policy_id) {
+        $policy = self::policy($policy_id);
+        $cases = array();
+        foreach ($policy['cases'] as $case) {
+            $cases[$case['id']] = array($case);
+        }
+        return $cases;
+    }
+
+    public static function policy($policy_id) {
+        foreach (self::load()['policies'] as $policy) {
+            if ($policy['id'] === $policy_id) {
+                return $policy;
+            }
+        }
+        throw new RuntimeException('Unknown policy case set: '.$policy_id);
+    }
+
+    private static function load() {
+        if (self::$data === null) {
+            self::$data = json_decode(
+                file_get_contents(APP_PATH.'docs/policy-cases.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+        }
+        return self::$data;
+    }
+}


### PR DESCRIPTION
This is to satisfy the requirement of the criterion "[Bundle policy and source code](https://www.standardforpubliccode.org/criteria/bundle-policy-and-source-code.html)" from the Standard for Public Code, which states that the codebase must include the policy that the source code is based on, recommends that it be in a machine-readable format...

This PR updates our assessment against the criterion as follows:

| Meets | Requirement | Notes and links |
| ----- | ----------- | -------------- |
| yes | The codebase MUST include the policy that the source code is based on. | [The policy cases](https://github.com/cypht-org/cypht/pull/2095/changes#diff-91afc4ee58ce23a57a0b1dbcaa4299e7ca9dd57cfdd2b67cef3f6d522c42823b) embedded in the codebase, and linked from [CONTRIBUTING.md](https://github.com/cypht-org/cypht/pull/2095/changes#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) . |
| n/a | If a policy is based on source code, that source code MUST be included in the codebase, unless used for fraud detection. | In this implementation, the policy is expressed as normalized behavioral cases that are executed by PHPUnit rather than as a separate implementation-only source policy. |
| yes | Policy SHOULD be provided in machine-readable and unambiguous formats. | The policy registry is machine-readable JSON and is validated against a schema in [docs/policy-cases.schema.json](https://github.com/cypht-org/cypht/pull/2095/changes#diff-a5b3fab96fe0ca951ce872272502af43304b1d39d33826e6d7a0b4f30e53dd33). |
| yes | Continuous integration tests SHOULD validate that the source code and the policy are executed coherently. | The repository includes a dedicated workflow in [.github/workflows/policy-cases.yml](https://github.com/cypht-org/cypht/pull/2095/changes#diff-98cd2f2252d57d69c377f9cd94d3a90e3e0a72e24a9b4a536901608d480b9b00), backed by the data-provider loader in [tests/phpunit/policy_cases.php](https://github.com/cypht-org/cypht/pull/2095/changes#diff-711fedac4d7cb4dd9e1f1f80c16fef0bf5ae1b1b5a0e10205d4e95bc2aa44b0e). |

<br>
<br>

Related: https://github.com/cypht-org/cypht-website/issues/166